### PR TITLE
Make blueprint extensible

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'generators' => [
+        \Blueprint\Generators\MigrationGenerator::class,
+        \Blueprint\Generators\ModelGenerator::class,
+        \Blueprint\Generators\FactoryGenerator::class,
+    ],
+
+    'lexers' => [
+        \Blueprint\Lexers\ModelLexer::class,
+    ],
+];

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -2,15 +2,27 @@
 
 namespace Blueprint;
 
-
-use Blueprint\Contracts\Generator;
 use Blueprint\Contracts\Lexer;
 use Symfony\Component\Yaml\Yaml;
+use Blueprint\Contracts\Generator;
 
 class Blueprint
 {
     private $lexers = [];
     private $generators = [];
+
+    public function boot()
+    {
+        collect(config('blueprint.lexers'))->each(function ($lexer) {
+            $this->registerLexer(new $lexer());
+        });
+
+        collect(config('blueprint.generators'))->each(function ($generatorClass) {
+            $generator = resolve('blueprint.generators')[$generatorClass];
+
+            $this->registerGenerator($generator);
+        });
+    }
 
     public function parse($content)
     {
@@ -23,7 +35,7 @@ class Blueprint
     {
         $registry = [
             'models' => [],
-            'controllers' => []
+            'controllers' => [],
         ];
 
         foreach ($this->lexers as $lexer) {

--- a/src/BlueprintCommand.php
+++ b/src/BlueprintCommand.php
@@ -2,9 +2,9 @@
 
 namespace Blueprint;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 
 class BlueprintCommand extends Command
@@ -27,7 +27,7 @@ class BlueprintCommand extends Command
     protected $files;
 
     /**
-     * @param Filesystem $files
+     * @param Filesystem                         $files
      * @param \Illuminate\Contracts\View\Factory $view
      */
     public function __construct(Filesystem $files)
@@ -42,17 +42,9 @@ class BlueprintCommand extends Command
      *
      * @return mixed
      */
-    public function handle()
+    public function handle(Blueprint $blueprint)
     {
         $contents = $this->files->get($this->argument('draft'));
-
-        $blueprint = new Blueprint();
-
-        $blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-
-        $blueprint->registerGenerator(new \Blueprint\Generators\MigrationGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\ModelGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\FactoryGenerator($this->files));
 
         $tokens = $blueprint->parse($contents);
         $registry = $blueprint->analyze($tokens);
@@ -67,7 +59,6 @@ class BlueprintCommand extends Command
             $this->line('');
         });
     }
-
 
     /**
      * Get the console command arguments.
@@ -93,9 +84,9 @@ class BlueprintCommand extends Command
 
     private function outputStyle($action)
     {
-        if ($action === 'deleted') {
+        if ('deleted' === $action) {
             return 'error';
-        } elseif ($action === 'updated') {
+        } elseif ('updated' === $action) {
             return 'warning';
         }
 

--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -2,32 +2,50 @@
 
 namespace Blueprint;
 
-use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
+use Blueprint\Generators\ModelGenerator;
+use Blueprint\Generators\FactoryGenerator;
+use Blueprint\Generators\MigrationGenerator;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
 class BlueprintServiceProvider extends ServiceProvider implements DeferrableProvider
 {
     /**
      * Bootstrap the application events.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(Blueprint $blueprint)
     {
-        // ...
-        if (!defined('STUBS_PATH')) {
+        $this->publishes([
+            __DIR__ . '/../config/blueprint.php' => config_path('blueprint.php'),
+        ], 'config');
+
+        if (! defined('STUBS_PATH')) {
             define('STUBS_PATH', dirname(__DIR__) . '/stubs');
         }
+
+        $blueprint->boot();
     }
 
     /**
      * Register the service provider.
-     *
-     * @return void
      */
     public function register()
     {
-        $this->app->bind('command.blueprint.build',
+        $this->mergeConfigFrom(__DIR__ . '/../config/blueprint.php', 'blueprint');
+
+        $this->app->bind('blueprint.generators', function ($app) {
+            return [
+                FactoryGenerator::class => new FactoryGenerator($app->make(Filesystem::class)),
+                MigrationGenerator::class => new MigrationGenerator($app->make(Filesystem::class)),
+                ModelGenerator::class => new ModelGenerator($app->make(Filesystem::class)),
+            ];
+        });
+
+        $this->app->singleton(Blueprint::class, Blueprint::class);
+
+        $this->app->bind(
+            'command.blueprint.build',
             function ($app) {
                 return new BlueprintCommand($app['files']);
             }
@@ -45,5 +63,4 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
     {
         return ['command.blueprint.build'];
     }
-
 }

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
-use Blueprint\Blueprint;
-use Blueprint\Contracts\Generator;
-use Blueprint\Contracts\Lexer;
-use Symfony\Component\Yaml\Exception\ParseException;
 use Tests\TestCase;
+use Blueprint\Blueprint;
+use Blueprint\Contracts\Lexer;
+use Blueprint\Contracts\Generator;
+use Symfony\Component\Yaml\Exception\ParseException;
 
 class BlueprintTest extends TestCase
 {
@@ -15,7 +15,7 @@ class BlueprintTest extends TestCase
      */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -53,10 +53,10 @@ class BlueprintTest extends TestCase
             'controllers' => [
                 'UserController' => [
                     'index' => [
-                        'action' => 'detail'
+                        'action' => 'detail',
                     ],
                     'create' => [
-                        'action' => 'additional detail'
+                        'action' => 'additional detail',
                     ],
                 ],
                 'RoleController' => [
@@ -100,7 +100,7 @@ class BlueprintTest extends TestCase
                     'title' => 'string',
                     'content' => 'bigtext',
                     'published_at' => 'nullable timestamp',
-                    'timestamps' => 'timestamps'
+                    'timestamps' => 'timestamps',
                 ],
             ],
             'controllers' => [
@@ -141,11 +141,13 @@ class BlueprintTest extends TestCase
     {
         $tokens = [];
 
-        $this->assertEquals([
+        $this->assertEquals(
+            [
             'models' => [],
-            'controllers' => []
+            'controllers' => [],
         ],
-            $this->subject->analyze($tokens));
+            $this->subject->analyze($tokens)
+        );
     }
 
     /**
@@ -164,7 +166,7 @@ class BlueprintTest extends TestCase
         $this->assertEquals([
             'models' => [],
             'controllers' => [],
-            'mock' => 'lexer'
+            'mock' => 'lexer',
         ], $this->subject->analyze($tokens));
     }
 
@@ -180,7 +182,7 @@ class BlueprintTest extends TestCase
             ->andReturn([
                 'created' => ['one/new.php'],
                 'updated' => ['one/existing.php'],
-                'deleted' => ['one/trashed.php']
+                'deleted' => ['one/trashed.php'],
             ]);
 
         $generatorTwo = \Mockery::mock(Generator::class);
@@ -189,7 +191,7 @@ class BlueprintTest extends TestCase
             ->andReturn([
                 'created' => ['two/new.php'],
                 'updated' => ['two/existing.php'],
-                'deleted' => ['two/trashed.php']
+                'deleted' => ['two/trashed.php'],
             ]);
 
         $this->subject->registerGenerator($generatorOne);

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Generators;
 
+use Tests\TestCase;
 use Blueprint\Blueprint;
 use Blueprint\Generators\FactoryGenerator;
-use Tests\TestCase;
 
 class FactoryGeneratorTest extends TestCase
 {
@@ -15,7 +15,7 @@ class FactoryGeneratorTest extends TestCase
     /** @var FactoryGenerator */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -60,11 +60,10 @@ class FactoryGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
-
     public function modelTreeDataProvider()
     {
         return [
-            ['definitions/post.bp', 'database/factories/PostFactory.php', 'factories/post.php']
+            ['definitions/post.bp', 'database/factories/PostFactory.php', 'factories/post.php'],
         ];
     }
 }

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature\Generators;
 
-use Blueprint\Blueprint;
-use Blueprint\Generators\MigrationGenerator;
 use Carbon\Carbon;
 use Tests\TestCase;
+use Blueprint\Blueprint;
+use Blueprint\Generators\MigrationGenerator;
 
 class MigrationGeneratorTest extends TestCase
 {
@@ -16,7 +16,7 @@ class MigrationGeneratorTest extends TestCase
     /** @var MigrationGenerator */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -65,7 +65,6 @@ class MigrationGeneratorTest extends TestCase
 
         $this->assertEquals(['created' => [$timestamp_path]], $this->subject->output($tree));
     }
-
 
     public function modelTreeDataProvider()
     {

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Generators;
 
+use Tests\TestCase;
 use Blueprint\Blueprint;
 use Blueprint\Generators\ModelGenerator;
-use Tests\TestCase;
 
 class ModelGeneratorTest extends TestCase
 {
@@ -15,7 +15,7 @@ class ModelGeneratorTest extends TestCase
     /** @var ModelGenerator */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -71,7 +71,6 @@ class ModelGeneratorTest extends TestCase
 
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
-
 
     public function modelTreeDataProvider()
     {

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature\Lexers;
 
-use Blueprint\Lexers\ModelLexer;
 use Tests\TestCase;
+use Blueprint\Lexers\ModelLexer;
 
 class ModelLexerTest extends TestCase
 {
@@ -12,7 +12,7 @@ class ModelLexerTest extends TestCase
      */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -36,11 +36,11 @@ class ModelLexerTest extends TestCase
             'models' => [
                 'ModelOne' => [
                     'id' => 'id',
-                    'name' => 'string nullable'
+                    'name' => 'string nullable',
                 ],
                 'ModelTwo' => [
                     'count' => 'integer',
-                    'timestamps' => 'timestamps'
+                    'timestamps' => 'timestamps',
                 ],
             ],
         ];
@@ -85,8 +85,8 @@ class ModelLexerTest extends TestCase
         $tokens = [
             'models' => [
                 'Model' => [
-                    'title' => 'string nullable'
-                ]
+                    'title' => 'string nullable',
+                ],
             ],
         ];
 
@@ -120,7 +120,7 @@ class ModelLexerTest extends TestCase
             'models' => [
                 'Model' => [
                     'timestamps' => false,
-                ]
+                ],
             ],
         ];
 
@@ -142,8 +142,8 @@ class ModelLexerTest extends TestCase
         $tokens = [
             'models' => [
                 'Model' => [
-                    'title' => 'nullable'
-                ]
+                    'title' => 'nullable',
+                ],
             ],
         ];
 
@@ -178,8 +178,8 @@ class ModelLexerTest extends TestCase
                 'Model' => [
                     'sequence' => 'unsignedbiginteger autoincrement',
                     'content' => 'longtext',
-                    'saved_at' => 'timestamptz usecurrent'
-                ]
+                    'saved_at' => 'timestamptz usecurrent',
+                ],
             ],
         ];
 
@@ -212,7 +212,6 @@ class ModelLexerTest extends TestCase
         $this->assertEquals(['useCurrent'], $columns['saved_at']->modifiers());
     }
 
-
     /**
      * @test
      * @dataProvider dataTypeAttributesDataProvider
@@ -222,8 +221,8 @@ class ModelLexerTest extends TestCase
         $tokens = [
             'models' => [
                 'Model' => [
-                    'column' => $definition
-                ]
+                    'column' => $definition,
+                ],
             ],
         ];
 
@@ -256,8 +255,8 @@ class ModelLexerTest extends TestCase
         $tokens = [
             'models' => [
                 'Model' => [
-                    'column' => $definition . ' nullable'
-                ]
+                    'column' => $definition . ' nullable',
+                ],
             ],
         ];
 
@@ -300,7 +299,7 @@ class ModelLexerTest extends TestCase
         return [
             ['default:5', 'default', 5],
             ['default:0.00', 'default', 0.00],
-            ["default:string", 'default', 'string'],
+            ['default:string', 'default', 'string'],
             ["default:'empty'", 'default', "'empty'"],
             ['default:""', 'default', '""'],
             ['charset:utf8', 'charset', 'utf8'],


### PR DESCRIPTION
I've no clue if this is what you thought in #2.
I just wanted to give it a try. Maybe you can use some code of it or none at all.

---

I added a singleton for the `Blueprint` class and added a config where the `generators` and `lexers` can be defined which should be registered by default. I personally don't like that the `boot()` method on `Blueprint` is called within the `BlueprintServiceProvider@boot()` method, but could think of a better alternative.

I also didn't add any tests for the `boot()` method on the `Blueprint` class, because I ran into an error that `config()` method is not defined, which is likely to be caused by how the tests are setup.

---

If this PR doesn't help you at all please tell me and if you have the time I'd appreciate why and how I could improve things for future contributions.

Thanks!