### PR TITLE
Add support for longtext in fakeableTypes

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -137,6 +137,7 @@ class FactoryGenerator implements Generator
             'smallint' => 'randomNumber()',
             'decimal' => 'randomFloat()',
             'float' => 'randomFloat()',
+            'longtext' => 'text',
             'boolean' => 'boolean'
         ];
 


### PR DESCRIPTION
Noticed longtext type results in an empty faker value in the factory generation.