### PR TITLE
Add $hidden attribute to Models

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -99,6 +99,11 @@ class ModelGenerator implements Generator
             $properties .= $this->files->stub('model/fillable.stub');
         }
 
+        $columns = $this->hiddenColumns($model->columns());
+        if (!empty($columns)) {
+            $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns, false), $this->files->stub('model/hidden.stub'));
+        }
+
         $columns = $this->castableColumns($model->columns());
         if (!empty($columns)) {
             $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns), $this->files->stub('model/casts.stub'));
@@ -156,6 +161,16 @@ class ModelGenerator implements Generator
             'created_at',
             'updated_at',
         ]);
+    }
+
+    private function hiddenColumns(array $columns)
+    {
+        return array_filter(array_keys($columns), function ($column) {
+            return in_array($column, [
+                'password',
+                'remember_token',
+            ]);
+        });
     }
 
     private function castableColumns(array $columns)

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -165,12 +165,10 @@ class ModelGenerator implements Generator
 
     private function hiddenColumns(array $columns)
     {
-        return array_filter(array_keys($columns), function ($column) {
-            return in_array($column, [
-                'password',
-                'remember_token',
-            ]);
-        });
+        return array_intersect(array_keys($columns), [
+            'password',
+            'remember_token',
+        ]);
     }
 
     private function castableColumns(array $columns)

--- a/stubs/model/hidden.stub
+++ b/stubs/model/hidden.stub
@@ -1,0 +1,6 @@
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [];

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -55,6 +55,12 @@ class ModelGeneratorTest extends TestCase
             ->with('model/fillable.stub')
             ->andReturn(file_get_contents('stubs/model/fillable.stub'));
 
+        if ($definition === 'definitions/nested-components.bp') {
+            $this->files->expects('stub')
+                ->with('model/hidden.stub')
+                ->andReturn(file_get_contents('stubs/model/hidden.stub'));
+        }
+
         $this->files->expects('stub')
             ->with('model/casts.stub')
             ->andReturn(file_get_contents('stubs/model/casts.stub'));

--- a/tests/fixtures/definitions/nested-components.bp
+++ b/tests/fixtures/definitions/nested-components.bp
@@ -1,6 +1,7 @@
 models:
   Admin/User:
     name: string
+    password: password
 
 controllers:
   Admin/User:

--- a/tests/fixtures/factories/nested-components.php
+++ b/tests/fixtures/factories/nested-components.php
@@ -8,5 +8,6 @@ use Faker\Generator as Faker;
 $factory->define(User::class, function (Faker $faker) {
     return [
         'name' => $faker->name,
+        'password' => $faker->password,
     ];
 });

--- a/tests/fixtures/models/nested-components.php
+++ b/tests/fixtures/models/nested-components.php
@@ -16,6 +16,15 @@ class User extends Model
     ];
 
     /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password',
+    ];
+
+    /**
      * The attributes that should be cast to native types.
      *
      * @var array


### PR DESCRIPTION
This PR will add a `$hidden` attribute to models if the columns include `password` or `remember_token`. The same values as in the default Laravel `User.php`.

Mentioned in #92 