### PR TITLE
Fix factory generation for morphs column type

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -107,6 +107,9 @@ class FactoryGenerator implements Generator
                 $default = $column->defaultValue() ?? "'{}'";
                 $definition .= self::INDENT . "'{$column->name()}' => {$default}," . PHP_EOL;
             } elseif ($column->dataType() === 'morphs') {
+                if ($column->isNullable()) {
+                    continue;
+                }
                 $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_id'",  self::fakerDataType('id'), PHP_EOL);
                 $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_type'",  self::fakerDataType('string'), PHP_EOL);
             } else {

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -2,10 +2,10 @@
 
 namespace Blueprint\Generators;
 
+use Blueprint\Contracts\Generator;
+use Blueprint\Models\Column;
 use Blueprint\Models\Model;
 use Illuminate\Support\Str;
-use Blueprint\Models\Column;
-use Blueprint\Contracts\Generator;
 
 class FactoryGenerator implements Generator
 {
@@ -110,8 +110,8 @@ class FactoryGenerator implements Generator
                 if ($column->isNullable()) {
                     continue;
                 }
-                $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_id'",  self::fakerDataType('id'), PHP_EOL);
-                $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_type'",  self::fakerDataType('string'), PHP_EOL);
+                $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_id'", self::fakerDataType('id'), PHP_EOL);
+                $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_type'", self::fakerDataType('string'), PHP_EOL);
             } else {
                 $definition .= self::INDENT . "'{$column->name()}' => ";
                 $faker = self::fakerData($column->name()) ?? self::fakerDataType($column->dataType());

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -106,6 +106,9 @@ class FactoryGenerator implements Generator
             } elseif ($column->dataType() === 'json') {
                 $default = $column->defaultValue() ?? "'{}'";
                 $definition .= self::INDENT . "'{$column->name()}' => {$default}," . PHP_EOL;
+            } elseif ($column->dataType() === 'morphs') {
+                $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_id'",  self::fakerDataType('id'), PHP_EOL);
+                $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_type'",  self::fakerDataType('string'), PHP_EOL);
             } else {
                 $definition .= self::INDENT . "'{$column->name()}' => ";
                 $faker = self::fakerData($column->name()) ?? self::fakerDataType($column->dataType());

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -111,7 +111,7 @@ class MigrationGenerator implements Generator
                 $dataType = 'unsigned' . ucfirst($dataType);
             }
 
-            if (in_array($dataType, self::NULLABLE_TYPES) && in_array('nullable', $column->modifiers())) {
+            if (in_array($dataType, self::NULLABLE_TYPES) && $column->isNullable()) {
                 $dataType = 'nullable' . ucfirst($dataType);
             }
 

--- a/src/Models/Column.php
+++ b/src/Models/Column.php
@@ -45,4 +45,9 @@ class Column
                 return $key === 'default';
             });
     }
+
+    public function isNullable()
+    {
+        return in_array('nullable', $this->modifiers);
+    }
 }

--- a/tests/Unit/Models/ColumnTest.php
+++ b/tests/Unit/Models/ColumnTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+
+
+use Blueprint\Models\Column;
+use PHPUnit\Framework\TestCase;
+
+class ColumnTest extends TestCase
+{
+    /** @test */
+    public function it_knows_if_its_nullable()
+    {
+        $this->assertTrue((new Column('foo', 'string', ['nullable']))->isNullable());
+
+        $this->assertFalse((new Column('foo', 'string', []))->isNullable());
+        $this->assertFalse((new Column('foo', 'string', ['something']))->isNullable());
+    }
+}

--- a/tests/Unit/Models/ColumnTest.php
+++ b/tests/Unit/Models/ColumnTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Unit\Models;
 
-
-
 use Blueprint\Models\Column;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/fixtures/definitions/phone.bp
+++ b/tests/fixtures/definitions/phone.bp
@@ -5,3 +5,4 @@ models:
     phone_number: text
     type: enum:home,cell
     status: set:archived,deleted
+    foo: morphs

--- a/tests/fixtures/definitions/phone.bp
+++ b/tests/fixtures/definitions/phone.bp
@@ -6,4 +6,4 @@ models:
     type: enum:home,cell
     status: set:archived,deleted
     foo: morphs
-    nullable: morphs nullable
+    bar: morphs nullable

--- a/tests/fixtures/definitions/phone.bp
+++ b/tests/fixtures/definitions/phone.bp
@@ -6,3 +6,4 @@ models:
     type: enum:home,cell
     status: set:archived,deleted
     foo: morphs
+    nullable: morphs nullable

--- a/tests/fixtures/factories/phone.php
+++ b/tests/fixtures/factories/phone.php
@@ -12,5 +12,7 @@ $factory->define(Phone::class, function (Faker $faker) {
         'phone_number' => $faker->phoneNumber,
         'type' => $faker->randomElement(["home","cell"]),
         'status' => $faker->randomElement(["archived","deleted"]),
+        'foo_id' => $faker->randomDigitNotNull,
+        'foo_type' => $faker->word,
     ];
 });


### PR DESCRIPTION
Right now if we use a morphs column type like:
```
foo: morphs
```

We get a factory like this:
![image](https://user-images.githubusercontent.com/11543163/79696877-392a1600-8277-11ea-9f70-ff577976b83d.png)

This PR will add those 2 fields (id and type) for morphs.
For a column definition like `morphs nullable` it will not generate factory fields for those 2 columns.

An `isNullable()` helper method for the Column Model.


Questions:

- Should we add a factory definition for a nullable column? 
In my opinion we shouldn't. If a column is nullable, the factory should not have a definition for that column, otherwise we don't have a way to set it to null. If we send a null value for a key, the factory will generate the value for that key.

- Should we add support for  `nullableMorphs`, `nullableUuidMorphs`, `nullableTimestamps` column definitions that are availabe on Laravel.

So right now this works:
```
foo: morphs nullable
```
But this doesn't
```
foo: nullableMorphs
```
