### PR TITLE
Adds various validation rules based on column name and dataType

### DIFF
--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -79,6 +79,7 @@ class ModelLexer implements Lexer
         'unsigned' => 'unsigned',
         'usecurrent' => 'useCurrent',
         'always' => 'always',
+        'unique' => 'unique',
     ];
 
     public function analyze(array $tokens): array
@@ -137,11 +138,11 @@ class ModelLexer implements Lexer
         foreach ($tokens as $token) {
             $parts = explode(':', $token);
             $value = $parts[0];
-            $attributes = $parts[1] ?? null;
 
             if ($value === 'id') {
                 $data_type = 'id';
             } elseif (isset(self::$dataTypes[strtolower($value)])) {
+                $attributes = $parts[1] ?? null;
                 $data_type = self::$dataTypes[strtolower($value)];
                 if (!empty($attributes)) {
                     $attributes = explode(',', $attributes);
@@ -149,11 +150,11 @@ class ModelLexer implements Lexer
             }
 
             if (isset(self::$modifiers[strtolower($value)])) {
-                if (empty($attributes)) {
+                $modifierAttributes = $parts[1] ?? null;
+                if (empty($modifierAttributes)) {
                     $modifiers[] = self::$modifiers[strtolower($value)];
                 } else {
-                    $modifiers[] = [self::$modifiers[strtolower($value)] => $attributes];
-                    $attributes = [];
+                    $modifiers[] = [self::$modifiers[strtolower($value)] => $modifierAttributes];
                 }
             }
         }

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -56,6 +56,10 @@ class Rules
             $rules = array_merge($rules, ['in:' . implode(',', $column->attributes())]);
         }
 
+        if (in_array($column->dataType(), ['date', 'datetime', 'datetimetz'])) {
+            $rules = array_merge($rules, ['date']);
+        }
+
         if ($column->attributes()) {
             if (in_array($column->dataType(), ['string', 'char'])) {
                 $rules = array_merge($rules, ['max:' . implode($column->attributes())]);

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -31,10 +31,6 @@ class Rules
             }
         }
 
-        // if () {
-        // $rules = array_merge($rules, ['email']);
-        // }
-
         return $rules;
     }
 

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -3,6 +3,7 @@
 namespace Blueprint\Translators;
 
 use Blueprint\Column;
+use Illuminate\Support\Str;
 
 class Rules
 {
@@ -20,8 +21,9 @@ class Rules
 
         // hack for tests...
         if (in_array($column->dataType(), ['string', 'char', 'text', 'longText'])) {
-            $rules = array_merge($rules, ['string']);
+            $rules = array_merge($rules, [self::overrideStringRuleForSpecialNames($column->name())]);
         }
+
 
         if ($column->attributes()) {
             if (in_array($column->dataType(), ['string', 'char'])) {
@@ -29,6 +31,25 @@ class Rules
             }
         }
 
+        // if () {
+        // $rules = array_merge($rules, ['email']);
+        // }
+
         return $rules;
+    }
+
+    private static function overrideStringRuleForSpecialNames($name)
+    {
+        switch ($name) {
+            case Str::startsWith($name, 'email'):
+                return 'email';
+                break;
+            case $name === 'password':
+                return 'password';
+                break;
+            default:
+                return 'string';
+                break;
+        }
     }
 }

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -52,6 +52,9 @@ class Rules
             }
         }
 
+        if (in_array($column->dataType(), ['enum', 'set'])) {
+            $rules = array_merge($rules, ['in:' . implode(',', $column->attributes())]);
+        }
 
         if ($column->attributes()) {
             if (in_array($column->dataType(), ['string', 'char'])) {

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -30,20 +30,29 @@ class Rules
             'smallInteger',
             'mediumInteger',
             'bigInteger',
-            'decimal',
-            'double',
-            'float',
             'increments',
             'tinyIncrements',
             'smallIncrements',
             'mediumIncrements',
             'bigIncrements',
             'unsignedBigInteger',
-            'unsignedDecimal',
             'unsignedInteger',
             'unsignedMediumInteger',
             'unsignedSmallInteger',
             'unsignedTinyInteger'
+        ])) {
+            $rules = array_merge($rules, ['integer']);
+
+            if (Str::startsWith($column->dataType(), 'unsigned')) {
+                $rules = array_merge($rules, ['gt:0']);
+            }
+        }
+
+        if (in_array($column->dataType(), [
+            'decimal',
+            'double',
+            'float',
+            'unsignedDecimal',
         ])) {
             $rules = array_merge($rules, ['numeric']);
 
@@ -71,16 +80,13 @@ class Rules
 
     private static function overrideStringRuleForSpecialNames($name)
     {
-        switch ($name) {
-            case Str::startsWith($name, 'email'):
-                return 'email';
-                break;
-            case $name === 'password':
-                return 'password';
-                break;
-            default:
-                return 'string';
-                break;
+        if (Str::startsWith($name, 'email')) {
+            return 'email';
         }
+        if ($name === 'password') {
+            return 'password';
+        }
+
+        return 'string';
     }
 }

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -24,6 +24,34 @@ class Rules
             $rules = array_merge($rules, [self::overrideStringRuleForSpecialNames($column->name())]);
         }
 
+        if (in_array($column->dataType(), [
+            'integer',
+            'tinyInteger',
+            'smallInteger',
+            'mediumInteger',
+            'bigInteger',
+            'decimal',
+            'double',
+            'float',
+            'increments',
+            'tinyIncrements',
+            'smallIncrements',
+            'mediumIncrements',
+            'bigIncrements',
+            'unsignedBigInteger',
+            'unsignedDecimal',
+            'unsignedInteger',
+            'unsignedMediumInteger',
+            'unsignedSmallInteger',
+            'unsignedTinyInteger'
+        ])) {
+            $rules = array_merge($rules, ['numeric']);
+
+            if (Str::startsWith($column->dataType(), 'unsigned')) {
+                $rules = array_merge($rules, ['gt:0']);
+            }
+        }
+
 
         if ($column->attributes()) {
             if (in_array($column->dataType(), ['string', 'char'])) {

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -46,6 +46,11 @@ class Rules
             if (Str::startsWith($column->dataType(), 'unsigned')) {
                 $rules = array_merge($rules, ['gt:0']);
             }
+
+            if (Str::endsWith($column->name(), '_id')) {
+                [$table, $field] = explode('_', $column->name());
+                $rules = array_merge($rules, ['exists:' . Str::plural($table) . ',' . $field]);
+            }
         }
 
         if (in_array($column->dataType(), [

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 
 class Rules
 {
-    public static function fromColumn(Column $column)
+    public static function fromColumn(Column $column, string $context = null)
     {
         // TODO: what about nullable?
         $rules = ['required'];
@@ -73,6 +73,10 @@ class Rules
             if (in_array($column->dataType(), ['string', 'char'])) {
                 $rules = array_merge($rules, ['max:' . implode($column->attributes())]);
             }
+        }
+
+        if (in_array('unique', $column->modifiers()) && $context) {
+            $rules = array_merge($rules, ['unique:' . $context]);
         }
 
         return $rules;

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -292,6 +292,28 @@ class ModelLexerTest extends TestCase
     /**
      * @test
      */
+    public function it_handles_attributes_and_modifiers_with_attributes()
+    {
+        $tokens = [
+            'models' => [
+                'Model' => [
+                    'column' => 'string:100 unique charset:utf8'
+                ]
+            ],
+        ];
+
+        $actual = $this->subject->analyze($tokens)['models']['Model']->columns()['column'];
+
+        $this->assertEquals('column', $actual->name());
+        $this->assertEquals('string', $actual->dataType());
+        $this->assertEquals(['unique', ['charset' => 'utf8']], $actual->modifiers());
+        $this->assertEquals(['100'], $actual->attributes());
+    }
+
+
+    /**
+     * @test
+     */
     public function it_enables_soft_deletes()
     {
         $tokens = [

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -85,18 +85,27 @@ class RulesTest extends TestCase
 
     /**
      * @test
+     * @dataProvider integerDataTypesProvider
+     */
+    public function forColumn_returns_integer_rule_for_integer_types($data_type)
+    {
+        $column = new Column('test', $data_type);
+
+        $this->assertContains('integer', Rules::fromColumn($column));
+    }
+
+    /**
+     * @test
      */
     public function forColumn_returns_gt0_rule_for_unsigned_numeric_types()
     {
         $column = new Column('test', 'integer');
 
-        $this->assertContains('numeric', Rules::fromColumn($column));
         $this->assertNotContains('gt:0', Rules::fromColumn($column));
 
         $column = new Column('test', 'unsignedInteger');
 
         $this->assertContains('gt:0', Rules::fromColumn($column));
-        $this->assertContains('numeric', Rules::fromColumn($column));
     }
 
     /**
@@ -132,7 +141,7 @@ class RulesTest extends TestCase
         ];
     }
 
-    public function numericDataTypesProvider()
+    public function integerDataTypesProvider()
     {
         return [
             ['integer'],
@@ -140,20 +149,26 @@ class RulesTest extends TestCase
             ['smallInteger'],
             ['mediumInteger'],
             ['bigInteger'],
-            ['decimal'],
-            ['double'],
-            ['float'],
+            ['unsignedBigInteger'],
+            ['unsignedInteger'],
+            ['unsignedMediumInteger'],
+            ['unsignedSmallInteger'],
+            ['unsignedTinyInteger'],
             ['increments'],
             ['tinyIncrements'],
             ['smallIncrements'],
             ['mediumIncrements'],
             ['bigIncrements'],
-            ['unsignedBigInteger'],
+        ];
+    }
+
+    public function numericDataTypesProvider()
+    {
+        return [
+            ['decimal'],
+            ['double'],
+            ['float'],
             ['unsignedDecimal'],
-            ['unsignedInteger'],
-            ['unsignedMediumInteger'],
-            ['unsignedSmallInteger'],
-            ['unsignedTinyInteger'],
         ];
     }
 

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -43,6 +43,35 @@ class RulesTest extends TestCase
         $this->assertContains('max:10', Rules::fromColumn($column));
     }
 
+    /**
+     * @test
+     * @dataProvider stringDataTypesProvider
+     */
+    public function forColumn_overrides_string_rule_with_email_rule_for_attributes_named_email_or_email_address($data_type)
+    {
+        $column = new Column('email', $data_type);
+
+        $this->assertContains('email', Rules::fromColumn($column));
+        $this->assertNotContains('string', Rules::fromColumn($column));
+
+        $column = new Column('email_address', $data_type);
+
+        $this->assertContains('email', Rules::fromColumn($column));
+        $this->assertNotContains('string', Rules::fromColumn($column));
+    }
+
+    /**
+     * @test
+     * @dataProvider stringDataTypesProvider
+     */
+    public function forColumn_overrides_string_rule_with_password_rule_for_attributes_named_password($data_type)
+    {
+        $column = new Column('password', $data_type);
+
+        $this->assertContains('password', Rules::fromColumn($column));
+        $this->assertNotContains('string', Rules::fromColumn($column));
+    }
+
     public function stringDataTypesProvider()
     {
         return [
@@ -51,5 +80,4 @@ class RulesTest extends TestCase
             ['text']
         ];
     }
-
 }

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -132,6 +132,30 @@ class RulesTest extends TestCase
         $this->assertContains('date', Rules::fromColumn($column));
     }
 
+    /**
+     * @test
+     * @dataProvider stringDataTypesProvider
+     */
+    public function forColumn_does_not_return_unique_rule_for_the_unique_modifier_without_context($data_type)
+    {
+        $column = new Column('test', $data_type, ['unique', 'nullable']);
+
+        $this->assertNotContains('unique:', Rules::fromColumn($column));
+    }
+
+    /**
+     * @test
+     */
+    public function forColumn_returns_unique_rule_for_the_unique_modifier()
+    {
+        $column = new Column('test', 'string', ['unique'], [100]);
+
+        $actual = Rules::fromColumn($column, 'connection.table');
+
+        $this->assertContains('unique:connection.table', $actual);
+        $this->assertContains('max:100', $actual);
+    }
+
     public function stringDataTypesProvider()
     {
         return [

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -90,8 +90,19 @@ class RulesTest extends TestCase
     public function forColumn_returns_integer_rule_for_integer_types($data_type)
     {
         $column = new Column('test', $data_type);
+        $this->assertContains('integer', Rules::fromColumn($column));
+    }
+
+    /**
+     * @test
+     * @dataProvider integerDataTypesProvider
+     */
+    public function forColumn_returns_exists_rule_for_foreign_keys($data_type)
+    {
+        $column = new Column('test_id', $data_type);
 
         $this->assertContains('integer', Rules::fromColumn($column));
+        $this->assertContains('exists:tests,id', Rules::fromColumn($column));
     }
 
     /**

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -99,6 +99,19 @@ class RulesTest extends TestCase
         $this->assertContains('numeric', Rules::fromColumn($column));
     }
 
+    /**
+     * @test
+     */
+    public function forColumn_returns_in_rule_for_enums_and_sets()
+    {
+        $column = new Column('test', 'enum', [], ['alpha', 'bravo', 'charlie']);
+        $this->assertContains('in:alpha,bravo,charlie', Rules::fromColumn($column));
+
+        $column = new Column('test', 'set', [], [2,4,6]);
+
+        $this->assertContains('in:2,4,6', Rules::fromColumn($column));
+    }
+
     public function stringDataTypesProvider()
     {
         return [

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -112,6 +112,17 @@ class RulesTest extends TestCase
         $this->assertContains('in:2,4,6', Rules::fromColumn($column));
     }
 
+    /**
+     * @test
+     * @dataProvider dateDataTypesProvider
+     */
+    public function forColumn_returns_date_rule_for_date_types($data_type)
+    {
+        $column = new Column('test', $data_type);
+
+        $this->assertContains('date', Rules::fromColumn($column));
+    }
+
     public function stringDataTypesProvider()
     {
         return [
@@ -143,6 +154,15 @@ class RulesTest extends TestCase
             ['unsignedMediumInteger'],
             ['unsignedSmallInteger'],
             ['unsignedTinyInteger'],
+        ];
+    }
+
+    public function dateDataTypesProvider()
+    {
+        return [
+            ['date'],
+            ['datetime'],
+            ['datetimetz'],
         ];
     }
 }

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -72,12 +72,64 @@ class RulesTest extends TestCase
         $this->assertNotContains('string', Rules::fromColumn($column));
     }
 
+    /**
+     * @test
+     * @dataProvider numericDataTypesProvider
+     */
+    public function forColumn_returns_numeric_rule_for_numeric_types($data_type)
+    {
+        $column = new Column('test', $data_type);
+
+        $this->assertContains('numeric', Rules::fromColumn($column));
+    }
+
+    /**
+     * @test
+     */
+    public function forColumn_returns_gt0_rule_for_unsigned_numeric_types()
+    {
+        $column = new Column('test', 'integer');
+
+        $this->assertContains('numeric', Rules::fromColumn($column));
+        $this->assertNotContains('gt:0', Rules::fromColumn($column));
+
+        $column = new Column('test', 'unsignedInteger');
+
+        $this->assertContains('gt:0', Rules::fromColumn($column));
+        $this->assertContains('numeric', Rules::fromColumn($column));
+    }
+
     public function stringDataTypesProvider()
     {
         return [
             ['string'],
             ['char'],
             ['text']
+        ];
+    }
+
+    public function numericDataTypesProvider()
+    {
+        return [
+            ['integer'],
+            ['tinyInteger'],
+            ['smallInteger'],
+            ['mediumInteger'],
+            ['bigInteger'],
+            ['decimal'],
+            ['double'],
+            ['float'],
+            ['increments'],
+            ['tinyIncrements'],
+            ['smallIncrements'],
+            ['mediumIncrements'],
+            ['bigIncrements'],
+            ['unsignedBigInteger'],
+            ['unsignedDecimal'],
+            ['unsignedInteger'],
+            ['unsignedMediumInteger'],
+            ['unsignedSmallInteger'],
+            ['unsignedTinyInteger'],
         ];
     }
 }

--- a/tests/fixtures/definitions/model-modifiers.bp
+++ b/tests/fixtures/definitions/model-modifiers.bp
@@ -1,9 +1,8 @@
 models:
   Modifier:
     title: string nullable
-    name: string:1000
+    name: string:1000 unique charset:'utf8'
     content: string default:''
     total: decimal:10,2
     ssn: char:11
     role: enum:user,admin,owner
-

--- a/tests/fixtures/migrations/modifiers.php
+++ b/tests/fixtures/migrations/modifiers.php
@@ -16,7 +16,7 @@ class CreateModifiersTable extends Migration
         Schema::create('modifiers', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title')->nullable();
-            $table->string('name', 1000);
+            $table->string('name', 1000)->unique()->charset('utf8');
             $table->string('content')->default('');
             $table->decimal('total', 10, 2);
             $table->char('ssn', 11);


### PR DESCRIPTION
- if the dataType is string and the column name starts with 'email', the ```string``` rule gets replaced with the ```email``` rule
- if the dataType is string and the column name is 'password', the ```string``` rule gets replaced with the ```password``` rule
- If the dataType is numeric the ```numeric``` rule is added. If the dataType is unsigned, ```gt:0``` is also added
- added `in:` rule with attributes for enums and sets
- added `date` rule for dataTypes date, datetime and datetimetz

Issue #17 

Thanks JMac, Loving the streams