### PR TITLE
Register Blueprint as singleton for extensibility

### DIFF
--- a/src/BlueprintCommand.php
+++ b/src/BlueprintCommand.php
@@ -50,27 +50,8 @@ class BlueprintCommand extends Command
         }
 
         $contents = $this->files->get($file);
-
-        $blueprint = new Blueprint();
-
-        $blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-        $blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new \Blueprint\Lexers\StatementLexer()));
-
-        $blueprint->registerGenerator(new \Blueprint\Generators\MigrationGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\ModelGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\FactoryGenerator($this->files));
-
-        $blueprint->registerGenerator(new \Blueprint\Generators\ControllerGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\EventGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\FormRequestGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\JobGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\MailGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\Statements\ViewGenerator($this->files));
-        $blueprint->registerGenerator(new \Blueprint\Generators\RouteGenerator($this->files));
-
-        $tokens = $blueprint->parse($contents);
-        $registry = $blueprint->analyze($tokens);
-        $generated = $blueprint->generate($registry);
+        $blueprint = resolve(Blueprint::class);
+        $generated = Builder::execute($blueprint, $contents);
 
         collect($generated)->each(function ($files, $action) {
             $this->line(Str::studly($action) . ':', $this->outputStyle($action));

--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -31,11 +31,32 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
                 return new BlueprintCommand($app['files']);
             }
         );
+
         $this->app->bind('command.blueprint.erase',
             function ($app) {
                 return new EraseCommand($app['files']);
             }
         );
+
+        $this->app->singleton(Blueprint::class, function ($app) {
+            $blueprint = new Blueprint();
+            $blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
+            $blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new \Blueprint\Lexers\StatementLexer()));
+
+            $blueprint->registerGenerator(new \Blueprint\Generators\MigrationGenerator($app['files']));
+            $blueprint->registerGenerator(new \Blueprint\Generators\ModelGenerator($app['files']));
+            $blueprint->registerGenerator(new \Blueprint\Generators\FactoryGenerator($app['files']));
+
+            $blueprint->registerGenerator(new \Blueprint\Generators\ControllerGenerator($app['files']));
+            $blueprint->registerGenerator(new \Blueprint\Generators\Statements\EventGenerator($app['files']));
+            $blueprint->registerGenerator(new \Blueprint\Generators\Statements\FormRequestGenerator($app['files']));
+            $blueprint->registerGenerator(new \Blueprint\Generators\Statements\JobGenerator($app['files']));
+            $blueprint->registerGenerator(new \Blueprint\Generators\Statements\MailGenerator($app['files']));
+            $blueprint->registerGenerator(new \Blueprint\Generators\Statements\ViewGenerator($app['files']));
+            $blueprint->registerGenerator(new \Blueprint\Generators\RouteGenerator($app['files']));
+
+            return $blueprint;
+        });
 
         $this->commands([
             'command.blueprint.build',
@@ -53,6 +74,7 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
         return [
             'command.blueprint.build',
             'command.blueprint.erase',
+            Blueprint::class,
         ];
     }
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Blueprint;
+
+class Builder
+{
+    public static function execute(Blueprint $blueprint, string $draft)
+    {
+        // TODO: read in previous models...
+
+        $tokens = $blueprint->parse($draft);
+        $registry = $blueprint->analyze($tokens);
+        $generated = $blueprint->generate($registry);
+
+        // TODO: save to .blueprint
+
+        return $generated;
+    }
+}

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit;
+
+use Blueprint\Blueprint;
+use Blueprint\Builder;
+use Tests\TestCase;
+
+class BuilderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function execute_uses_blueprint_to_build_draft()
+    {
+        $digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        shuffle($digits);
+
+        $draft = implode($digits);
+        $tokens = $digits;
+        $registry = array_rand($digits, 9);
+        $generated = array_rand($digits, 9);
+
+        $blueprint = \Mockery::mock(Blueprint::class);
+        $blueprint->expects('parse')
+            ->with($draft)
+            ->andReturn($tokens);
+        $blueprint->expects('analyze')
+            ->with($tokens)
+            ->andReturn($registry);
+        $blueprint->expects('generate')
+            ->with($registry)
+            ->andReturn($generated);
+
+        $actual = Builder::execute($blueprint, $draft);
+
+        $this->assertSame($generated, $actual);
+    }
+}


### PR DESCRIPTION
By registering Blueprint as a singleton, users may completely override their own implementations or resolve the shared instance to register their own generators.