### PR TITLE
suggested fix for relativeNamespace function

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -11,10 +11,17 @@ class Blueprint
     private $lexers = [];
     private $generators = [];
 
-    public static function relativeNamespace(string $fullyQualifiedClassName)
-    {
-        return ltrim(str_replace(config('blueprint.namespace'), '', $fullyQualifiedClassName), '\\');
-    }
+	public static function relativeNamespace(string $fullyQualifiedClassName)
+	{
+		$newClassName = preg_replace(
+			'!^'.preg_quote(config('blueprint.namespace')).'!',
+			'',
+			$fullyQualifiedClassName,
+			1
+		);
+
+		return ltrim($newClassName,'\\');
+	}
 
     public function parse($content)
     {

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -275,4 +275,26 @@ class BlueprintTest extends TestCase
             'deleted' => ['one/trashed.php', 'two/trashed.php'],
         ], $this->subject->generate($tree));
     }
+
+	/**
+	 * @test
+	 */
+	public function relative_namespace_only_replace_first_occurrence_of_default_namespace()
+	{
+		$string = "App\Appointments";
+
+		$actual = Blueprint::relativeNamespace($string);
+
+		$this->assertEquals("Appointments", $actual);
+
+		config(['blueprint.namespace'=>'Foo']);
+
+		$string = "Foo\Appointments";
+
+		$actual = Blueprint::relativeNamespace($string);
+
+		$this->assertEquals("Appointments", $actual);
+
+
+    }
 }


### PR DESCRIPTION
So the Blueprint::relativeNamespace function was too greedy with using str_replace. Any other instance of the string App in the fully qualified class name pass would be stripped out. So App\Appointments would become ointments etc. I added a test. Hopefully this helps.