### PR TITLE
Exclude files from package export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.github export-ignore
+/tests export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.phplint.yml export-ignore
+blueprint-logo.png export-ignore
+


### PR DESCRIPTION
Using a `.gitattributes` file seems to be the common way to exclude files from being part of the package during a `composer install`.

This closes #119 and provides a foundation for excluding other files in the future.