### PR TITLE
fix models namespace issues

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -221,7 +221,7 @@ class ControllerGenerator implements Generator
         }
 
         $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith(preg_replace('/.+\\\\/', '', $key), Str::studly($context));
+            return Str::endsWith($key, '/'.Str::studly($context));
         });
 
         if (count($matches) === 1) {

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -207,7 +207,7 @@ class ControllerGenerator implements Generator
         /** @var \Blueprint\Models\Model $model */
         $model = $this->modelForContext($model_name);
 
-        if (isset($this->models[Str::studly($model_name)])) {
+        if (isset($model)) {
             return $model->fullyQualifiedClassName();
         }
 
@@ -221,7 +221,7 @@ class ControllerGenerator implements Generator
         }
 
         $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/'.Str::studly($context));
+            return Str::endsWith(preg_replace('/.+\\\\/', '', $key), Str::studly($context));
         });
 
         if (count($matches) === 1) {


### PR DESCRIPTION
I tried to add a namespace for Models, but there was a namespacing error in the controller file.
### Expected import:
use App\Models\Post; 

### Current import:
use App\Admin\Post; 

#### draft.yaml used file:

 ```yaml
 models:
    Models\Post:
      title: string:400
      content: longtext

  controllers:
    Admin\Post:
      index:
        query: all
        render: post.index with:posts

      store:
        validate: title, content
        save: post
        flash: post.title
        redirect: post.index
```
Those changes should solve the problem as I tried it locally
Thanks! 