### PR TITLE
Optimize unsigned columns

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -12,6 +12,11 @@ class MigrationGenerator implements Generator
 {
     const INDENT = '            ';
 
+    const NULLABLE_TYPES = [
+        'morphs',
+        'uuidMorphs',
+    ];
+
     const UNSIGNABLE_TYPES = [
       'bigInteger',
       'decimal',
@@ -76,6 +81,10 @@ class MigrationGenerator implements Generator
                 $dataType = 'unsigned' . ucfirst($dataType);
             }
 
+            if (in_array($dataType, self::NULLABLE_TYPES) && in_array('nullable', $column->modifiers())) {
+                $dataType = 'nullable' . ucfirst($dataType);
+            }
+
             if ($dataType === 'bigIncrements' && $this->isLaravel7orNewer()) {
                 $definition .= self::INDENT . '$table->id(';
             } else {
@@ -102,6 +111,8 @@ class MigrationGenerator implements Generator
                         $definition .= '->' . key($modifier) . '(' . current($modifier) . ')';
                     }
                 } elseif ($modifier === 'unsigned' && strpos($dataType, 'unsigned') === 0) {
+                    continue;
+                } elseif ($modifier === 'nullable' && strpos($dataType, 'nullable') === 0) {
                     continue;
                 } else {
                     $definition .= '->' . $modifier . '()';

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -95,13 +95,10 @@ class MigrationGenerator implements Generator
             $foreign = '';
 
             foreach ($column->modifiers() as $modifier) {
-                if (is_array($modifier))
-                {
-                    if (key($modifier) === 'foreign')
-                    {
+                if (is_array($modifier)) {
+                    if (key($modifier) === 'foreign') {
                         $foreign = self::INDENT . '$table->foreign(' . "'{$column->name()}')->references('id')->on('" . Str::lower(Str::plural(current($modifier))) . "')->onDelete('cascade');" . PHP_EOL;
-                    } else
-                    {
+                    } else {
                         $definition .= '->' . key($modifier) . '(' . current($modifier) . ')';
                     }
                 } elseif ($modifier === 'unsigned' && strpos($dataType, 'unsigned') === 0) {

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -110,9 +110,9 @@ class MigrationGenerator implements Generator
                     } else {
                         $definition .= '->' . key($modifier) . '(' . current($modifier) . ')';
                     }
-                } elseif ($modifier === 'unsigned' && strpos($dataType, 'unsigned') === 0) {
+                } elseif ($modifier === 'unsigned' && Str::startsWith($dataType, 'unsigned')) {
                     continue;
-                } elseif ($modifier === 'nullable' && strpos($dataType, 'nullable') === 0) {
+                } elseif ($modifier === 'nullable' && Str::startsWith($dataType, 'nullable')) {
                     continue;
                 } else {
                     $definition .= '->' . $modifier . '()';

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -135,6 +135,7 @@ class MigrationGeneratorTest extends TestCase
             ['definitions/with-timezones.bp', 'database/migrations/timestamp_create_comments_table.php', 'migrations/with-timezones.php'],
             ['definitions/relationships.bp', 'database/migrations/timestamp_create_comments_table.php', 'migrations/relationships.php'],
             ['definitions/unconventional.bp', 'database/migrations/timestamp_create_teams_table.php', 'migrations/unconventional.php'],
+            ['definitions/optimize.bp', 'database/migrations/timestamp_create_optimizes_table.php', 'migrations/optimize.php'],
             ['definitions/model-key-constraints.bp', 'database/migrations/timestamp_create_orders_table.php', 'migrations/model-key-constraints.php'],
         ];
     }

--- a/tests/fixtures/definitions/optimize.bp
+++ b/tests/fixtures/definitions/optimize.bp
@@ -6,4 +6,6 @@ models:
     int: integer unsigned
     dec: decimal:8,2 unsigned
     big: bigInteger unsigned
+    foo: morphs nullable
+    foobar: uuidMorphs nullable
     timestamps: false

--- a/tests/fixtures/definitions/optimize.bp
+++ b/tests/fixtures/definitions/optimize.bp
@@ -1,0 +1,9 @@
+models:
+  Optimize:
+    tiny: tinyInteger unsigned
+    small: smallInteger unsigned
+    medium: mediumInteger unsigned
+    int: integer unsigned
+    dec: decimal:8,2 unsigned
+    big: bigInteger unsigned
+    timestamps: false

--- a/tests/fixtures/migrations/optimize.php
+++ b/tests/fixtures/migrations/optimize.php
@@ -1,1 +1,36 @@
 <?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateOptimizesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('optimizes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedTinyInteger('tiny');
+            $table->unsignedSmallInteger('small');
+            $table->unsignedMediumInteger('medium');
+            $table->unsignedInteger('int');
+            $table->unsignedDecimal('dec', 8, 2);
+            $table->unsignedBigInteger('big');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('optimizes');
+    }
+}

--- a/tests/fixtures/migrations/optimize.php
+++ b/tests/fixtures/migrations/optimize.php
@@ -21,6 +21,8 @@ class CreateOptimizesTable extends Migration
             $table->unsignedInteger('int');
             $table->unsignedDecimal('dec', 8, 2);
             $table->unsignedBigInteger('big');
+            $table->nullableMorphs('foo');
+            $table->nullableUuidMorphs('foobar');
         });
     }
 


### PR DESCRIPTION
Any unsignable datatype that has the unsigned modifier specified will be optimized to it's `unsigned[type]` corresponding datatype.

ie: 
```
foo: integer unsigned
```

Becomes:
```
$table->unsignedInteger('foo');
```

And so forth.

Closes #5 