### PR TITLE
Nested components and configurable namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "mockery/mockery": "^1.2"
+        "mockery/mockery": "^1.2",
+        "orchestra/testbench": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e382b18b733825210955273213ad8722",
+    "content-hash": "139e5c20bdbdd456f864324dad903a1a",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -74,40 +74,156 @@
             "time": "2018-01-09T20:05:19+00:00"
         },
         {
-            "name": "illuminate/console",
-            "version": "v6.5.0",
+            "name": "doctrine/lexer",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/illuminate/console.git",
-                "reference": "e87ca7da2c1849a33b86b1e6ec1e64fe6faa937d"
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/console/zipball/e87ca7da2c1849a33b86b1e6ec1e64fe6faa937d",
-                "reference": "e87ca7da2c1849a33b86b1e6ec1e64fe6faa937d",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^6.0",
-                "illuminate/support": "^6.0",
-                "php": "^7.2",
-                "symfony/console": "^4.3.4",
-                "symfony/process": "^4.3.4"
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "time": "2019-10-30T14:39:59+00:00"
+        },
+        {
+            "name": "dragonmantank/cron-expression",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dragonmantank/cron-expression.git",
+                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/72b6fbf76adb3cf5bc0db68559b33d41219aba27",
+                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4|^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cron\\": "src/Cron/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Chris Tankersley",
+                    "email": "chris@ctankersley.com",
+                    "homepage": "https://github.com/dragonmantank"
+                }
+            ],
+            "description": "CRON for PHP: Calculate the next or previous run date and determine if a CRON expression is due",
+            "keywords": [
+                "cron",
+                "schedule"
+            ],
+            "time": "2019-03-31T00:38:28+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "2.1.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "c4b8d12921999d8a561004371701dbc2e05b5ece"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/c4b8d12921999d8a561004371701dbc2e05b5ece",
+                "reference": "c4b8d12921999d8a561004371701dbc2e05b5ece",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^1.0.1",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "dominicsayers/isemail": "^3.0.7",
+                "phpunit/phpunit": "^4.8.36|^7.5.15",
+                "satooshi/php-coveralls": "^1.0.1"
             },
             "suggest": {
-                "dragonmantank/cron-expression": "Required to use scheduling component (^2.0).",
-                "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^6.0).",
-                "illuminate/filesystem": "Required to use the generator command (^6.0)"
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Illuminate\\Console\\": ""
+                    "Egulias\\EmailValidator\\": "EmailValidator"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -116,42 +232,45 @@
             ],
             "authors": [
                 {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
+                    "name": "Eduardo Gulias Davis"
                 }
             ],
-            "description": "The Illuminate Console package.",
-            "homepage": "https://laravel.com",
-            "time": "2019-10-24T11:49:56+00:00"
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "time": "2020-01-05T14:11:20+00:00"
         },
         {
-            "name": "illuminate/contracts",
-            "version": "v6.5.0",
+            "name": "erusev/parsedown",
+            "version": "1.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/illuminate/contracts.git",
-                "reference": "5e32ed8640ff70179dfde98eda04790b1cfa9a41"
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/5e32ed8640ff70179dfde98eda04790b1cfa9a41",
-                "reference": "5e32ed8640ff70179dfde98eda04790b1cfa9a41",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
-                "psr/container": "^1.0",
-                "psr/simple-cache": "^1.0"
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.0-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Illuminate\\Contracts\\": ""
+                "psr-0": {
+                    "Parsedown": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -160,112 +279,146 @@
             ],
             "authors": [
                 {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
                 }
             ],
-            "description": "The Illuminate Contracts package.",
-            "homepage": "https://laravel.com",
-            "time": "2019-10-21T18:36:48+00:00"
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2019-12-30T22:54:17+00:00"
         },
         {
-            "name": "illuminate/filesystem",
+            "name": "laravel/framework",
             "version": "v6.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "197bac14e3f49d2c39f37e4a8ae1422ac08d50cf"
+                "url": "https://github.com/laravel/framework.git",
+                "reference": "6d120a21ef0c69630e92dec67932ef434c746019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/197bac14e3f49d2c39f37e4a8ae1422ac08d50cf",
-                "reference": "197bac14e3f49d2c39f37e4a8ae1422ac08d50cf",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/contracts": "^6.0",
-                "illuminate/support": "^6.0",
-                "php": "^7.2",
-                "symfony/finder": "^4.3.4"
-            },
-            "suggest": {
-                "league/flysystem": "Required to use the Flysystem local and FTP drivers (^1.0).",
-                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
-                "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
-                "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
-                "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0)"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Filesystem\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Filesystem package.",
-            "homepage": "https://laravel.com",
-            "time": "2019-10-27T20:14:21+00:00"
-        },
-        {
-            "name": "illuminate/support",
-            "version": "v6.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/support.git",
-                "reference": "236fa24d2e510c4800429cde89ed72e535051a5d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/236fa24d2e510c4800429cde89ed72e535051a5d",
-                "reference": "236fa24d2e510c4800429cde89ed72e535051a5d",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/6d120a21ef0c69630e92dec67932ef434c746019",
+                "reference": "6d120a21ef0c69630e92dec67932ef434c746019",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "^1.1",
+                "dragonmantank/cron-expression": "^2.0",
+                "egulias/email-validator": "^2.1.10",
+                "erusev/parsedown": "^1.7",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "illuminate/contracts": "^6.0",
+                "ext-openssl": "*",
+                "league/flysystem": "^1.0.8",
+                "monolog/monolog": "^1.12|^2.0",
                 "nesbot/carbon": "^2.0",
-                "php": "^7.2"
+                "opis/closure": "^3.1",
+                "php": "^7.2",
+                "psr/container": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "ramsey/uuid": "^3.7",
+                "swiftmailer/swiftmailer": "^6.0",
+                "symfony/console": "^4.3.4",
+                "symfony/debug": "^4.3.4",
+                "symfony/finder": "^4.3.4",
+                "symfony/http-foundation": "^4.3.4",
+                "symfony/http-kernel": "^4.3.4",
+                "symfony/process": "^4.3.4",
+                "symfony/routing": "^4.3.4",
+                "symfony/var-dumper": "^4.3.4",
+                "tijsverkoyen/css-to-inline-styles": "^2.2.1",
+                "vlucas/phpdotenv": "^3.3"
             },
             "conflict": {
                 "tightenco/collect": "<5.5.33"
             },
+            "replace": {
+                "illuminate/auth": "self.version",
+                "illuminate/broadcasting": "self.version",
+                "illuminate/bus": "self.version",
+                "illuminate/cache": "self.version",
+                "illuminate/config": "self.version",
+                "illuminate/console": "self.version",
+                "illuminate/container": "self.version",
+                "illuminate/contracts": "self.version",
+                "illuminate/cookie": "self.version",
+                "illuminate/database": "self.version",
+                "illuminate/encryption": "self.version",
+                "illuminate/events": "self.version",
+                "illuminate/filesystem": "self.version",
+                "illuminate/hashing": "self.version",
+                "illuminate/http": "self.version",
+                "illuminate/log": "self.version",
+                "illuminate/mail": "self.version",
+                "illuminate/notifications": "self.version",
+                "illuminate/pagination": "self.version",
+                "illuminate/pipeline": "self.version",
+                "illuminate/queue": "self.version",
+                "illuminate/redis": "self.version",
+                "illuminate/routing": "self.version",
+                "illuminate/session": "self.version",
+                "illuminate/support": "self.version",
+                "illuminate/translation": "self.version",
+                "illuminate/validation": "self.version",
+                "illuminate/view": "self.version"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/dbal": "^2.6",
+                "filp/whoops": "^2.4",
+                "guzzlehttp/guzzle": "^6.3",
+                "league/flysystem-cached-adapter": "^1.0",
+                "mockery/mockery": "^1.2.3",
+                "moontoast/math": "^1.1",
+                "orchestra/testbench-core": "^4.0",
+                "pda/pheanstalk": "^4.0",
+                "phpunit/phpunit": "^8.3",
+                "predis/predis": "^1.1.1",
+                "symfony/cache": "^4.3",
+                "true/punycode": "^2.1"
+            },
             "suggest": {
-                "illuminate/filesystem": "Required to use the composer class (^6.0).",
+                "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.0).",
+                "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
+                "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
+                "ext-memcached": "Required to use the memcache cache driver.",
+                "ext-pcntl": "Required to use all features of the queue worker.",
+                "ext-posix": "Required to use all features of the queue worker.",
+                "ext-redis": "Required to use the Redis cache and queue drivers.",
+                "filp/whoops": "Required for friendly error pages in development (^2.4).",
+                "fzaninotto/faker": "Required to use the eloquent factory builder (^1.4).",
+                "guzzlehttp/guzzle": "Required to use the Mailgun mail driver and the ping methods on schedules (^6.0).",
+                "laravel/tinker": "Required to use the tinker console command (^1.0).",
+                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
+                "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
+                "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
                 "moontoast/math": "Required to use ordered UUIDs (^1.1).",
-                "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
-                "symfony/process": "Required to use the composer class (^4.3.4).",
-                "symfony/var-dumper": "Required to use the dd function (^4.3.4).",
-                "vlucas/phpdotenv": "Required to use the Env class and env helper (^3.3)."
+                "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
+                "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0)",
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.2).",
+                "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.x-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Illuminate\\Support\\": ""
-                },
                 "files": [
-                    "helpers.php"
-                ]
+                    "src/Illuminate/Foundation/helpers.php",
+                    "src/Illuminate/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\": "src/Illuminate/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -277,9 +430,178 @@
                     "email": "taylor@laravel.com"
                 }
             ],
-            "description": "The Illuminate Support package.",
+            "description": "The Laravel Framework.",
             "homepage": "https://laravel.com",
-            "time": "2019-11-04T13:46:29+00:00"
+            "keywords": [
+                "framework",
+                "laravel"
+            ],
+            "time": "2019-11-05T14:32:58+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "1.0.63",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "8132daec326565036bc8e8d1876f77ec183a7bd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/8132daec326565036bc8e8d1876f77ec183a7bd6",
+                "reference": "8132daec326565036bc8e8d1876f77ec183a7bd6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^3.4",
+                "phpunit/phpunit": "^5.7.10"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "time": "2020-01-04T16:30:31+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "c861fcba2ca29404dc9e617eedd9eff4616986b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c861fcba2ca29404dc9e617eedd9eff4616986b8",
+                "reference": "c861fcba2ca29404dc9e617eedd9eff4616986b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "psr/log": "^1.0.1"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^6.0",
+                "graylog2/gelf-php": "^1.4.2",
+                "jakub-onderka/php-parallel-lint": "^0.9",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "phpspec/prophecy": "^1.6.1",
+                "phpunit/phpunit": "^8.3",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2019-12-20T14:22:59+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -349,6 +671,167 @@
             "time": "2019-10-21T21:32:25+00:00"
         },
         {
+            "name": "opis/closure",
+            "version": "3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/closure.git",
+                "reference": "93ebc5712cdad8d5f489b500c59d122df2e53969"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/closure/zipball/93ebc5712cdad8d5f489b500c59d122df2e53969",
+                "reference": "93ebc5712cdad8d5f489b500c59d122df2e53969",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0"
+            },
+            "require-dev": {
+                "jeremeamia/superclosure": "^2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Closure\\": "src/"
+                },
+                "files": [
+                    "functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "A library that can be used to serialize closures (anonymous functions) and arbitrary objects.",
+            "homepage": "https://opis.io/closure",
+            "keywords": [
+                "anonymous functions",
+                "closure",
+                "function",
+                "serializable",
+                "serialization",
+                "serialize"
+            ],
+            "time": "2019-11-29T22:36:02+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959",
+                "reference": "77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9 || ^7.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.3",
+                "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "time": "2019-12-15T19:35:24+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -398,6 +881,53 @@
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
+            "name": "psr/log",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2019-11-01T11:05:21+00:00"
+        },
+        {
             "name": "psr/simple-cache",
             "version": "1.0.1",
             "source": {
@@ -444,6 +974,155 @@
                 "simple-cache"
             ],
             "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "3.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "7779489a47d443f845271badbdcedfe4df8e06fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/7779489a47d443f845271badbdcedfe4df8e06fb",
+                "reference": "7779489a47d443f845271badbdcedfe4df8e06fb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "paragonie/random_compat": "^1 | ^2 | 9.99.99",
+                "php": "^5.4 | ^7 | ^8",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "codeception/aspect-mock": "^1 | ^2",
+                "doctrine/annotations": "^1.2",
+                "goaop/framework": "1.0.0-alpha.2 | ^1 | ^2.1",
+                "jakub-onderka/php-parallel-lint": "^1",
+                "mockery/mockery": "^0.9.11 | ^1",
+                "moontoast/math": "^1.1",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock-phpunit": "^0.3 | ^1.1",
+                "phpunit/phpunit": "^4.8 | ^5.4 | ^6.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "ext-ctype": "Provides support for PHP Ctype functions",
+                "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-openssl": "Provides the OpenSSL extension for use with the OpenSslGenerator",
+                "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
+                "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                },
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Thibaud Fabre",
+                    "email": "thibaud@aztech.io"
+                }
+            ],
+            "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2019-12-17T08:18:51+00:00"
+        },
+        {
+            "name": "swiftmailer/swiftmailer",
+            "version": "v6.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swiftmailer/swiftmailer.git",
+                "reference": "149cfdf118b169f7840bbe3ef0d4bc795d1780c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/149cfdf118b169f7840bbe3ef0d4bc795d1780c9",
+                "reference": "149cfdf118b169f7840bbe3ef0d4bc795d1780c9",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "~2.0",
+                "php": ">=7.0.0",
+                "symfony/polyfill-iconv": "^1.0",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.1",
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
+            },
+            "suggest": {
+                "ext-intl": "Needed to support internationalized email addresses",
+                "true/punycode": "Needed to support internationalized email addresses, if ext-intl is not installed"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/swift_required.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Corbyn"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Swiftmailer, free feature-rich PHP mailer",
+            "homepage": "https://swiftmailer.symfony.com",
+            "keywords": [
+                "email",
+                "mail",
+                "mailer"
+            ],
+            "time": "2019-11-12T09:31:26+00:00"
         },
         {
             "name": "symfony/console",
@@ -521,6 +1200,299 @@
             "time": "2019-10-30T12:58:49+00:00"
         },
         {
+            "name": "symfony/css-selector",
+            "version": "v5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "19d29e7098b7b2c3313cb03902ca30f100dcb837"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/19d29e7098b7b2c3313cb03902ca30f100dcb837",
+                "reference": "19d29e7098b7b2c3313cb03902ca30f100dcb837",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony CssSelector Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v4.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "5c4c1db977dc70bb3250e1308d3e8c6341aa38f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/5c4c1db977dc70bb3250e1308d3e8c6341aa38f5",
+                "reference": "5c4c1db977dc70bb3250e1308d3e8c6341aa38f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": "<3.4"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-12-16T14:46:54+00:00"
+        },
+        {
+            "name": "symfony/error-handler",
+            "version": "v4.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "6d7d7712a6ff5215ec26215672293b154f1db8c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/6d7d7712a6ff5215ec26215672293b154f1db8c1",
+                "reference": "6d7d7712a6ff5215ec26215672293b154f1db8c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0",
+                "symfony/debug": "^4.4",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/serializer": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ErrorHandler Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-12-16T14:46:54+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "b3c3068a72623287550fe20b84a2b01dcba2686f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b3c3068a72623287550fe20b84a2b01dcba2686f",
+                "reference": "b3c3068a72623287550fe20b84a2b01dcba2686f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/event-dispatcher-contracts": "^1.1"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-11-28T13:33:56+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-09-17T09:54:03+00:00"
+        },
+        {
             "name": "symfony/finder",
             "version": "v4.3.6",
             "source": {
@@ -568,6 +1540,213 @@
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "time": "2019-10-30T12:53:54+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v4.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "fcae1cff5b57b2a9c3aabefeb1527678705ddb62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fcae1cff5b57b2a9c3aabefeb1527678705ddb62",
+                "reference": "fcae1cff5b57b2a9c3aabefeb1527678705ddb62",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/mime": "^4.3|^5.0",
+                "symfony/polyfill-mbstring": "~1.1"
+            },
+            "require-dev": {
+                "predis/predis": "~1.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-12-19T15:57:49+00:00"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v4.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "fe310d2e95cd4c356836c8ecb0895a46d97fede2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fe310d2e95cd4c356836c8ecb0895a46d97fede2",
+                "reference": "fe310d2e95cd4c356836c8ecb0895a46d97fede2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0",
+                "symfony/error-handler": "^4.4",
+                "symfony/event-dispatcher": "^4.4",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-php73": "^1.9"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<4.3",
+                "symfony/config": "<3.4",
+                "symfony/console": ">=5",
+                "symfony/dependency-injection": "<4.3",
+                "symfony/translation": "<4.2",
+                "twig/twig": "<1.34|<2.4,>=2"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/cache": "~1.0",
+                "symfony/browser-kit": "^4.3|^5.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0",
+                "symfony/css-selector": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^4.3|^5.0",
+                "symfony/dom-crawler": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/finder": "^3.4|^4.0|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/routing": "^3.4|^4.0|^5.0",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0",
+                "symfony/templating": "^3.4|^4.0|^5.0",
+                "symfony/translation": "^4.2|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "twig/twig": "^1.34|^2.4|^3.0"
+            },
+            "suggest": {
+                "symfony/browser-kit": "",
+                "symfony/config": "",
+                "symfony/console": "",
+                "symfony/dependency-injection": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpKernel Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-12-19T16:23:40+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "0e6a4ced216e49d457eddcefb61132173a876d79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/0e6a4ced216e49d457eddcefb61132173a876d79",
+                "reference": "0e6a4ced216e49d457eddcefb61132173a876d79",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/mailer": "<4.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10",
+                "symfony/dependency-injection": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A library to manipulate MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "time": "2019-11-30T14:12:50+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -628,6 +1807,127 @@
             "time": "2019-08-06T08:03:45+00:00"
         },
         {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "a019efccc03f1a335af6b4f20c30f5ea8060be36"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/a019efccc03f1a335af6b4f20c30f5ea8060be36",
+                "reference": "a019efccc03f1a335af6b4f20c30f5ea8060be36",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T13:56:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "6f9c239e61e1b0c9229a28ff89a812dc449c3d46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/6f9c239e61e1b0c9229a28ff89a812dc449c3d46",
+                "reference": "6f9c239e61e1b0c9229a28ff89a812dc449c3d46",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.9"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T13:56:44+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.12.0",
             "source": {
@@ -685,6 +1985,61 @@
                 "shim"
             ],
             "time": "2019-08-06T08:03:45+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/66fea50f6cb37a35eea048d75a7d99a45b586038",
+                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -792,6 +2147,82 @@
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
             "time": "2019-10-28T17:07:32+00:00"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v4.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "628bcafae1b2043969378dcfbf9c196539a38722"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/628bcafae1b2043969378dcfbf9c196539a38722",
+                "reference": "628bcafae1b2043969378dcfbf9c196539a38722",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/config": "<4.2",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.2",
+                "psr/log": "~1.0",
+                "symfony/config": "^4.2|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation loader",
+                "symfony/config": "For using the all-in-one router or any loader",
+                "symfony/expression-language": "For using expression matching",
+                "symfony/http-foundation": "For using a Symfony Request object",
+                "symfony/yaml": "For using the YAML loader"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Routing\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Routing Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "router",
+                "routing",
+                "uri",
+                "url"
+            ],
+            "time": "2019-12-12T12:53:52+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -985,6 +2416,82 @@
             "time": "2019-09-17T11:12:18+00:00"
         },
         {
+            "name": "symfony/var-dumper",
+            "version": "v4.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "be330f919bdb395d1e0c3f2bfb8948512d6bdd99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/be330f919bdb395d1e0c3f2bfb8948512d6bdd99",
+                "reference": "be330f919bdb395d1e0c3f2bfb8948512d6bdd99",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php72": "~1.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "twig/twig": "^1.34|^2.4|^3.0"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2019-12-18T13:41:29+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v4.3.6",
             "source": {
@@ -1042,6 +2549,112 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2019-10-30T12:58:49+00:00"
+        },
+        {
+            "name": "tijsverkoyen/css-to-inline-styles",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
+                "reference": "dda2ee426acd6d801d5b7fd1001cde9b5f790e15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/dda2ee426acd6d801d5b7fd1001cde9b5f790e15",
+                "reference": "dda2ee426acd6d801d5b7fd1001cde9b5f790e15",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^5.5 || ^7.0",
+                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TijsVerkoyen\\CssToInlineStyles\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Tijs Verkoyen",
+                    "email": "css_to_inline_styles@verkoyen.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
+            "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
+            "time": "2019-10-24T08:53:34+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "1bdf24f065975594f6a117f0f1f6cabf1333b156"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/1bdf24f065975594f6a117f0f1f6cabf1333b156",
+                "reference": "1bdf24f065975594f6a117f0f1f6cabf1333b156",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0",
+                "phpoption/phpoption": "^1.5",
+                "symfony/polyfill-ctype": "^1.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "homepage": "https://gjcampbell.co.uk/"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://vancelucas.com/"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2019-09-10T21:37:39+00:00"
         }
     ],
     "packages-dev": [
@@ -1100,6 +2713,56 @@
                 "instantiate"
             ],
             "time": "2019-03-17T17:37:11+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/fc10d778e4b84d5bd315dad194661e091d307c6f",
+                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
+                "squizlabs/php_codesniffer": "^2.9.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2019-12-12T13:22:17+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -1261,6 +2924,121 @@
                 "object graph"
             ],
             "time": "2019-08-09T12:45:53+00:00"
+        },
+        {
+            "name": "orchestra/testbench",
+            "version": "v4.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/testbench.git",
+                "reference": "39799813d491c1abbf97e3f909801efb3e6f3a4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/39799813d491c1abbf97e3f909801efb3e6f3a4b",
+                "reference": "39799813d491c1abbf97e3f909801efb3e6f3a4b",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^6.4",
+                "mockery/mockery": "^1.2.3",
+                "orchestra/testbench-core": "^4.4.1",
+                "php": ">=7.2",
+                "phpunit/phpunit": "^8.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com",
+                    "homepage": "https://github.com/crynobone"
+                }
+            ],
+            "description": "Laravel Testing Helper for Packages Development",
+            "homepage": "http://orchestraplatform.com/docs/latest/components/testbench/",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "laravel",
+                "orchestra-platform",
+                "orchestral",
+                "testing"
+            ],
+            "time": "2019-11-22T22:36:07+00:00"
+        },
+        {
+            "name": "orchestra/testbench-core",
+            "version": "v4.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/testbench-core.git",
+                "reference": "b92e31c5b101fc87bc5c3137610151dcae82f0e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/b92e31c5b101fc87bc5c3137610151dcae82f0e3",
+                "reference": "b92e31c5b101fc87bc5c3137610151dcae82f0e3",
+                "shasum": ""
+            },
+            "require": {
+                "fzaninotto/faker": "^1.4",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "laravel/framework": "^6.9",
+                "laravel/laravel": "dev-master",
+                "mockery/mockery": "^1.2.3",
+                "phpunit/phpunit": "^8.3 || ^9.0"
+            },
+            "suggest": {
+                "laravel/framework": "Required for testing (^6.9).",
+                "mockery/mockery": "Allow using Mockery for testing (^1.2.3).",
+                "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^4.0).",
+                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^4.0).",
+                "phpunit/phpunit": "Allow using PHPUnit for testing (^8.3)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Orchestra\\Testbench\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com",
+                    "homepage": "https://github.com/crynobone"
+                }
+            ],
+            "description": "Testing Helper for Laravel Development",
+            "homepage": "http://orchestraplatform.com/docs/latest/components/testbench/",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "laravel",
+                "orchestra-platform",
+                "orchestral",
+                "testing"
+            ],
+            "time": "2019-12-31T01:37:59+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -1,0 +1,47 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Namespace
+    |--------------------------------------------------------------------------
+    |
+    | Blueprint assumes a default Laravel application namespace of 'App'.
+    | However, you may configure Blueprint to use a custom namespace.
+    | Ultimately this should match the PSR-4 autoload value set
+    | within the composer.json file of your application.
+    |
+    */
+    'namespace' => 'App',
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Component Namespaces
+    |--------------------------------------------------------------------------
+    |
+    | Blueprint promotes following Laravel conventions. As such, it generates
+    | components under the default namespaces. For example, models are under
+    | the `App` namespace. However, you may configure Blueprint to use
+    | a custom namespace when generating these components.
+    |
+    */
+    'models_namespace' => '',
+    'controllers_namespace' => 'Http\\Controllers',
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Path
+    |--------------------------------------------------------------------------
+    |
+    | Here you may customize the path where Blueprint stores generated
+    | components. By default, Blueprint will store files under the
+    | `app` folder However, you may change the path to store
+    | generated component elsewhere.
+    |
+    */
+    'app_path' => app_path(),
+
+];

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -11,6 +11,11 @@ class Blueprint
     private $lexers = [];
     private $generators = [];
 
+    public static function relativeNamespace(string $fullyQualifiedClassName)
+    {
+        return ltrim(str_replace(config('blueprint.namespace'), '', $fullyQualifiedClassName), '\\');
+    }
+
     public function parse($content)
     {
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)$/mi', function ($matches) {

--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Blueprint;
 
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
 
 class BlueprintServiceProvider extends ServiceProvider implements DeferrableProvider
@@ -33,6 +34,8 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
         $this->mergeConfigFrom(
             __DIR__.'/../config/blueprint.php', 'blueprint'
         );
+
+        File::mixin(new FileMixins());
 
         $this->app->bind('command.blueprint.build',
             function ($app) {

--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -17,6 +17,10 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
         if (!defined('STUBS_PATH')) {
             define('STUBS_PATH', dirname(__DIR__) . '/stubs');
         }
+
+        $this->publishes([
+            __DIR__.'/../config/blueprint.php' => config_path('blueprint.php'),
+        ]);
     }
 
     /**
@@ -26,6 +30,10 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function register()
     {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/blueprint.php', 'blueprint'
+        );
+
         $this->app->bind('command.blueprint.build',
             function ($app) {
                 return new BlueprintCommand($app['files']);

--- a/src/FileMixins.php
+++ b/src/FileMixins.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Blueprint;
+
+
+class FileMixins
+{
+    private $stubs = [];
+
+    public function stub()
+    {
+        return function ($path) {
+            if (!isset($this->stubs[$path])) {
+                $this->stubs[$path] = $this->get(STUBS_PATH . DIRECTORY_SEPARATOR . $path);
+            }
+
+            return $this->stubs[$path];
+        };
+    }
+}

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -34,7 +34,7 @@ class ControllerGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/controller/class.stub');
+        $stub = $this->files->stub('controller/class.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {
@@ -63,7 +63,7 @@ class ControllerGenerator implements Generator
 
     private function buildMethods(Controller $controller)
     {
-        $template = $this->methodStub();
+        $template = $this->files->stub('controller/method.stub');
 
         $methods = '';
 
@@ -118,7 +118,7 @@ class ControllerGenerator implements Generator
                     $this->addImport($controller, config('blueprint.namespace') . '\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $this->determineModel($controller, $statement->reference()));
                 } elseif ($statement instanceof QueryStatement) {
                     $body .= self::INDENT . $statement->output($controller->prefix()) . PHP_EOL;
-                    $this->addImport($controller, config('blueprint.namespace') . '\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '')  . $this->determineModel($controller, $statement->model()));
+                    $this->addImport($controller, config('blueprint.namespace') . '\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $this->determineModel($controller, $statement->model()));
                 }
 
                 $body .= PHP_EOL;
@@ -139,17 +139,6 @@ class ControllerGenerator implements Generator
         $path = str_replace('\\', '/', Blueprint::relativeNamespace($controller->fullyQualifiedClassName()));
 
         return config('blueprint.app_path') . '/' . $path . '.php';
-    }
-
-    private function methodStub()
-    {
-        static $stub = '';
-
-        if (empty($stub)) {
-            $stub = $this->files->get(STUBS_PATH . '/controller/method.stub');
-        }
-
-        return $stub;
     }
 
     private function addImport(Controller $controller, $class)

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -40,12 +40,17 @@ class FactoryGenerator implements Generator
 
     protected function getPath(Model $model)
     {
-        return 'database/factories/' . $model->name() . 'Factory.php';
+        $path = $model->name();
+        if ($model->namespace()) {
+            $path = str_replace('\\', '/', $model->namespace()) . '/' . $path;
+        }
+
+        return 'database/factories/' . $path . 'Factory.php';
     }
 
     protected function populateStub(string $stub, Model $model)
     {
-        $stub = str_replace('DummyNamespace', 'App', $stub);
+        $stub = str_replace('DummyModel', $model->fullyQualifiedClassName(), $stub);
         $stub = str_replace('DummyClass', $model->name(), $stub);
         $stub = str_replace('// definition...', $this->buildDefinition($model), $stub);
 
@@ -67,7 +72,7 @@ class FactoryGenerator implements Generator
                 $class = Str::studly($column->attributes()[0] ?? $name);
 
                 $definition .= self::INDENT . "'{$column->name()}' => ";
-                $definition .= sprintf("factory(\App\%s::class)", $class);
+                $definition .= sprintf("factory(%s::class)", '\\' . $model->fullyQualifiedNamespace() . '\\' . $class);
                 $definition .= ',' . PHP_EOL;
             } else {
                 $definition .= self::INDENT . "'{$column->name()}' => ";

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -22,7 +22,7 @@ class FactoryGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/factory.stub');
+        $stub = $this->files->stub('factory.stub');
 
         /** @var \Blueprint\Models\Model $model */
         foreach ($tree['models'] as $model) {

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -23,7 +23,7 @@ class MigrationGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/migration.stub');
+        $stub = $this->files->stub('migration.stub');
 
         $sequential_timestamp = \Carbon\Carbon::now()->subSeconds(count($tree['models']));
 

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Blueprint\Generators;
 
+use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Column;
 use Blueprint\Models\Model;
@@ -39,7 +40,7 @@ class ModelGenerator implements Generator
 
     protected function populateStub(string $stub, Model $model)
     {
-        $stub = str_replace('DummyNamespace', 'App', $stub);
+        $stub = str_replace('DummyNamespace', $model->fullyQualifiedNamespace(), $stub);
         $stub = str_replace('DummyClass', $model->name(), $stub);
 
         $body = $this->buildProperties($model);
@@ -93,7 +94,7 @@ class ModelGenerator implements Generator
         foreach ($columns as $column) {
             $name = Str::beforeLast($column->name(), '_id');
             $class = Str::studly($column->attributes()[0] ?? $name);
-            $relationship = sprintf("\$this->belongsTo(\App\%s::class)", $class);
+            $relationship = sprintf("\$this->belongsTo(%s::class)", '\\' . $model->fullyQualifiedNamespace() . '\\' . $class);
 
             $method = str_replace('DummyName', Str::camel($name), $template);
             $method = str_replace('null', $relationship, $method);
@@ -106,7 +107,9 @@ class ModelGenerator implements Generator
 
     protected function getPath(Model $model)
     {
-        return 'app/' . $model->name() . '.php';
+        $path = str_replace('\\', '/', Blueprint::relativeNamespace($model->fullyQualifiedClassName()));
+
+        return config('blueprint.app_path') . '/' . $path . '.php';
     }
 
     private function fillableColumns(array $columns)

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -22,7 +22,7 @@ class ModelGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/model/class.stub');
+        $stub = $this->files->stub('model/class.stub');
 
         /** @var \Blueprint\Models\Model $model */
         foreach ($tree['models'] as $model) {
@@ -59,19 +59,19 @@ class ModelGenerator implements Generator
 
         $columns = $this->fillableColumns($model->columns());
         if (!empty($columns)) {
-            $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns, false), $this->getStub('fillable'));
+            $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns, false), $this->files->stub('model/fillable.stub'));
         } else {
-            $properties .= $this->getStub('fillable');
+            $properties .= $this->files->stub('model/fillable.stub');
         }
 
         $columns = $this->castableColumns($model->columns());
         if (!empty($columns)) {
-            $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns), $this->getStub('casts'));
+            $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns), $this->files->stub('model/casts.stub'));
         }
 
         $columns = $this->dateColumns($model->columns());
         if (!empty($columns)) {
-            $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns, false), $this->getStub('dates'));
+            $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns, false), $this->files->stub('model/dates.stub'));
         }
 
         return trim($properties);
@@ -88,7 +88,7 @@ class ModelGenerator implements Generator
         }
 
         $methods = '';
-        $template = $this->getStub('method');
+        $template = $this->files->stub('model/method.stub');
 
         /** @var Column $column */
         foreach ($columns as $column) {
@@ -175,17 +175,6 @@ class ModelGenerator implements Generator
         }
 
         return trim($output);
-    }
-
-    private function getStub(string $stub)
-    {
-        static $stubs = [];
-
-        if (empty($stubs[$stub])) {
-            $stubs[$stub] = $this->files->get(STUBS_PATH . '/model/' . $stub . '.stub');
-        }
-
-        return $stubs[$stub];
     }
 
     private function addTraits(Model $model, $stub)

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -59,12 +59,12 @@ class EventGenerator implements Generator
 
     protected function getPath(string $name)
     {
-        return 'app/Events/' . $name . '.php';
+        return config('blueprint.app_path') . '/Events/' . $name . '.php';
     }
 
     protected function populateStub(string $stub, FireStatement $fireStatement)
     {
-        $stub = str_replace('DummyNamespace', 'App\\Events', $stub);
+        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Events', $stub);
         $stub = str_replace('DummyClass', $fireStatement->event(), $stub);
         $stub = str_replace('// properties...', $this->buildConstructor($fireStatement), $stub);
 

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -21,7 +21,7 @@ class EventGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/event.stub');
+        $stub = $this->files->stub('event.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {
@@ -76,7 +76,7 @@ class EventGenerator implements Generator
         static $constructor = null;
 
         if (is_null($constructor)) {
-            $constructor = str_replace('new instance', 'new event instance', $this->files->get(STUBS_PATH . '/partials/constructor.stub'));
+            $constructor = str_replace('new instance', 'new event instance', $this->files->stub('partials/constructor.stub'));
         }
 
         if (empty($fireStatement->data())) {

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -28,7 +28,7 @@ class FormRequestGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/form-request.stub');
+        $stub = $this->files->stub('form-request.stub');
 
         $this->registerModels($tree['models'] ?? []);
 

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -3,6 +3,7 @@
 namespace Blueprint\Generators\Statements;
 
 use Blueprint\Contracts\Generator;
+use Blueprint\Models\Controller;
 use Blueprint\Models\Statements\ValidateStatement;
 use Blueprint\Translators\Rules;
 use Illuminate\Support\Str;
@@ -41,7 +42,7 @@ class FormRequestGenerator implements Generator
 
                     $context = Str::singular($controller->prefix());
                     $name = $this->getName($context, $method);
-                    $path = $this->getPath($name);
+                    $path = $this->getPath($controller, $name);
 
                     if ($this->files->exists($path)) {
                         continue;
@@ -53,7 +54,7 @@ class FormRequestGenerator implements Generator
 
                     $this->files->put(
                         $path,
-                        $this->populateStub($stub, $name, $context, $statement)
+                        $this->populateStub($stub, $name, $context, $statement, $controller)
                     );
 
                     $output['created'][] = $path;
@@ -64,14 +65,14 @@ class FormRequestGenerator implements Generator
         return $output;
     }
 
-    protected function getPath(string $name)
+    protected function getPath(Controller $controller, string $name)
     {
-        return 'app/Http/Requests/' . $name . '.php';
+        return config('blueprint.app_path') . '/Http/Requests/' . ($controller->namespace() ? $controller->namespace() . '/' : '') . $name . '.php';
     }
 
-    protected function populateStub(string $stub, string $name, $context, ValidateStatement $validateStatement)
+    protected function populateStub(string $stub, string $name, $context, ValidateStatement $validateStatement, Controller $controller)
     {
-        $stub = str_replace('DummyNamespace', 'App\\Http\\Requests', $stub);
+        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Http\\Requests' . ($controller->namespace() ? '\\' . $controller->namespace() : ''), $stub);
         $stub = str_replace('DummyClass', $name, $stub);
         $stub = str_replace('// rules...', $this->buildRules($context, $validateStatement), $stub);
 
@@ -96,7 +97,19 @@ class FormRequestGenerator implements Generator
 
     private function modelForContext(string $context)
     {
-        return $this->models[Str::studly($context)] ?? $this->models[Str::lower($context)] ?? null;
+        if (isset($this->models[Str::studly($context)])) {
+            return $this->models[Str::studly($context)];
+        }
+
+        $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
+            return Str::endsWith($key, '/' . Str::studly($context));
+        });
+
+        if (count($matches) === 1) {
+            return $this->models[$matches[0]];
+        }
+
+        return null;
     }
 
     private function getName(string $context, string $method)

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -55,12 +55,12 @@ class JobGenerator implements Generator
 
     protected function getPath(string $name)
     {
-        return 'app/Jobs/' . $name . '.php';
+        return config('blueprint.app_path') . '/Jobs/' . $name . '.php';
     }
 
     protected function populateStub(string $stub, DispatchStatement $dispatchStatement)
     {
-        $stub = str_replace('DummyNamespace', 'App\\Jobs', $stub);
+        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Jobs', $stub);
         $stub = str_replace('DummyClass', $dispatchStatement->job(), $stub);
         $stub = str_replace('// properties...', $this->buildConstructor($dispatchStatement), $stub);
 

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -21,7 +21,7 @@ class JobGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/job.stub');
+        $stub = $this->files->stub('job.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {
@@ -72,7 +72,7 @@ class JobGenerator implements Generator
         static $constructor = null;
 
         if (is_null($constructor)) {
-            $constructor = str_replace('new instance', 'new job instance', $this->files->get(STUBS_PATH . '/partials/constructor.stub'));
+            $constructor = str_replace('new instance', 'new job instance', $this->files->stub('partials/constructor.stub'));
         }
 
         if (empty($dispatchStatement->data())) {

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -55,12 +55,12 @@ class MailGenerator implements Generator
 
     protected function getPath(string $name)
     {
-        return 'app/Mail/' . $name . '.php';
+        return config('blueprint.app_path') . '/Mail/' . $name . '.php';
     }
 
     protected function populateStub(string $stub, SendStatement $sendStatement)
     {
-        $stub = str_replace('DummyNamespace', 'App\\Mail', $stub);
+        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Mail', $stub);
         $stub = str_replace('DummyClass', $sendStatement->mail(), $stub);
         $stub = str_replace('// properties...', $this->buildConstructor($sendStatement), $stub);
 

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -21,7 +21,7 @@ class MailGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/mail.stub');
+        $stub = $this->files->stub('mail.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {
@@ -72,7 +72,7 @@ class MailGenerator implements Generator
         static $constructor = null;
 
         if (is_null($constructor)) {
-            $constructor = str_replace('new instance', 'new message instance', $this->files->get(STUBS_PATH . '/partials/constructor.stub'));
+            $constructor = str_replace('new instance', 'new message instance', $this->files->stub('partials/constructor.stub'));
         }
 
         if (empty($sendStatement->data())) {

--- a/src/Generators/Statements/ViewGenerator.php
+++ b/src/Generators/Statements/ViewGenerator.php
@@ -21,7 +21,7 @@ class ViewGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/view.stub');
+        $stub = $this->files->stub('view.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {

--- a/src/Models/Controller.php
+++ b/src/Models/Controller.php
@@ -17,6 +17,11 @@ class Controller
     private $name;
 
     /**
+     * @var string
+     */
+    private $namespace;
+
+    /**
      * @var array
      */
     private $methods = [];
@@ -27,7 +32,8 @@ class Controller
      */
     public function __construct(string $name)
     {
-        $this->name = $name;
+        $this->name = class_basename($name);
+        $this->namespace = trim(implode('\\', array_slice(explode('\\', str_replace('/', '\\', $name)), 0, -1)), '\\');
     }
 
     public function name(): string
@@ -38,6 +44,35 @@ class Controller
     public function className(): string
     {
         return $this->name() . (Str::endsWith($this->name(), 'Controller') ? '' : 'Controller');
+    }
+
+    public function namespace()
+    {
+        if (empty($this->namespace)) {
+            return '';
+        }
+
+        return $this->namespace;
+    }
+
+    public function fullyQualifiedNamespace()
+    {
+        $fqn = config('blueprint.namespace');
+
+        if (config('blueprint.controllers_namespace')) {
+            $fqn .= '\\' . config('blueprint.controllers_namespace');
+        }
+
+        if ($this->namespace) {
+            $fqn .= '\\' . $this->namespace;
+        }
+
+        return $fqn;
+    }
+
+    public function fullyQualifiedClassName()
+    {
+        return $this->fullyQualifiedNamespace() . '\\' . $this->className();
     }
 
     public function methods(): array

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 class Model
 {
     private $name;
+    private $namespace;
     private $timestamps = 'timestamps';
     private $softDeletes = false;
     private $columns = [];
@@ -16,12 +17,42 @@ class Model
      */
     public function __construct($name)
     {
-        $this->name = $name;
+        $this->name = class_basename($name);
+        $this->namespace = trim(implode('\\', array_slice(explode('\\', str_replace('/', '\\', $name)), 0, -1)), '\\');
     }
 
     public function name(): string
     {
         return Str::studly($this->name);
+    }
+
+    public function namespace()
+    {
+        if (empty($this->namespace)) {
+            return '';
+        }
+
+        return $this->namespace;
+    }
+
+    public function fullyQualifiedNamespace()
+    {
+        $fqn = config('blueprint.namespace');
+
+        if (config('blueprint.models_namespace')) {
+            $fqn .= '\\' . config('blueprint.models_namespace');
+        }
+
+        if ($this->namespace) {
+            $fqn .= '\\' . $this->namespace;
+        }
+
+        return $fqn;
+    }
+
+    public function fullyQualifiedClassName()
+    {
+        return $this->fullyQualifiedNamespace() . '\\' . $this->name;
     }
 
     public function addColumn(Column $column)

--- a/src/Models/Statements/QueryStatement.php
+++ b/src/Models/Statements/QueryStatement.php
@@ -28,8 +28,8 @@ class QueryStatement
         $this->operation = $operation;
         $this->clauses = $clauses;
 
-        if ($operation === 'all' && !empty($this->clauses())) {
-            $this->model = Str::studly(Str::singular($this->clauses()[0]));
+        if ($operation === 'all' && !empty($clauses)) {
+            $this->model = Str::studly(Str::singular($clauses[0]));
         }
     }
 

--- a/tests/Feature/Generator/ControllerGeneratorTest.php
+++ b/tests/Feature/Generator/ControllerGeneratorTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature\Generators;
 
-use Tests\TestCase;
 use Blueprint\Blueprint;
-use Blueprint\Lexers\StatementLexer;
 use Blueprint\Generators\ControllerGenerator;
+use Blueprint\Lexers\StatementLexer;
+use Tests\TestCase;
 
 /**
  * @see ControllerGenerator
@@ -36,8 +36,8 @@ class ControllerGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/controller/class.stub')
+        $this->files->expects('stub')
+            ->with('controller/class.stub')
             ->andReturn(file_get_contents('stubs/controller/class.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -51,17 +51,13 @@ class ControllerGeneratorTest extends TestCase
      */
     public function output_writes_migration_for_controller_tree($definition, $path, $controller)
     {
-        static $iteration = 0;
-
-        $this->files->expects('get')
-            ->with('stubs/controller/class.stub')
+        $this->files->expects('stub')
+            ->with('controller/class.stub')
             ->andReturn(file_get_contents('stubs/controller/class.stub'));
 
-        if ($iteration === 0) {
-            $this->files->expects('get')
-                ->with('stubs/controller/method.stub')
-                ->andReturn(file_get_contents('stubs/controller/method.stub'));
-        }
+        $this->files->expects('stub')
+            ->with('controller/method.stub')
+            ->andReturn(file_get_contents('stubs/controller/method.stub'));
 
         $this->files->expects('put')
             ->with($path, $this->fixture($controller));
@@ -70,7 +66,6 @@ class ControllerGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
-        $iteration++;
     }
 
     /**
@@ -82,12 +77,12 @@ class ControllerGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
         $this->app['config']->set('blueprint.controllers_namespace', 'Other\\Http');
 
-        $this->files->expects('get')
-            ->with('stubs/controller/class.stub')
+        $this->files->expects('stub')
+            ->with('controller/class.stub')
             ->andReturn(file_get_contents('stubs/controller/class.stub'));
 
-        $this->files->expects('get')
-            ->with('stubs/controller/method.stub')
+        $this->files->expects('stub')
+            ->with('controller/method.stub')
             ->andReturn(file_get_contents('stubs/controller/method.stub'));
 
         $this->files->expects('put')

--- a/tests/Feature/Generator/ControllerGeneratorTest.php
+++ b/tests/Feature/Generator/ControllerGeneratorTest.php
@@ -73,11 +73,38 @@ class ControllerGeneratorTest extends TestCase
         $iteration++;
     }
 
+    /**
+     * @test
+     */
+    public function output_respects_configuration()
+    {
+        $this->app['config']->set('blueprint.app_path', 'src/path');
+        $this->app['config']->set('blueprint.namespace', 'Some\\App');
+        $this->app['config']->set('blueprint.controllers_namespace', 'Other\\Http');
+
+        $this->files->expects('get')
+            ->with('stubs/controller/class.stub')
+            ->andReturn(file_get_contents('stubs/controller/class.stub'));
+
+        $this->files->expects('get')
+            ->with('stubs/controller/method.stub')
+            ->andReturn(file_get_contents('stubs/controller/method.stub'));
+
+        $this->files->expects('put')
+            ->with('src/path/Other/Http/UserController.php', $this->fixture('controllers/controller-configured.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/simple-controller.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['src/path/Other/Http/UserController.php']], $this->subject->output($tree));
+    }
+
     public function controllerTreeDataProvider()
     {
         return [
             ['definitions/readme-example.bp', 'app/Http/Controllers/PostController.php', 'controllers/readme-example.php'],
             ['definitions/crazy-eloquent.bp', 'app/Http/Controllers/PostController.php', 'controllers/crazy-eloquent.php'],
+            ['definitions/nested-components.bp', 'app/Http/Controllers/Admin/UserController.php', 'controllers/nested-components.php'],
         ];
     }
 }

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -63,12 +63,34 @@ class FactoryGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
+    /**
+     * @test
+     */
+    public function output_respects_configuration()
+    {
+        $this->app['config']->set('blueprint.namespace', 'Some\\App');
+        $this->app['config']->set('blueprint.models_namespace', 'Models');
+
+        $this->files->expects('get')
+            ->with('stubs/factory.stub')
+            ->andReturn(file_get_contents('stubs/factory.stub'));
+
+        $this->files->expects('put')
+            ->with('database/factories/PostFactory.php', $this->fixture('factories/post-configured.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/post.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['database/factories/PostFactory.php']], $this->subject->output($tree));
+    }
+
     public function modelTreeDataProvider()
     {
         return [
             ['definitions/post.bp', 'database/factories/PostFactory.php', 'factories/post.php'],
             ['definitions/team.bp', 'database/factories/TeamFactory.php', 'factories/team.php'],
-            ['definitions/unconventional.bp', 'database/factories/TeamFactory.php', 'factories/unconventional.php']
+            ['definitions/unconventional.bp', 'database/factories/TeamFactory.php', 'factories/unconventional.php'],
+            ['definitions/nested-components.bp', 'database/factories/Admin/UserFactory.php', 'factories/nested-components.php']
         ];
     }
 }

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -35,8 +35,8 @@ class FactoryGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/factory.stub')
+        $this->files->expects('stub')
+            ->with('factory.stub')
             ->andReturn(file_get_contents('stubs/factory.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -50,8 +50,8 @@ class FactoryGeneratorTest extends TestCase
      */
     public function output_writes_migration_for_model_tree($definition, $path, $migration)
     {
-        $this->files->expects('get')
-            ->with('stubs/factory.stub')
+        $this->files->expects('stub')
+            ->with('factory.stub')
             ->andReturn(file_get_contents('stubs/factory.stub'));
 
         $this->files->expects('put')
@@ -71,8 +71,8 @@ class FactoryGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
         $this->app['config']->set('blueprint.models_namespace', 'Models');
 
-        $this->files->expects('get')
-            ->with('stubs/factory.stub')
+        $this->files->expects('stub')
+            ->with('factory.stub')
             ->andReturn(file_get_contents('stubs/factory.stub'));
 
         $this->files->expects('put')

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -36,8 +36,8 @@ class MigrationGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/migration.stub')
+        $this->files->expects('stub')
+            ->with('migration.stub')
             ->andReturn(file_get_contents('stubs/migration.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -51,8 +51,8 @@ class MigrationGeneratorTest extends TestCase
      */
     public function output_writes_migration_for_model_tree($definition, $path, $migration)
     {
-        $this->files->expects('get')
-            ->with('stubs/migration.stub')
+        $this->files->expects('stub')
+            ->with('migration.stub')
             ->andReturn(file_get_contents('stubs/migration.stub'));
 
         $now = Carbon::now();
@@ -74,8 +74,8 @@ class MigrationGeneratorTest extends TestCase
      */
     public function output_uses_past_timestamp_for_multiple_migrations()
     {
-        $this->files->expects('get')
-            ->with('stubs/migration.stub')
+        $this->files->expects('stub')
+            ->with('migration.stub')
             ->andReturn(file_get_contents('stubs/migration.stub'));
 
         $now = Carbon::now();

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -84,6 +84,28 @@ class ModelGeneratorTest extends TestCase
         $iteration++;
     }
 
+    /**
+     * @test
+     */
+    public function output_respects_configuration()
+    {
+        $this->app['config']->set('blueprint.app_path', 'src/path');
+        $this->app['config']->set('blueprint.namespace', 'Some\\App');
+        $this->app['config']->set('blueprint.models_namespace', 'Models');
+
+        $this->files->expects('get')
+            ->with('stubs/model/class.stub')
+            ->andReturn(file_get_contents('stubs/model/class.stub'));
+
+        $this->files->expects('put')
+            ->with('src/path/Models/Comment.php', $this->fixture('models/model-configured.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/relationships.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['src/path/Models/Comment.php']], $this->subject->output($tree));
+    }
+
     public function modelTreeDataProvider()
     {
         return [
@@ -92,6 +114,7 @@ class ModelGeneratorTest extends TestCase
             ['definitions/soft-deletes.bp', 'app/Comment.php', 'models/soft-deletes.php'],
             ['definitions/relationships.bp', 'app/Comment.php', 'models/relationships.php'],
             ['definitions/unconventional.bp', 'app/Team.php', 'models/unconventional.php'],
+            ['definitions/nested-components.bp', 'app/Admin/User.php', 'models/nested-components.php'],
         ];
     }
 }

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Generators;
 
-use Tests\TestCase;
 use Blueprint\Blueprint;
 use Blueprint\Generators\ModelGenerator;
+use Tests\TestCase;
 
 class ModelGeneratorTest extends TestCase
 {
@@ -32,8 +32,8 @@ class ModelGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/model/class.stub')
+        $this->files->expects('stub')
+            ->with('model/class.stub')
             ->andReturn(file_get_contents('stubs/model/class.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -47,32 +47,27 @@ class ModelGeneratorTest extends TestCase
      */
     public function output_writes_migration_for_model_tree($definition, $path, $model)
     {
-        static $iteration = 0;
-
-        $this->files->expects('get')
-            ->with('stubs/model/class.stub')
+        $this->files->expects('stub')
+            ->with('model/class.stub')
             ->andReturn(file_get_contents('stubs/model/class.stub'));
 
-        // TODO: remove conditional expectations
-        if ($iteration === 0) {
-            $this->files->expects('get')
-                ->with('stubs/model/fillable.stub')
-                ->andReturn(file_get_contents('stubs/model/fillable.stub'));
+        $this->files->expects('stub')
+            ->with('model/fillable.stub')
+            ->andReturn(file_get_contents('stubs/model/fillable.stub'));
 
-            $this->files->expects('get')
-                ->with('stubs/model/casts.stub')
-                ->andReturn(file_get_contents('stubs/model/casts.stub'));
+        $this->files->expects('stub')
+            ->with('model/casts.stub')
+            ->andReturn(file_get_contents('stubs/model/casts.stub'));
 
-            $this->files->expects('get')
-                ->with('stubs/model/dates.stub')
+        if ($definition === 'definitions/readme-example.bp') {
+            $this->files->expects('stub')
+                ->with('model/dates.stub')
                 ->andReturn(file_get_contents('stubs/model/dates.stub'));
         }
 
-        if ($definition === 'definitions/soft-deletes.bp') {
-            $this->files->expects('get')
-                ->with('stubs/model/method.stub')
-                ->andReturn(file_get_contents('stubs/model/method.stub'));
-        }
+        $this->files->shouldReceive('stub')
+            ->with('model/method.stub')
+            ->andReturn(file_get_contents('stubs/model/method.stub'));
 
         $this->files->expects('put')
             ->with($path, $this->fixture($model));
@@ -81,7 +76,6 @@ class ModelGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
-        $iteration++;
     }
 
     /**
@@ -93,9 +87,21 @@ class ModelGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
         $this->app['config']->set('blueprint.models_namespace', 'Models');
 
-        $this->files->expects('get')
-            ->with('stubs/model/class.stub')
+        $this->files->expects('stub')
+            ->with('model/class.stub')
             ->andReturn(file_get_contents('stubs/model/class.stub'));
+
+        $this->files->expects('stub')
+            ->with('model/fillable.stub')
+            ->andReturn(file_get_contents('stubs/model/fillable.stub'));
+
+        $this->files->expects('stub')
+            ->with('model/casts.stub')
+            ->andReturn(file_get_contents('stubs/model/casts.stub'));
+
+        $this->files->expects('stub')
+            ->with('model/method.stub')
+            ->andReturn(file_get_contents('stubs/model/method.stub'));
 
         $this->files->expects('put')
             ->with('src/path/Models/Comment.php', $this->fixture('models/model-configured.php'));

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature\Generators;
 
-use Tests\TestCase;
 use Blueprint\Blueprint;
-use Blueprint\Lexers\StatementLexer;
 use Blueprint\Generators\RouteGenerator;
+use Blueprint\Lexers\StatementLexer;
+use Tests\TestCase;
 
 /**
  * @see RouteGenerator

--- a/tests/Feature/Generator/Statements/EventGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/EventGeneratorTest.php
@@ -120,4 +120,37 @@ class EventGeneratorTest extends TestCase
 
         $this->assertEquals([], $this->subject->output($tree));
     }
+
+    /**
+     * @test
+     */
+    public function it_respects_configuration()
+    {
+        $this->app['config']->set('blueprint.namespace', 'Some\\App');
+        $this->app['config']->set('blueprint.app_path', 'src/path');
+
+        $this->files->expects('get')
+            ->with('stubs/event.stub')
+            ->andReturn(file_get_contents('stubs/event.stub'));
+
+        $this->files->expects('get')
+            ->with('stubs/partials/constructor.stub')
+            ->andReturn(file_get_contents('stubs/partials/constructor.stub'));
+
+        $this->files->expects('exists')
+            ->with('src/path/Events')
+            ->andReturnFalse();
+        $this->files->expects('makeDirectory')
+            ->with('src/path/Events');
+        $this->files->expects('exists')
+            ->with('src/path/Events/NewPost.php')
+            ->andReturnFalse();
+        $this->files->expects('put')
+            ->with('src/path/Events/NewPost.php', $this->fixture('events/event-configured.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/readme-example.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['src/path/Events/NewPost.php']], $this->subject->output($tree));
+    }
 }

--- a/tests/Feature/Generator/Statements/EventGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/EventGeneratorTest.php
@@ -36,8 +36,8 @@ class EventGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/event.stub')
+        $this->files->expects('stub')
+            ->with('event.stub')
             ->andReturn(file_get_contents('stubs/event.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -50,8 +50,8 @@ class EventGeneratorTest extends TestCase
      */
     public function output_writes_nothing_tree_without_validate_statements()
     {
-        $this->files->expects('get')
-            ->with('stubs/event.stub')
+        $this->files->expects('stub')
+            ->with('event.stub')
             ->andReturn(file_get_contents('stubs/event.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -67,12 +67,12 @@ class EventGeneratorTest extends TestCase
      */
     public function output_writes_events()
     {
-        $this->files->expects('get')
-            ->with('stubs/event.stub')
+        $this->files->expects('stub')
+            ->with('event.stub')
             ->andReturn(file_get_contents('stubs/event.stub'));
 
-        $this->files->expects('get')
-            ->with('stubs/partials/constructor.stub')
+        $this->files->expects('stub')
+            ->with('partials/constructor.stub')
             ->andReturn(file_get_contents('stubs/partials/constructor.stub'));
 
         $this->files->shouldReceive('exists')
@@ -104,8 +104,8 @@ class EventGeneratorTest extends TestCase
      */
     public function it_only_outputs_new_events()
     {
-        $this->files->expects('get')
-            ->with('stubs/event.stub')
+        $this->files->expects('stub')
+            ->with('event.stub')
             ->andReturn(file_get_contents('stubs/event.stub'));
 
         $this->files->expects('exists')
@@ -129,13 +129,9 @@ class EventGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
         $this->app['config']->set('blueprint.app_path', 'src/path');
 
-        $this->files->expects('get')
-            ->with('stubs/event.stub')
+        $this->files->expects('stub')
+            ->with('event.stub')
             ->andReturn(file_get_contents('stubs/event.stub'));
-
-        $this->files->expects('get')
-            ->with('stubs/partials/constructor.stub')
-            ->andReturn(file_get_contents('stubs/partials/constructor.stub'));
 
         $this->files->expects('exists')
             ->with('src/path/Events')

--- a/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
@@ -126,4 +126,59 @@ class FormRequestGeneratorTest extends TestCase
 
         $this->assertEquals([], $this->subject->output($tree));
     }
+
+    /**
+     * @test
+     */
+    public function output_supports_nested_form_requests()
+    {
+        $this->files->expects('get')
+            ->with('stubs/form-request.stub')
+            ->andReturn(file_get_contents('stubs/form-request.stub'));
+
+        $this->files->expects('exists')
+            ->with('app/Http/Requests/Admin')
+            ->andReturnFalse();
+        $this->files->expects('exists')
+            ->with('app/Http/Requests/Admin/UserStoreRequest.php')
+            ->andReturnFalse();
+        $this->files->expects('makeDirectory')
+            ->with('app/Http/Requests/Admin');
+        $this->files->expects('put')
+            ->with('app/Http/Requests/Admin/UserStoreRequest.php', $this->fixture('form-requests/nested-components.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/nested-components.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['app/Http/Requests/Admin/UserStoreRequest.php']], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     */
+    public function it_respects_configuration()
+    {
+        $this->app['config']->set('blueprint.namespace', 'Some\\App');
+        $this->app['config']->set('blueprint.app_path', 'src/path');
+
+        $this->files->expects('get')
+            ->with('stubs/form-request.stub')
+            ->andReturn(file_get_contents('stubs/form-request.stub'));
+
+        $this->files->expects('exists')
+            ->with('src/path/Http/Requests')
+            ->andReturns(false);
+        $this->files->expects('exists')
+            ->with('src/path/Http/Requests/PostStoreRequest.php')
+            ->andReturnFalse();
+        $this->files->expects('makeDirectory')
+            ->with('src/path/Http/Requests');
+        $this->files->expects('put')
+            ->with('src/path/Http/Requests/PostStoreRequest.php', $this->fixture('form-requests/form-request-configured.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/readme-example.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['src/path/Http/Requests/PostStoreRequest.php']], $this->subject->output($tree));
+    }
 }

--- a/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
@@ -37,8 +37,8 @@ class FormRequestGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/form-request.stub')
+        $this->files->expects('stub')
+            ->with('form-request.stub')
             ->andReturn(file_get_contents('stubs/form-request.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -51,8 +51,8 @@ class FormRequestGeneratorTest extends TestCase
      */
     public function output_writes_nothing_without_validate_statements()
     {
-        $this->files->expects('get')
-            ->with('stubs/form-request.stub')
+        $this->files->expects('stub')
+            ->with('form-request.stub')
             ->andReturn(file_get_contents('stubs/form-request.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -68,8 +68,8 @@ class FormRequestGeneratorTest extends TestCase
      */
     public function output_writes_form_requests()
     {
-        $this->files->expects('get')
-            ->with('stubs/form-request.stub')
+        $this->files->expects('stub')
+            ->with('form-request.stub')
             ->andReturn(file_get_contents('stubs/form-request.stub'));
 
         $this->files->shouldReceive('exists')
@@ -107,8 +107,8 @@ class FormRequestGeneratorTest extends TestCase
      */
     public function it_only_outputs_new_form_requests()
     {
-        $this->files->expects('get')
-            ->with('stubs/form-request.stub')
+        $this->files->expects('stub')
+            ->with('form-request.stub')
             ->andReturn(file_get_contents('stubs/form-request.stub'));
 
         $this->files->expects('exists')
@@ -132,8 +132,8 @@ class FormRequestGeneratorTest extends TestCase
      */
     public function output_supports_nested_form_requests()
     {
-        $this->files->expects('get')
-            ->with('stubs/form-request.stub')
+        $this->files->expects('stub')
+            ->with('form-request.stub')
             ->andReturn(file_get_contents('stubs/form-request.stub'));
 
         $this->files->expects('exists')
@@ -161,8 +161,8 @@ class FormRequestGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
         $this->app['config']->set('blueprint.app_path', 'src/path');
 
-        $this->files->expects('get')
-            ->with('stubs/form-request.stub')
+        $this->files->expects('stub')
+            ->with('form-request.stub')
             ->andReturn(file_get_contents('stubs/form-request.stub'));
 
         $this->files->expects('exists')

--- a/tests/Feature/Generator/Statements/JobGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/JobGeneratorTest.php
@@ -120,4 +120,38 @@ class JobGeneratorTest extends TestCase
 
         $this->assertEquals([], $this->subject->output($tree));
     }
+
+    /**
+     * @test
+     */
+    public function it_respects_configuration()
+    {
+        $this->app['config']->set('blueprint.namespace', 'Some\\App');
+        $this->app['config']->set('blueprint.app_path', 'src/path');
+
+        $this->files->expects('get')
+            ->with('stubs/job.stub')
+            ->andReturn(file_get_contents('stubs/job.stub'));
+
+        $this->files->expects('get')
+            ->with('stubs/partials/constructor.stub')
+            ->andReturn(file_get_contents('stubs/partials/constructor.stub'));
+
+        $this->files->shouldReceive('exists')
+            ->twice()
+            ->with('src/path/Jobs')
+            ->andReturnFalse();
+        $this->files->expects('exists')
+            ->with('src/path/Jobs/SyncMedia.php')
+            ->andReturnFalse();
+        $this->files->expects('makeDirectory')
+            ->with('src/path/Jobs');
+        $this->files->expects('put')
+            ->with('src/path/Jobs/SyncMedia.php', $this->fixture('jobs/job-configured.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/readme-example.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['src/path/Jobs/SyncMedia.php']], $this->subject->output($tree));
+    }
 }

--- a/tests/Feature/Generator/Statements/JobGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/JobGeneratorTest.php
@@ -36,8 +36,8 @@ class JobGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/job.stub')
+        $this->files->expects('stub')
+            ->with('job.stub')
             ->andReturn(file_get_contents('stubs/job.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -50,8 +50,8 @@ class JobGeneratorTest extends TestCase
      */
     public function output_writes_nothing_tree_without_validate_statements()
     {
-        $this->files->expects('get')
-            ->with('stubs/job.stub')
+        $this->files->expects('stub')
+            ->with('job.stub')
             ->andReturn(file_get_contents('stubs/job.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -67,12 +67,12 @@ class JobGeneratorTest extends TestCase
      */
     public function output_writes_jobs()
     {
-        $this->files->expects('get')
-            ->with('stubs/job.stub')
+        $this->files->expects('stub')
+            ->with('job.stub')
             ->andReturn(file_get_contents('stubs/job.stub'));
 
-        $this->files->expects('get')
-            ->with('stubs/partials/constructor.stub')
+        $this->files->expects('stub')
+            ->with('partials/constructor.stub')
             ->andReturn(file_get_contents('stubs/partials/constructor.stub'));
 
         $this->files->shouldReceive('exists')
@@ -104,8 +104,8 @@ class JobGeneratorTest extends TestCase
      */
     public function it_only_outputs_new_jobs()
     {
-        $this->files->expects('get')
-            ->with('stubs/job.stub')
+        $this->files->expects('stub')
+            ->with('job.stub')
             ->andReturn(file_get_contents('stubs/job.stub'));
 
         $this->files->expects('exists')
@@ -129,16 +129,11 @@ class JobGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
         $this->app['config']->set('blueprint.app_path', 'src/path');
 
-        $this->files->expects('get')
-            ->with('stubs/job.stub')
+        $this->files->expects('stub')
+            ->with('job.stub')
             ->andReturn(file_get_contents('stubs/job.stub'));
 
-        $this->files->expects('get')
-            ->with('stubs/partials/constructor.stub')
-            ->andReturn(file_get_contents('stubs/partials/constructor.stub'));
-
-        $this->files->shouldReceive('exists')
-            ->twice()
+        $this->files->expects('exists')
             ->with('src/path/Jobs')
             ->andReturnFalse();
         $this->files->expects('exists')

--- a/tests/Feature/Generator/Statements/MailGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/MailGeneratorTest.php
@@ -36,8 +36,8 @@ class MailGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/mail.stub')
+        $this->files->expects('stub')
+            ->with('mail.stub')
             ->andReturn(file_get_contents('stubs/mail.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -50,8 +50,8 @@ class MailGeneratorTest extends TestCase
      */
     public function output_writes_nothing_tree_without_validate_statements()
     {
-        $this->files->expects('get')
-            ->with('stubs/mail.stub')
+        $this->files->expects('stub')
+            ->with('mail.stub')
             ->andReturn(file_get_contents('stubs/mail.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -67,12 +67,12 @@ class MailGeneratorTest extends TestCase
      */
     public function output_writes_mails()
     {
-        $this->files->expects('get')
-            ->with('stubs/mail.stub')
+        $this->files->expects('stub')
+            ->with('mail.stub')
             ->andReturn(file_get_contents('stubs/mail.stub'));
 
-        $this->files->expects('get')
-            ->with('stubs/partials/constructor.stub')
+        $this->files->expects('stub')
+            ->with('partials/constructor.stub')
             ->andReturn(file_get_contents('stubs/partials/constructor.stub'));
 
         $this->files->shouldReceive('exists')
@@ -104,8 +104,8 @@ class MailGeneratorTest extends TestCase
      */
     public function it_only_outputs_new_mails()
     {
-        $this->files->expects('get')
-            ->with('stubs/mail.stub')
+        $this->files->expects('stub')
+            ->with('mail.stub')
             ->andReturn(file_get_contents('stubs/mail.stub'));
 
         $this->files->expects('exists')
@@ -129,16 +129,11 @@ class MailGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
         $this->app['config']->set('blueprint.app_path', 'src/path');
 
-        $this->files->expects('get')
-            ->with('stubs/mail.stub')
+        $this->files->expects('stub')
+            ->with('mail.stub')
             ->andReturn(file_get_contents('stubs/mail.stub'));
 
-        $this->files->expects('get')
-            ->with('stubs/partials/constructor.stub')
-            ->andReturn(file_get_contents('stubs/partials/constructor.stub'));
-
-        $this->files->shouldReceive('exists')
-            ->twice()
+        $this->files->expects('exists')
             ->with('src/path/Mail')
             ->andReturnFalse();
         $this->files->expects('exists')

--- a/tests/Feature/Generator/Statements/ViewGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ViewGeneratorTest.php
@@ -36,8 +36,8 @@ class ViewGeneratorTest extends TestCase
      */
     public function output_writes_nothing_for_empty_tree()
     {
-        $this->files->expects('get')
-            ->with('stubs/view.stub')
+        $this->files->expects('stub')
+            ->with('view.stub')
             ->andReturn(file_get_contents('stubs/view.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -50,8 +50,8 @@ class ViewGeneratorTest extends TestCase
      */
     public function output_writes_nothing_without_render_statements()
     {
-        $this->files->expects('get')
-            ->with('stubs/view.stub')
+        $this->files->expects('stub')
+            ->with('view.stub')
             ->andReturn(file_get_contents('stubs/view.stub'));
 
         $this->files->shouldNotHaveReceived('put');
@@ -68,8 +68,8 @@ class ViewGeneratorTest extends TestCase
     public function output_writes_views_for_render_statements()
     {
         $template = file_get_contents('stubs/view.stub');
-        $this->files->expects('get')
-            ->with('stubs/view.stub')
+        $this->files->expects('stub')
+            ->with('view.stub')
             ->andReturn($template);
 
         $this->files->shouldReceive('exists')
@@ -111,8 +111,8 @@ class ViewGeneratorTest extends TestCase
      */
     public function it_only_outputs_new_views()
     {
-        $this->files->expects('get')
-            ->with('stubs/view.stub')
+        $this->files->expects('stub')
+            ->with('view.stub')
             ->andReturn(file_get_contents('stubs/view.stub'));
 
         $this->files->expects('exists')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,15 @@
 
 namespace Tests;
 
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-
-class TestCase extends \PHPUnit\Framework\TestCase
+class TestCase extends \Orchestra\Testbench\TestCase
 {
-    use MockeryPHPUnitIntegration;
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('blueprint.namespace', 'App');
+        $app['config']->set('blueprint.controllers_namespace', 'Http\\Controllers');
+        $app['config']->set('blueprint.models_namespace', '');
+        $app['config']->set('blueprint.app_path', 'app');
+    }
 
     public function fixture(string $path)
     {

--- a/tests/Unit/Models/Statements/EloquentStatementTest.php
+++ b/tests/Unit/Models/Statements/EloquentStatementTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature\Generators;
 
 use Blueprint\Models\Statements\EloquentStatement;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @see EloquentStatement

--- a/tests/Unit/Models/Statements/QueryStatementTest.php
+++ b/tests/Unit/Models/Statements/QueryStatementTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature\Generators;
 
 use Blueprint\Models\Statements\QueryStatement;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @see QueryStatement

--- a/tests/fixtures/controllers/controller-configured.php
+++ b/tests/fixtures/controllers/controller-configured.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Some\App\Other\Http;
+
+use Illuminate\Http\Request;
+use Some\App\Http\Requests\UserStoreRequest;
+use Some\App\User;
+
+class UserController extends Controller
+{
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $users = User::all();
+
+        return view('user.index', compact('users'));
+    }
+
+    /**
+     * @param \Some\App\Http\Requests\UserStoreRequest $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(UserStoreRequest $request)
+    {
+        $user = User::create($request->all());
+
+        $request->session()->flash('user.name', $user->name);
+
+        return redirect()->route('post.index');
+    }
+}

--- a/tests/fixtures/controllers/nested-components.php
+++ b/tests/fixtures/controllers/nested-components.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Admin\User;
+use App\Events\NewUser;
+use App\Http\Requests\Admin\UserStoreRequest;
+use App\Jobs\BuildAccount;
+use App\Mail\InviteNotification;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+
+class UserController extends Controller
+{
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $users = User::all();
+
+        return view('admin.user.index', compact('users'));
+    }
+
+    /**
+     * @param \App\Http\Requests\Admin\UserStoreRequest $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(UserStoreRequest $request)
+    {
+        $user = User::create($request->all());
+
+        Mail::to($user->name)->send(new InviteNotification($user));
+
+        BuildAccount::dispatch($user);
+
+        event(new NewUser($user));
+
+        $request->session()->flash('user.name', $user->name);
+
+        return redirect()->route('admin.user.index');
+    }
+}

--- a/tests/fixtures/definitions/nested-components.bp
+++ b/tests/fixtures/definitions/nested-components.bp
@@ -1,0 +1,18 @@
+models:
+  Admin/User:
+    name: string
+
+controllers:
+  Admin/User:
+    index:
+      query: all:users
+      render: admin.user.index with:users
+
+    store:
+      validate: name
+      save: user
+      send: InviteNotification to:user.name with:user
+      dispatch: BuildAccount with:user
+      fire: NewUser with:user
+      flash: user.name
+      redirect: admin.user.index

--- a/tests/fixtures/definitions/simple-controller.bp
+++ b/tests/fixtures/definitions/simple-controller.bp
@@ -1,0 +1,11 @@
+controllers:
+  User:
+    index:
+      query: all:users
+      render: user.index with:users
+
+    store:
+      validate: name
+      save: user
+      flash: user.name
+      redirect: post.index

--- a/tests/fixtures/events/event-configured.php
+++ b/tests/fixtures/events/event-configured.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Some\App\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class NewPost
+{
+    use SerializesModels;
+
+    public $post;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct($post)
+    {
+        $this->post = $post;
+    }
+}

--- a/tests/fixtures/factories/nested-components.php
+++ b/tests/fixtures/factories/nested-components.php
@@ -2,11 +2,11 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-use DummyModel;
+use App\Admin\User;
 use Faker\Generator as Faker;
 
-$factory->define(DummyClass::class, function (Faker $faker) {
+$factory->define(User::class, function (Faker $faker) {
     return [
-        // definition...
+        'name' => $faker->name,
     ];
 });

--- a/tests/fixtures/factories/post-configured.php
+++ b/tests/fixtures/factories/post-configured.php
@@ -1,0 +1,16 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Some\App\Models\Post;
+use Faker\Generator as Faker;
+
+$factory->define(Post::class, function (Faker $faker) {
+    return [
+        'title' => $faker->sentence(4),
+        'author_id' => factory(\Some\App\Models\Author::class),
+        'content' => $faker->paragraphs(3, true),
+        'published_at' => $faker->dateTime(),
+        'word_count' => $faker->randomNumber(),
+    ];
+});

--- a/tests/fixtures/form-requests/form-request-configured.php
+++ b/tests/fixtures/form-requests/form-request-configured.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Some\App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|string|max:400',
+            'content' => 'required|string',
+        ];
+    }
+}

--- a/tests/fixtures/form-requests/nested-components.php
+++ b/tests/fixtures/form-requests/nested-components.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|string',
+        ];
+    }
+}

--- a/tests/fixtures/jobs/job-configured.php
+++ b/tests/fixtures/jobs/job-configured.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Some\App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SyncMedia implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $post;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($post)
+    {
+        $this->post = $post;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/tests/fixtures/mailables/mail-configured.php
+++ b/tests/fixtures/mailables/mail-configured.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Some\App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class ReviewNotification extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $post;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($post)
+    {
+        $this->post = $post;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('view.name');
+    }
+}

--- a/tests/fixtures/models/model-configured.php
+++ b/tests/fixtures/models/model-configured.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Some\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'post_id',
+        'author_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'post_id' => 'integer',
+        'author_id' => 'integer',
+    ];
+
+
+    public function post()
+    {
+        return $this->belongsTo(\Some\App\Models\Post::class);
+    }
+
+    public function author()
+    {
+        return $this->belongsTo(\Some\App\Models\User::class);
+    }
+}

--- a/tests/fixtures/models/nested-components.php
+++ b/tests/fixtures/models/nested-components.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+}


### PR DESCRIPTION
This adds the ability to use nested components names to generate classes within sub-folders.

**Example**
```yaml
models:
    Admin/User:
        # ...

controllers:
     Admin/UserController:
        # ...
```

This can be combined or set globally using the new `blueprint.php` configuration file which allows you to customize the `App`, _Controllers_, and _Models_ namespaces, as well as override the app path.

By default, Blueprint will continue to follow Laravel conventions. However, this adds some configuration for those who follow common conventions for larger projects.

------

Closes #37