### PR TITLE
Fixes #32: Attach relationships to models in factory definitions

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -4,6 +4,7 @@ namespace Blueprint\Generators;
 
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Model;
+use Illuminate\Support\Str;
 
 class FactoryGenerator implements Generator
 {
@@ -61,10 +62,19 @@ class FactoryGenerator implements Generator
                 continue;
             }
 
-            $definition .= self::INDENT . "'{$column->name()}' => ";
-            $faker = $this->fakerData($column->name()) ?? $this->fakerDataType($column->dataType());
-            $definition .= '$faker->' . $faker;
-            $definition .= ',' . PHP_EOL;
+            if ($column->dataType() === 'id') {
+				$name = Str::substr($column->name(), 0, -3);
+				$class = Str::studly($column->attributes()[0] ?? $name);
+
+				$definition .= self::INDENT . "'{$column->name()}' => ";
+				$definition .= sprintf("factory(\App\%s::class)", $class);
+				$definition .= ',' . PHP_EOL;
+			} else {
+				$definition .= self::INDENT . "'{$column->name()}' => ";
+				$faker = $this->fakerData($column->name()) ?? $this->fakerDataType($column->dataType());
+				$definition .= '$faker->' . $faker;
+				$definition .= ',' . PHP_EOL;
+			}
         }
 
         return trim($definition);

--- a/tests/fixtures/factories/post.php
+++ b/tests/fixtures/factories/post.php
@@ -8,7 +8,7 @@ use Faker\Generator as Faker;
 $factory->define(Post::class, function (Faker $faker) {
     return [
         'title' => $faker->sentence(4),
-        'author_id' => $faker->randomDigitNotNull,
+        'author_id' => factory(\App\Author::class),
         'content' => $faker->paragraphs(3, true),
         'published_at' => $faker->dateTime(),
         'word_count' => $faker->randomNumber(),


### PR DESCRIPTION
This PR will add the ability for the `FactoryGenerator` to render a relationship definition.

Instead of:
```php
$factory->define(Person::class, function (Faker $faker) {
    return [
        'additionalName' => $faker->word,
        'address_id' => $faker->randomDigitNotNull,
        'familyName' => $faker->word,
        'givenName' => $faker->word,
    ];
});
```

It will now yield:
```php
$factory->define(Person::class, function (Faker $faker) {
    return [
        'additionalName' => $faker->word,
        'address_id' => factory(App\PostalAddress::class),
        'familyName' => $faker->word,
        'givenName' => $faker->word,
    ];
});
```

Using the factory to create a `Person` will also yield the creation of a `PostalAddress`.

PR includes an updated fixture to allow the test suite to get green.

If there's anything that needs to be changed, please let me know.

Cheers!