### PR TITLE
Fix draft file not found

### DIFF
--- a/src/BlueprintCommand.php
+++ b/src/BlueprintCommand.php
@@ -44,7 +44,11 @@ class BlueprintCommand extends Command
      */
     public function handle()
     {
-        $contents = $this->files->get(posix_getcwd() . $this->argument('draft'));
+        if (!file_exists($file = $this->argument('draft'))) {
+            $this->error("The {$file} file could not be found.");
+        }
+
+        $contents = $this->files->get($file);
 
         $blueprint = new Blueprint();
 

--- a/src/BlueprintCommand.php
+++ b/src/BlueprintCommand.php
@@ -44,7 +44,7 @@ class BlueprintCommand extends Command
      */
     public function handle()
     {
-        $contents = $this->files->get($this->argument('draft'));
+        $contents = $this->files->get(posix_getcwd() . $this->argument('draft'));
 
         $blueprint = new Blueprint();
 


### PR DESCRIPTION
This should make #15 a bit more obvious. By default, it will look for the 'draft.yaml' file in the current working directory which if you're running 'php artisan' will be the root of your Laravel project.

You could also use a relative path such as '../draft.yaml' and this would work too I believe. I imagine there will tests for this in the future.