### PR TITLE
Support uuid primary key shorthand

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -38,6 +38,10 @@ class Blueprint
             return $matches[1] . 'resource: all';
         }, $content);
 
+        $content = preg_replace_callback('/^(\s+)uuid(: true)?$/mi', function ($matches) {
+            return $matches[1] . 'id: uuid primary';
+        }, $content);
+
         return Yaml::parse($content);
     }
 

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -98,6 +98,23 @@ class BlueprintTest extends TestCase
     /**
      * @test
      */
+    public function it_parses_uuid_shorthand()
+    {
+        $blueprint = $this->fixture('definitions/uuid-shorthand.bp');
+
+        $this->assertEquals([
+            'models' => [
+                'Person' => [
+                    'id' => 'uuid primary',
+                    'timestamps' => 'timestamps',
+                ],
+            ]
+        ], $this->subject->parse($blueprint));
+    }
+
+    /**
+     * @test
+     */
     public function it_parses_shorthands_with_timezones()
     {
         $blueprint = $this->fixture('definitions/with-timezones.bp');

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -138,6 +138,7 @@ class MigrationGeneratorTest extends TestCase
             ['definitions/optimize.bp', 'database/migrations/timestamp_create_optimizes_table.php', 'migrations/optimize.php'],
             ['definitions/model-key-constraints.bp', 'database/migrations/timestamp_create_orders_table.php', 'migrations/model-key-constraints.php'],
             ['definitions/disable-auto-columns.bp', 'database/migrations/timestamp_create_states_table.php', 'migrations/disable-auto-columns.php'],
+            ['definitions/uuid-shorthand.bp', 'database/migrations/timestamp_create_people_table.php', 'migrations/uuid-shorthand.php'],
         ];
     }
 }

--- a/tests/fixtures/definitions/uuid-shorthand.bp
+++ b/tests/fixtures/definitions/uuid-shorthand.bp
@@ -1,0 +1,4 @@
+models:
+  Person:
+    uuid
+    timestamps

--- a/tests/fixtures/migrations/uuid-shorthand.php
+++ b/tests/fixtures/migrations/uuid-shorthand.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePeopleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('people', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('people');
+    }
+}


### PR DESCRIPTION
Allows `uuid` shorthand in model definitions which will expand to `id: uuid primary`.

---
Closes #77 