### PR TITLE
New command to load existing models for reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "symfony/yaml": "^4.3|^5.0",
         "illuminate/console": "^6.0|^7.0",
         "illuminate/filesystem": "^6.0|^7.0",
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/support": "^6.0|^7.0",
+        "doctrine/dbal": "^2.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,258 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f061a59b4bc457342bdc109b2f52e86e",
+    "content-hash": "df2794a23b30b27f1a225782d0c3626b",
     "packages": [
+        {
+            "name": "doctrine/cache",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/382e7f4db9a12dc6c19431743a2b096041bcdd62",
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^6.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "time": "2019-11-29T15:36:20+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8",
+                "reference": "c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "ext-pdo": "*",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "jetbrains/phpstorm-stubs": "^2019.1",
+                "phpstan/phpstan": "^0.11.3",
+                "phpunit/phpunit": "^8.4.1",
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev",
+                    "dev-develop": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlanywhere",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "time": "2020-01-04T12:56:21+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "629572819973f13486371cb611386eb17851e85c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/629572819973f13486371cb611386eb17851e85c",
+                "reference": "629572819973f13486371cb611386eb17851e85c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "time": "2019-11-10T09:48:07+00:00"
+        },
         {
             "name": "doctrine/inflector",
             "version": "1.3.1",

--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace Blueprint;
 
+use Blueprint\Commands\BlueprintCommand;
+use Blueprint\Commands\EraseCommand;
+use Blueprint\Commands\TraceCommand;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
@@ -20,7 +23,7 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
         }
 
         $this->publishes([
-            __DIR__.'/../config/blueprint.php' => config_path('blueprint.php'),
+            __DIR__ . '/../config/blueprint.php' => config_path('blueprint.php'),
         ]);
     }
 
@@ -32,7 +35,7 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/blueprint.php', 'blueprint'
+            __DIR__ . '/../config/blueprint.php', 'blueprint'
         );
 
         File::mixin(new FileMixins());
@@ -42,10 +45,14 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
                 return new BlueprintCommand($app['files']);
             }
         );
-
         $this->app->bind('command.blueprint.erase',
             function ($app) {
                 return new EraseCommand($app['files']);
+            }
+        );
+        $this->app->bind('command.blueprint.trace',
+            function ($app) {
+                return new TraceCommand($app['files']);
             }
         );
 
@@ -74,6 +81,7 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
         $this->commands([
             'command.blueprint.build',
             'command.blueprint.erase',
+            'command.blueprint.trace',
         ]);
     }
 
@@ -87,6 +95,7 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
         return [
             'command.blueprint.build',
             'command.blueprint.erase',
+            'command.blueprint.trace',
             Blueprint::class,
         ];
     }

--- a/src/Commands/BlueprintCommand.php
+++ b/src/Commands/BlueprintCommand.php
@@ -1,10 +1,12 @@
 <?php
 
-namespace Blueprint;
+namespace Blueprint\Commands;
 
-use Illuminate\Support\Str;
+use Blueprint\Blueprint;
+use Blueprint\Builder;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 
 class BlueprintCommand extends Command
@@ -49,9 +51,8 @@ class BlueprintCommand extends Command
             $this->error('Draft file could not be found: ' . $file);
         }
 
-        $contents = $this->files->get($file);
         $blueprint = resolve(Blueprint::class);
-        $generated = Builder::execute($blueprint, $contents);
+        $generated = Builder::execute($blueprint, $this->files, $file);
 
         collect($generated)->each(function ($files, $action) {
             $this->line(Str::studly($action) . ':', $this->outputStyle($action));
@@ -61,11 +62,6 @@ class BlueprintCommand extends Command
 
             $this->line('');
         });
-
-        $this->files->put(
-            '.blueprint',
-            $blueprint->dump($generated)
-        );
     }
 
     /**

--- a/src/Commands/EraseCommand.php
+++ b/src/Commands/EraseCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Blueprint;
+namespace Blueprint\Commands;
 
-use Illuminate\Support\Str;
+use Blueprint\Blueprint;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace Blueprint\Commands;
+
+use Blueprint\Blueprint;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class TraceCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'blueprint:trace';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create definitions for existing models to reference in new drafts';
+
+    /** @var Filesystem $files */
+    protected $files;
+
+    /**
+     * @param Filesystem $files
+     * @param \Illuminate\Contracts\View\Factory $view
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $definitions = [];
+        foreach ($this->appClasses() as $class) {
+            $model = $this->loadModel($class);
+            if (is_null($model)) {
+                continue;
+            }
+
+            $definitions[$this->relativeClassName($model)] = $this->translateColumns($this->mapColumns($this->extractColumns($model)));
+        }
+
+        if (empty($definitions)) {
+            $this->error('No models found');
+
+            return;
+        }
+
+        $blueprint = new Blueprint();
+
+        $cache = [];
+        if ($this->files->exists('.blueprint')) {
+            $cache = $blueprint->parse($this->files->get('.blueprint'));
+        }
+
+        $cache['models'] = $definitions;
+
+        $this->files->put(
+            '.blueprint',
+            $blueprint->dump($cache)
+        );
+
+        $this->info('Traced ' . count($definitions) . ' ' . Str::plural('model', count($definitions)));
+    }
+
+    private function appClasses()
+    {
+        $dir = config('blueprint.app_path');
+
+        if (config('blueprint.models_namespace')) {
+            $dir .= DIRECTORY_SEPARATOR . str_replace('\\', '/', config('blueprint.models_namespace'));
+        }
+
+        if (!$this->files->exists($dir)) {
+            return [];
+        }
+
+        return array_map(function (\SplFIleInfo $file) {
+            return str_replace(
+                [config('blueprint.app_path') . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR],
+                [config('blueprint.namespace') . '\\', '\\'],
+                $file->getPath() . DIRECTORY_SEPARATOR . $file->getBasename('.php')
+            );
+        }, $this->files->allFiles($dir));
+    }
+
+    private function loadModel(string $class)
+    {
+        if (!class_exists($class)) {
+            return null;
+        }
+
+        $reflectionClass = new \ReflectionClass($class);
+        if (!$reflectionClass->isSubclassOf(\Illuminate\Database\Eloquent\Model::class)) {
+            return null;
+        }
+
+        return $this->laravel->make($class);
+    }
+
+    private function extractColumns(Model $model)
+    {
+        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
+        $schema = $model->getConnection()->getDoctrineSchemaManager();
+
+        $database = null;
+        if (strpos($table, '.')) {
+            list($database, $table) = explode('.', $table);
+        }
+
+        $columns = $schema->listTableColumns($table, $database);
+
+        return $columns;
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Column[] $columns
+     */
+    private function mapColumns($columns)
+    {
+        return collect($columns)
+            ->map([self::class, 'columns'])
+            ->toArray();
+    }
+
+    public static function columns(\Doctrine\DBAL\Schema\Column $column, string $key)
+    {
+        $attributes = [];
+
+        $type = self::translations($column->getType()->getName());
+
+        if (in_array($type, ['decimal', 'float'])) {
+            if ($column->getPrecision()) {
+                $type .= ':' . $column->getPrecision();
+            }
+            if ($column->getScale()) {
+                $type .= ',' . $column->getScale();
+            }
+        } elseif ($type === 'string' && $column->getLength()) {
+            if ($column->getLength() !== 255) {
+                $type .= ':' . $column->getLength();
+            }
+        } elseif ($type === 'text') {
+            if ($column->getLength() > 65535) {
+                $type = 'longtext';
+            }
+        }
+
+        // TODO: enums, guid/uuid
+
+        $attributes[] = $type;
+
+        if ($column->getUnsigned()) {
+            $attributes[] = 'unsigned';
+        }
+
+        if (!$column->getNotnull()) {
+            $attributes[] = 'nullable';
+        }
+
+        if ($column->getAutoincrement()) {
+            $attributes[] = 'autoincrement';
+        }
+
+        if (!is_null($column->getDefault())) {
+            $attributes[] = 'default:' . $column->getDefault();
+        }
+
+        return implode(' ', $attributes);
+    }
+
+    private static function translations(string $type)
+    {
+        static $mappings = [
+            'array' => 'string',
+            'bigint' => 'biginteger',
+            'binary' => 'binary',
+            'blob' => 'binary',
+            'boolean' => 'boolean',
+            'date' => 'date',
+            'date_immutable' => 'date',
+            'dateinterval' => 'date',
+            'datetime' => 'datetime',
+            'datetime_immutable' => 'datetime',
+            'datetimetz' => 'datetimetz',
+            'datetimetz_immutable' => 'datetimetz',
+            'decimal' => 'decimal',
+            'float' => 'float',
+            'guid' => 'string',
+            'integer' => 'integer',
+            'json' => 'json',
+            'object' => 'string',
+            'simple_array' => 'string',
+            'smallint' => 'smallinteger',
+            'string' => 'string',
+            'text' => 'text',
+            'time' => 'time',
+            'time_immutable' => 'time',
+        ];
+
+        return $mappings[$type] ?? 'string';
+    }
+
+    private function translateColumns(array $columns)
+    {
+        if (isset($columns['id']) && strpos($columns['id'], 'autoincrement') !== false && strpos($columns['id'], 'integer') !== false) {
+            unset($columns['id']);
+        }
+
+        if (isset($columns[Model::CREATED_AT]) && isset($columns[Model::UPDATED_AT])) {
+            if (strpos($columns[Model::CREATED_AT], 'datetimetz') !== false) {
+                $columns['timestampstz'] = 'timestampsTz';
+            }
+
+            unset($columns[Model::CREATED_AT]);
+            unset($columns[Model::UPDATED_AT]);
+        }
+
+        if (isset($columns['deleted_at'])) {
+            if (strpos($columns['deleted_at'], 'datetimetz') !== false) {
+                $columns['softdeletestz'] = 'softDeletesTz';
+            }
+
+            unset($columns['deleted_at']);
+        }
+
+        return $columns;
+    }
+
+    private function relativeClassName($model)
+    {
+        $name = Blueprint::relativeNamespace(get_class($model));
+        if (config('blueprint.models_namespace')) {
+            return $name;
+        }
+
+        return ltrim(str_replace(config('blueprint.models_namespace'), '', $name), '\\');
+    }
+}

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -30,7 +30,7 @@ class FormRequestGenerator implements Generator
 
         $stub = $this->files->stub('form-request.stub');
 
-        $this->registerModels($tree['models'] ?? []);
+        $this->registerModels($tree);
 
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {
@@ -140,8 +140,8 @@ class FormRequestGenerator implements Generator
         return 'required';
     }
 
-    private function registerModels(array $models)
+    private function registerModels(array $tree)
     {
-        $this->models = $models;
+        $this->models = array_merge($tree['cache'] ?? [], $tree['models'] ?? []);
     }
 }

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -44,7 +44,7 @@ class TestGenerator implements Generator
 
         $stub = $this->files->get(STUBS_PATH . '/test/class.stub');
 
-        $this->registerModels($tree['models'] ?? []);
+        $this->registerModels($tree);
 
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {
@@ -525,9 +525,9 @@ END;
         return null;
     }
 
-    private function registerModels(array $models)
+    private function registerModels(array $tree)
     {
-        $this->models = $models;
+        $this->models = array_merge($tree['cache'] ?? [], $tree['models'] ?? []);
     }
 
     private function splitField($field)

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -91,16 +91,22 @@ class ModelLexer implements Lexer
     public function analyze(array $tokens): array
     {
         $registry = [
-            'models' => []
+            'models' => [],
+            'cache' => []
         ];
 
-        if (empty($tokens['models'])) {
-            return $registry;
+        if (!empty($tokens['models'])) {
+            foreach ($tokens['models'] as $name => $definition) {
+                $registry['models'][$name] = $this->buildModel($name, $definition);
+            }
         }
 
-        foreach ($tokens['models'] as $name => $definition) {
-            $registry['models'][$name] = $this->buildModel($name, $definition);
+        if (!empty($tokens['cache'])) {
+            foreach ($tokens['cache'] as $name => $definition) {
+                $registry['cache'][$name] = $this->buildModel($name, $definition);
+            }
         }
+
 
         return $registry;
     }

--- a/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
@@ -181,4 +181,37 @@ class FormRequestGeneratorTest extends TestCase
 
         $this->assertEquals(['created' => ['src/path/Http/Requests/PostStoreRequest.php']], $this->subject->output($tree));
     }
+
+
+    /**
+     * @test
+     */
+    public function output_generates_test_for_controller_tree_using_cached_model()
+    {
+        $this->files->expects('stub')
+            ->with('form-request.stub')
+            ->andReturn(file_get_contents('stubs/form-request.stub'));
+
+        $this->files->expects('exists')
+            ->with('app/Http/Requests')
+            ->andReturnFalse();
+        $this->files->expects('exists')
+            ->with('app/Http/Requests/UserStoreRequest.php')
+            ->andReturnFalse();
+        $this->files->expects('makeDirectory')
+            ->with('app/Http/Requests', 0755, true);
+        $this->files->expects('put')
+            ->with('app/Http/Requests/UserStoreRequest.php', $this->fixture('form-requests/reference-cache.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/reference-cache.bp'));
+        $tokens['cache'] = [
+            'User' => [
+                'email' => 'string',
+                'password' => 'string',
+            ]
+        ];
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['app/Http/Requests/UserStoreRequest.php']], $this->subject->output($tree));
+    }
 }

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Blueprint\Blueprint;
 use Blueprint\Builder;
+use Illuminate\Filesystem\Filesystem;
 use Tests\TestCase;
 
 class BuilderTest extends TestCase
@@ -11,28 +12,94 @@ class BuilderTest extends TestCase
     /**
      * @test
      */
-    public function execute_uses_blueprint_to_build_draft()
+    public function execute_builds_draft_content()
     {
-        $digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        shuffle($digits);
-
-        $draft = implode($digits);
-        $tokens = $digits;
-        $registry = array_rand($digits, 9);
-        $generated = array_rand($digits, 9);
+        $draft = 'draft blueprint content';
+        $tokens = ['some', 'blueprint', 'tokens'];
+        $registry = ['controllers' => [1, 2, 3]];
+        $generated = ['created' => [1, 2], 'updated' => [3]];
 
         $blueprint = \Mockery::mock(Blueprint::class);
         $blueprint->expects('parse')
             ->with($draft)
             ->andReturn($tokens);
         $blueprint->expects('analyze')
-            ->with($tokens)
+            ->with($tokens + ['cache' => []])
             ->andReturn($registry);
         $blueprint->expects('generate')
             ->with($registry)
             ->andReturn($generated);
+        $blueprint->expects('dump')
+            ->with($generated)
+            ->andReturn('cacheable blueprint content');
 
-        $actual = Builder::execute($blueprint, $draft);
+        $file = \Mockery::mock(Filesystem::class);
+        $file->expects('get')
+            ->with('draft.yaml')
+            ->andReturn($draft);
+        $file->expects('exists')
+            ->with('.blueprint')
+            ->andReturnFalse();
+        $file->expects('put')
+            ->with('.blueprint', 'cacheable blueprint content');
+
+        $actual = Builder::execute($blueprint, $file, 'draft.yaml');
+
+        $this->assertSame($generated, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function execute_uses_cache_and_remembers_models()
+    {
+        $cache = [
+            'models' => [4, 5, 6],
+            'created' => [4],
+            'unknown' => [6],
+        ];
+        $draft = 'draft blueprint content';
+        $tokens = [
+            'models' => [1, 2, 3]
+        ];
+        $registry = ['registry'];
+        $generated = ['created' => [1, 2], 'updated' => [3]];
+
+        $blueprint = \Mockery::mock(Blueprint::class);
+        $blueprint->expects('parse')
+            ->with($draft)
+            ->andReturn($tokens);
+        $blueprint->expects('parse')
+            ->with('cached blueprint content')
+            ->andReturn($cache);
+        $blueprint->expects('analyze')
+            ->with($tokens + ['cache' => $cache['models']])
+            ->andReturn($registry);
+        $blueprint->expects('generate')
+            ->with($registry)
+            ->andReturn($generated);
+        $blueprint->expects('dump')
+            ->with([
+                'created' => [1, 2],
+                'updated' => [3],
+                'models' => [4, 5, 6, 1, 2, 3]
+            ])
+            ->andReturn('cacheable blueprint content');
+
+        $file = \Mockery::mock(Filesystem::class);
+        $file->expects('get')
+            ->with('draft.yaml')
+            ->andReturn($draft);
+        $file->expects('exists')
+            ->with('.blueprint')
+            ->andReturnTrue();
+        $file->expects('get')
+            ->with('.blueprint')
+            ->andReturn('cached blueprint content');
+        $file->expects('put')
+            ->with('.blueprint', 'cacheable blueprint content');
+
+        $actual = Builder::execute($blueprint, $file, 'draft.yaml');
 
         $this->assertSame($generated, $actual);
     }

--- a/tests/fixtures/definitions/reference-cache.bp
+++ b/tests/fixtures/definitions/reference-cache.bp
@@ -1,0 +1,7 @@
+controllers:
+  UserController:
+    store:
+      validate: email, password
+      save: user
+      flash: user.email
+      redirect: dashboard

--- a/tests/fixtures/form-requests/reference-cache.php
+++ b/tests/fixtures/form-requests/reference-cache.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'required|email',
+            'password' => 'required|password',
+        ];
+    }
+}

--- a/tests/fixtures/tests/reference-cache.php
+++ b/tests/fixtures/tests/reference-cache.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use JMac\Testing\Traits\HttpTestAssertions;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\UserController
+ */
+class UserControllerTest extends TestCase
+{
+    use HttpTestAssertions, RefreshDatabase, WithFaker;
+
+    /**
+     * @test
+     */
+    public function store_uses_form_request_validation()
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\UserController::class,
+            'store',
+            \App\Http\Requests\UserControllerStoreRequest::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function store_saves_and_redirects()
+    {
+        $email = $this->faker->safeEmail;
+        $password = $this->faker->password;
+
+        $response = $this->post(route('user.store'), [
+            'email' => $email,
+            'password' => $password,
+        ]);
+
+        $users = User::query()
+            ->where('email', $email)
+            ->where('password', $password)
+            ->get();
+        $this->assertCount(1, $users);
+        $user = $users->first();
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHas('user.email', $user->email);
+    }
+}


### PR DESCRIPTION
This new `blueprint:trace` command allows developers to load existing models into Blueprint to reference when building new components. It also automatically tracks new models generated by `blueprint:build`

The combination makes Blueprint more beneficial for generating code within existing applications. It also has use cases outside of generating new code, including:

- Consolidating many migrations into a smaller set of _create_ migrations which may improve build times.
- Modernizing migration syntax to use new shorthands for cleaner code.
- Regenerating `casts`, `dates`, or `@property` code for Models

Newly definite models will also take precedence over an existing model. This way it is easy to regenerated a model with Blueprint.

