### PR TITLE
Feature/add erase command

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -2,10 +2,9 @@
 
 namespace Blueprint;
 
-
-use Blueprint\Contracts\Generator;
 use Blueprint\Contracts\Lexer;
 use Symfony\Component\Yaml\Yaml;
+use Blueprint\Contracts\Generator;
 
 class Blueprint
 {
@@ -25,7 +24,7 @@ class Blueprint
     {
         $registry = [
             'models' => [],
-            'controllers' => []
+            'controllers' => [],
         ];
 
         foreach ($this->lexers as $lexer) {
@@ -44,6 +43,11 @@ class Blueprint
         }
 
         return $components;
+    }
+
+    public function dump(array $generated)
+    {
+        return Yaml::dump($generated);
     }
 
     public function registerLexer(Lexer $lexer)

--- a/src/BlueprintCommand.php
+++ b/src/BlueprintCommand.php
@@ -2,9 +2,9 @@
 
 namespace Blueprint;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 
 class BlueprintCommand extends Command
@@ -80,8 +80,12 @@ class BlueprintCommand extends Command
 
             $this->line('');
         });
-    }
 
+        $this->files->put(
+            '.last_build.yaml',
+            $blueprint->dump($generated)
+        );
+    }
 
     /**
      * Get the console command arguments.

--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Blueprint;
 
-use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
 class BlueprintServiceProvider extends ServiceProvider implements DeferrableProvider
 {
@@ -32,8 +32,16 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
                 return new BlueprintCommand($app['files']);
             }
         );
+        $this->app->bind('command.blueprint.erase',
+            function ($app) {
+                return new EraseCommand($app['files']);
+            }
+        );
 
-        $this->commands('command.blueprint.build');
+        $this->commands([
+            'command.blueprint.build',
+            'command.blueprint.erase',
+        ]);
     }
 
     /**
@@ -43,7 +51,9 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function provides()
     {
-        return ['command.blueprint.build'];
+        return [
+            'command.blueprint.build',
+            'command.blueprint.erase',
+        ];
     }
-
 }

--- a/src/EraseCommand.php
+++ b/src/EraseCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Blueprint;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputArgument;
+
+class EraseCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'blueprint:erase {draft=draft.yaml}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Erase components created from a Blueprint draft';
+
+    /** @var Filesystem $files */
+    protected $files;
+
+    /**
+     * @param Filesystem $files
+     * @param \Illuminate\Contracts\View\Factory $view
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $file = $this->argument('draft');
+        if (!file_exists($file)) {
+            $this->error('Draft file could not be found: ' . $file);
+        }
+
+        $contents = $this->files->get($file);
+
+        $blueprint = new Blueprint();
+
+        $blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
+        $blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new \Blueprint\Lexers\StatementLexer()));
+
+        $blueprint->registerGenerator(new \Blueprint\Generators\MigrationGenerator($this->files));
+        $blueprint->registerGenerator(new \Blueprint\Generators\ModelGenerator($this->files));
+        $blueprint->registerGenerator(new \Blueprint\Generators\FactoryGenerator($this->files));
+
+        $blueprint->registerGenerator(new \Blueprint\Generators\ControllerGenerator($this->files));
+        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\EventGenerator($this->files));
+        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\FormRequestGenerator($this->files));
+        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\JobGenerator($this->files));
+        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\MailGenerator($this->files));
+        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\ViewGenerator($this->files));
+        $blueprint->registerGenerator(new \Blueprint\Generators\RouteGenerator($this->files));
+
+        $tokens = $blueprint->parse($contents);
+        $registry = $blueprint->analyze($tokens);
+        $generated = $blueprint->generate($registry);
+
+        collect($generated)->each(function ($files, $action) {
+            $this->line(Str::studly($action) . ':', $this->outputStyle($action));
+            collect($files)->each(function ($file) {
+                $this->line('- ' . $file);
+            });
+
+            $this->line('');
+        });
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['draft', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Which models to include', []],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+
+    private function outputStyle($action)
+    {
+        if ($action === 'deleted') {
+            return 'error';
+        } elseif ($action === 'updated') {
+            return 'comment';
+        }
+
+        return 'info';
+    }
+}

--- a/tests/Feature/Generator/ControllerGeneratorTest.php
+++ b/tests/Feature/Generator/ControllerGeneratorTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature\Generators;
 
-use Blueprint\Blueprint;
-use Blueprint\Generators\ControllerGenerator;
-use Blueprint\Lexers\StatementLexer;
 use Tests\TestCase;
+use Blueprint\Blueprint;
+use Blueprint\Lexers\StatementLexer;
+use Blueprint\Generators\ControllerGenerator;
 
 /**
  * @see ControllerGenerator
@@ -70,9 +70,23 @@ class ControllerGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
-        ++$iteration;
+        $iteration++;
     }
 
+    /**
+     * @test
+     * @dataProvider controllerTreeDataProvider
+     */
+    public function erase_deletes_controllers_listed_in_tree($definition, $path)
+    {
+        $this->files->expects('delete')
+            ->with($path);
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['deleted' => [$path]], $this->subject->erase($tree));
+    }
 
     public function controllerTreeDataProvider()
     {

--- a/tests/Feature/Generator/ControllerGeneratorTest.php
+++ b/tests/Feature/Generator/ControllerGeneratorTest.php
@@ -73,21 +73,6 @@ class ControllerGeneratorTest extends TestCase
         $iteration++;
     }
 
-    /**
-     * @test
-     * @dataProvider controllerTreeDataProvider
-     */
-    public function erase_deletes_controllers_listed_in_tree($definition, $path)
-    {
-        $this->files->expects('delete')
-            ->with($path);
-
-        $tokens = $this->blueprint->parse($this->fixture($definition));
-        $tree = $this->blueprint->analyze($tokens);
-
-        $this->assertEquals(['deleted' => [$path]], $this->subject->erase($tree));
-    }
-
     public function controllerTreeDataProvider()
     {
         return [

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Generators;
 
+use Tests\TestCase;
 use Blueprint\Blueprint;
 use Blueprint\Generators\FactoryGenerator;
-use Tests\TestCase;
 
 class FactoryGeneratorTest extends TestCase
 {
@@ -60,11 +60,25 @@ class FactoryGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
+    /**
+     * @test
+     * @dataProvider modelTreeDataProvider
+     */
+    public function erase_deletes_factories_listed_in_tree($definition, $path)
+    {
+        $this->files->expects('delete')
+            ->with($path);
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['deleted' => [$path]], $this->subject->erase($tree));
+    }
 
     public function modelTreeDataProvider()
     {
         return [
-            ['definitions/post.bp', 'database/factories/PostFactory.php', 'factories/post.php']
+            ['definitions/post.bp', 'database/factories/PostFactory.php', 'factories/post.php'],
         ];
     }
 }

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -60,21 +60,6 @@ class FactoryGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     * @dataProvider modelTreeDataProvider
-     */
-    public function erase_deletes_factories_listed_in_tree($definition, $path)
-    {
-        $this->files->expects('delete')
-            ->with($path);
-
-        $tokens = $this->blueprint->parse($this->fixture($definition));
-        $tree = $this->blueprint->analyze($tokens);
-
-        $this->assertEquals(['deleted' => [$path]], $this->subject->erase($tree));
-    }
-
     public function modelTreeDataProvider()
     {
         return [

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -69,26 +69,6 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$timestamp_path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     * @dataProvider modelTreeDataProvider
-     */
-    public function erase_deltes_migrations_listed_in_model_tree($definition, $path)
-    {
-        $now = Carbon::now();
-        Carbon::setTestNow($now);
-
-        $timestamp_path = str_replace('timestamp', $now->format('Y_m_d_His'), $path);
-
-        $this->files->expects('delete')
-            ->with($timestamp_path);
-
-        $tokens = $this->blueprint->parse($this->fixture($definition));
-        $tree = $this->blueprint->analyze($tokens);
-
-        $this->assertEquals(['deleted' => [$timestamp_path]], $this->subject->erase($tree));
-    }
-
     public function modelTreeDataProvider()
     {
         return [

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature\Generators;
 
-use Blueprint\Blueprint;
-use Blueprint\Generators\MigrationGenerator;
 use Carbon\Carbon;
 use Tests\TestCase;
+use Blueprint\Blueprint;
+use Blueprint\Generators\MigrationGenerator;
 
 /**
  * @see MigrationGenerator
@@ -67,6 +67,26 @@ class MigrationGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals(['created' => [$timestamp_path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @dataProvider modelTreeDataProvider
+     */
+    public function erase_deltes_migrations_listed_in_model_tree($definition, $path)
+    {
+        $now = Carbon::now();
+        Carbon::setTestNow($now);
+
+        $timestamp_path = str_replace('timestamp', $now->format('Y_m_d_His'), $path);
+
+        $this->files->expects('delete')
+            ->with($timestamp_path);
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['deleted' => [$timestamp_path]], $this->subject->erase($tree));
     }
 
     public function modelTreeDataProvider()

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -83,21 +83,6 @@ class ModelGeneratorTest extends TestCase
         $iteration++;
     }
 
-    /**
-     * @test
-     * @dataProvider modelTreeDataProvider
-     */
-    public function erase_deletes_models_listed_in_tree($definition, $path)
-    {
-        $this->files->expects('delete')
-            ->with($path);
-
-        $tokens = $this->blueprint->parse($this->fixture($definition));
-        $tree = $this->blueprint->analyze($tokens);
-
-        $this->assertEquals(['deleted' => [$path]], $this->subject->erase($tree));
-    }
-
     public function modelTreeDataProvider()
     {
         return [

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Generators;
 
+use Tests\TestCase;
 use Blueprint\Blueprint;
 use Blueprint\Generators\ModelGenerator;
-use Tests\TestCase;
 
 class ModelGeneratorTest extends TestCase
 {
@@ -80,9 +80,23 @@ class ModelGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
-        ++$iteration;
+        $iteration++;
     }
 
+    /**
+     * @test
+     * @dataProvider modelTreeDataProvider
+     */
+    public function erase_deletes_models_listed_in_tree($definition, $path)
+    {
+        $this->files->expects('delete')
+            ->with($path);
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['deleted' => [$path]], $this->subject->erase($tree));
+    }
 
     public function modelTreeDataProvider()
     {

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature\Generators;
 
-use Blueprint\Blueprint;
-use Blueprint\Generators\RouteGenerator;
-use Blueprint\Lexers\StatementLexer;
 use Tests\TestCase;
+use Blueprint\Blueprint;
+use Blueprint\Lexers\StatementLexer;
+use Blueprint\Generators\RouteGenerator;
 
 /**
  * @see RouteGenerator
@@ -57,6 +57,24 @@ class RouteGeneratorTest extends TestCase
         $this->assertEquals(['updated' => [$path]], $this->subject->output($tree));
     }
 
+    /**
+     * @test
+     * @dataProvider controllerTreeDataProvider
+     */
+    public function erase_deletes_routes_in_tree($definition, $routes)
+    {
+        $path = 'routes/web.php';
+
+        $this->files->expects('get')
+            ->with($path);
+        $this->files->expects('put')
+            ->with($path, '');
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['updated' => [$path]], $this->subject->erase($tree));
+    }
 
     public function controllerTreeDataProvider()
     {

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -57,25 +57,6 @@ class RouteGeneratorTest extends TestCase
         $this->assertEquals(['updated' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     * @dataProvider controllerTreeDataProvider
-     */
-    public function erase_deletes_routes_in_tree($definition, $routes)
-    {
-        $path = 'routes/web.php';
-
-        $this->files->expects('get')
-            ->with($path);
-        $this->files->expects('put')
-            ->with($path, '');
-
-        $tokens = $this->blueprint->parse($this->fixture($definition));
-        $tree = $this->blueprint->analyze($tokens);
-
-        $this->assertEquals(['updated' => [$path]], $this->subject->erase($tree));
-    }
-
     public function controllerTreeDataProvider()
     {
         return [


### PR DESCRIPTION
closes #16 

---

I've first considered adding an `erase()` method to all generator-classes which un-does what they generated before. I didn't have a solution to undo just the last changes. Also, it seemed tedious and I had another idea.

Why not just store the generated build in a `yaml` file and iterate over it when the `erase` command is called? The only downside of this approach is that I have no way to access what happened to those files who weren't `created` but just `updated`. Maybe you have a solution for this as well?

EDIT:
I'd add tests for the `EraseCommand` if you would allow me to add the `orchestra/testbench`