### PR TITLE
Fix the migration datatype of an `id` column

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -58,7 +58,7 @@ class MigrationGenerator implements Generator
         foreach ($model->columns() as $column) {
             $dataType = $column->dataType();
             if ($column->name() === 'id') {
-                $dataType = 'increments';
+                $dataType = 'bigIncrements';
             } elseif ($column->dataType() === 'id') {
                 $dataType = 'unsignedBigInteger';
             }

--- a/tests/fixtures/migrations/comments.php
+++ b/tests/fixtures/migrations/comments.php
@@ -14,7 +14,7 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::create('comments', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->text('content');
             $table->timestamps();
         });

--- a/tests/fixtures/migrations/identity-columns.php
+++ b/tests/fixtures/migrations/identity-columns.php
@@ -14,7 +14,7 @@ class CreateRelationshipsTable extends Migration
     public function up()
     {
         Schema::create('relationships', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->unsignedBigInteger('post_id');
             $table->unsignedBigInteger('another');
         });

--- a/tests/fixtures/migrations/modifiers.php
+++ b/tests/fixtures/migrations/modifiers.php
@@ -14,7 +14,7 @@ class CreateModifiersTable extends Migration
     public function up()
     {
         Schema::create('modifiers', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('title')->nullable();
             $table->string('name', 1000)->unique()->charset('utf8');
             $table->string('content')->default('');

--- a/tests/fixtures/migrations/posts.php
+++ b/tests/fixtures/migrations/posts.php
@@ -14,7 +14,7 @@ class CreatePostsTable extends Migration
     public function up()
     {
         Schema::create('posts', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('title');
             $table->timestamps();
         });

--- a/tests/fixtures/migrations/readme-example.php
+++ b/tests/fixtures/migrations/readme-example.php
@@ -14,7 +14,7 @@ class CreatePostsTable extends Migration
     public function up()
     {
         Schema::create('posts', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('title', 400);
             $table->longText('content');
             $table->timestamp('published_at')->nullable();

--- a/tests/fixtures/migrations/relationships.php
+++ b/tests/fixtures/migrations/relationships.php
@@ -14,7 +14,7 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::create('comments', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->unsignedBigInteger('post_id');
             $table->unsignedBigInteger('author_id');
             $table->timestamps();

--- a/tests/fixtures/migrations/soft-deletes.php
+++ b/tests/fixtures/migrations/soft-deletes.php
@@ -14,7 +14,7 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::create('comments', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->unsignedBigInteger('post_id');
             $table->softDeletes();
             $table->timestamps();

--- a/tests/fixtures/migrations/with-timezones.php
+++ b/tests/fixtures/migrations/with-timezones.php
@@ -14,7 +14,7 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::create('comments', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->softDeletesTz();
             $table->timestampsTz();
         });


### PR DESCRIPTION
If applied, this pull request will:
- [x] change the dataType of an `id` column from `increments` to `bigIncrements` ensuring relationships created with `unsignedBigInteger` _(`UNSIGNED BIGINT equivalent column`)_ matches the dataType of an `id` column _(`Auto-incrementing UNSIGNED BIGINT` )_.
- [x] update all the current test fixtures

| Column Types| Description | 
| --: | :-- |
|`increments` | Auto-incrementing UNSIGNED INTEGER (primary key) equivalent column.|
|`bigIncrements` | Auto-incrementing UNSIGNED BIGINT (primary key) equivalent column.|
|`unsignedBigInteger` | UNSIGNED BIGINT equivalent column.|