### PR TITLE
fix: mismatched key casing

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -173,6 +173,6 @@ class FactoryGenerator implements Generator
             'enum' => 'randomElement(/** enum_attributes **/)',
         ];
 
-        return $fakeableTypes[$type] ?? null;
+        return $fakeableTypes[strtolower($type)] ?? null;
     }
 }

--- a/tests/fixtures/definitions/post.bp
+++ b/tests/fixtures/definitions/post.bp
@@ -2,6 +2,7 @@ models:
   Post:
     title: string
     author_id: id
+    author_bio: longtext
     content: bigtext nullable
     published_at: timestamp nullable
     word_count: integer unsigned

--- a/tests/fixtures/factories/post-configured.php
+++ b/tests/fixtures/factories/post-configured.php
@@ -9,6 +9,7 @@ $factory->define(Post::class, function (Faker $faker) {
     return [
         'title' => $faker->sentence(4),
         'author_id' => factory(\Some\App\Models\Author::class),
+        'author_bio' => $faker->text,
         'content' => $faker->paragraphs(3, true),
         'published_at' => $faker->dateTime(),
         'word_count' => $faker->randomNumber(),

--- a/tests/fixtures/factories/post.php
+++ b/tests/fixtures/factories/post.php
@@ -9,6 +9,7 @@ $factory->define(Post::class, function (Faker $faker) {
     return [
         'title' => $faker->sentence(4),
         'author_id' => factory(\App\Author::class),
+        'author_bio' => $faker->text,
         'content' => $faker->paragraphs(3, true),
         'published_at' => $faker->dateTime(),
         'word_count' => $faker->randomNumber(),


### PR DESCRIPTION
`FactoryGenerator.php` correctly generates `$faker->text` for `longtext`.