### PR TITLE
add json rule to json columns

### DIFF
--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -2,8 +2,8 @@
 
 namespace Blueprint\Translators;
 
-use Blueprint\Models\Column;
 use Illuminate\Support\Str;
+use Blueprint\Models\Column;
 
 class Rules
 {
@@ -36,13 +36,17 @@ class Rules
             'unsignedInteger',
             'unsignedMediumInteger',
             'unsignedSmallInteger',
-            'unsignedTinyInteger'
+            'unsignedTinyInteger',
         ])) {
             array_push($rules, 'integer');
 
             if (Str::startsWith($column->dataType(), 'unsigned')) {
                 array_push($rules, 'gt:0');
             }
+        }
+
+        if (in_array($column->dataType(), ['json'])) {
+            array_push($rules, 'json');
         }
 
         if (in_array($column->dataType(), [

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Translators;
 
+use Tests\TestCase;
 use Blueprint\Models\Column;
 use Blueprint\Translators\Rules;
-use Tests\TestCase;
 
 /**
  * @see Rules
@@ -158,12 +158,22 @@ class RulesTest extends TestCase
         $this->assertContains('unique:connection.table,column', Rules::fromColumn('connection.table', $column));
     }
 
+    /**
+     * @test
+     */
+    public function forColumn_return_json_rule_for_the_json_type()
+    {
+        $column = new Column('column', 'json');
+
+        $this->assertContains('json', Rules::fromColumn('context', $column));
+    }
+
     public function stringDataTypesProvider()
     {
         return [
             ['string'],
             ['char'],
-            ['text']
+            ['text'],
         ];
     }
 
@@ -212,7 +222,7 @@ class RulesTest extends TestCase
         return [
             ['test_id', 'tests'],
             ['user_id', 'users'],
-            ['sheep_id', 'sheep']
+            ['sheep_id', 'sheep'],
         ];
     }
 }


### PR DESCRIPTION
A `Column` with data type `json` will now receive the `json` validation rule.