### PR TITLE
ENUM and SET datatypes for FactoryGenerator

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -80,8 +80,8 @@ class FactoryGenerator implements Generator
                 $definition .= '$faker->' . $faker;
                 $definition .= ',' . PHP_EOL;
 
-                if ($column->dataType() === 'enum' and !empty($column->attributes())) {
-                    $definition = str_replace("/** attributes **/", json_encode($column->attributes()), $definition);
+                if (in_array($column->dataType(), ['enum', 'set']) and !empty($column->attributes())) {
+                    $definition = str_replace("/** {$column->dataType()}_attributes **/", json_encode($column->attributes()), $definition);
                 }
             }
         }
@@ -148,7 +148,8 @@ class FactoryGenerator implements Generator
             'float' => 'randomFloat()',
             'longtext' => 'text',
             'boolean' => 'boolean',
-            'enum' => 'randomElement(/** attributes **/)',
+            'set' => 'randomElement(/** set_attributes **/)',
+            'enum' => 'randomElement(/** enum_attributes **/)',
         ];
 
         return $fakeableTypes[$type] ?? null;

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -79,6 +79,10 @@ class FactoryGenerator implements Generator
                 $faker = $this->fakerData($column->name()) ?? $this->fakerDataType($column->dataType());
                 $definition .= '$faker->' . $faker;
                 $definition .= ',' . PHP_EOL;
+
+                if ($column->dataType() === 'enum' and !empty($column->attributes())) {
+                    $definition = str_replace("/** attributes **/", json_encode($column->attributes()), $definition);
+                }
             }
         }
 
@@ -143,7 +147,8 @@ class FactoryGenerator implements Generator
             'decimal' => 'randomFloat()',
             'float' => 'randomFloat()',
             'longtext' => 'text',
-            'boolean' => 'boolean'
+            'boolean' => 'boolean',
+            'enum' => 'randomElement(/** attributes **/)',
         ];
 
         return $fakeableTypes[$type] ?? null;

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -87,6 +87,7 @@ class FactoryGeneratorTest extends TestCase
     public function modelTreeDataProvider()
     {
         return [
+            ['definitions/phone.bp', 'database/factories/PhoneFactory.php', 'factories/phone.php'],
             ['definitions/post.bp', 'database/factories/PostFactory.php', 'factories/post.php'],
             ['definitions/team.bp', 'database/factories/TeamFactory.php', 'factories/team.php'],
             ['definitions/unconventional.bp', 'database/factories/TeamFactory.php', 'factories/unconventional.php'],

--- a/tests/fixtures/definitions/phone.bp
+++ b/tests/fixtures/definitions/phone.bp
@@ -1,0 +1,6 @@
+models:
+  Phone:
+    label: string
+    user_id: id
+    phone_number: text
+    type: enum:home,cell

--- a/tests/fixtures/definitions/phone.bp
+++ b/tests/fixtures/definitions/phone.bp
@@ -4,3 +4,4 @@ models:
     user_id: id
     phone_number: text
     type: enum:home,cell
+    status: set:archived,deleted

--- a/tests/fixtures/factories/phone.php
+++ b/tests/fixtures/factories/phone.php
@@ -10,6 +10,7 @@ $factory->define(Phone::class, function (Faker $faker) {
         'label' => $faker->word,
         'user_id' => factory(\App\User::class),
         'phone_number' => $faker->phoneNumber,
-        'type' => $faker->randomElement(["home", "cell"]),
+        'type' => $faker->randomElement(["home","cell"]),
+        'status' => $faker->randomElement(["archived","deleted"]),
     ];
 });

--- a/tests/fixtures/factories/phone.php
+++ b/tests/fixtures/factories/phone.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Phone;
+use Faker\Generator as Faker;
+
+$factory->define(Phone::class, function (Faker $faker) {
+    return [
+        'label' => $faker->word,
+        'user_id' => factory(\App\User::class),
+        'phone_number' => $faker->phoneNumber,
+        'type' => $faker->randomElement(["home", "cell"]),
+    ];
+});


### PR DESCRIPTION
fixes #59 
> ```
> models:
>   Category:
>     category_uuid: string:200
>     name: string:200
>     status: enum:ACTIVE,NONACTIVE
> ```
> 
> ...factory file is fail
> 
> ```
> <?php
> 
> /** @var \Illuminate\Database\Eloquent\Factory $factory */
> 
> use App\Category;
> use Faker\Generator as Faker;
> 
> $factory->define(Category::class, function (Faker $faker) {
>     return [
>         'category_uuid' => $faker->word,
>         'name' => $faker->name,
>         'status' => $faker->,
>     ];
> });
> ```
> [Issue #59](https://github.com/laravel-shift/blueprint/issues/59#issue-556787160)