### PR TITLE
Fixes pivot table filename and column references

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -163,12 +163,12 @@ class MigrationGenerator implements Generator
         return trim($definition);
     }
 
-    protected function buildPivotTableDefinition(array $segments, $dataType = 'bigIncrements')
+    protected function buildPivotTableDefinition(array $segments, $dataType = 'bigInteger')
     {
         $definition = '';
 
         foreach ($segments as $segment) {
-            $column = $segment . '_id';
+            $column = strtolower($segment) . '_id';
             $definition .= self::INDENT . '$table->' . $dataType . "('{$column}');" . PHP_EOL;
         }
 
@@ -187,7 +187,7 @@ class MigrationGenerator implements Generator
 
     protected function getPivotTablePath($tableName, Carbon $timestamp)
     {
-        return 'database/migrations/' . $timestamp->format('Y_m_d_His') . '_create_' . $tableName . '_table.php';
+        return 'database/migrations/' . $timestamp->format('Y_m_d_His') . '_create_' . $tableName . '_pivot_table.php';
     }
 
     protected function isLaravel7orNewer()

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -163,7 +163,7 @@ class MigrationGenerator implements Generator
         return trim($definition);
     }
 
-    protected function buildPivotTableDefinition(array $segments, $dataType = 'bigInteger')
+    protected function buildPivotTableDefinition(array $segments, $dataType = 'unsignedBigInteger')
     {
         $definition = '';
 
@@ -187,7 +187,7 @@ class MigrationGenerator implements Generator
 
     protected function getPivotTablePath($tableName, Carbon $timestamp)
     {
-        return 'database/migrations/' . $timestamp->format('Y_m_d_His') . '_create_' . $tableName . '_pivot_table.php';
+        return 'database/migrations/' . $timestamp->format('Y_m_d_His') . '_create_' . $tableName . '_table.php';
     }
 
     protected function isLaravel7orNewer()
@@ -197,7 +197,7 @@ class MigrationGenerator implements Generator
 
     protected function getPivotClassName(array $segments)
     {
-        return 'Create' . Str::studly($this->getPivotTableName($segments)) . 'PivotTable';
+        return 'Create' . Str::studly($this->getPivotTableName($segments)) . 'Table';
     }
 
     protected function getPivotTableName(array $segments)


### PR DESCRIPTION
This is a fix for #136 

Get lowercase $segment for column name
Sets the default dataType as bigInteger
Sets the filename to _pivot_table.php - I prefer this convention instead of removing from classname but could go either way there.