### PR TITLE
Fix duplicated factories

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -280,7 +280,11 @@ class TestGenerator implements Generator
                     $assertion = sprintf('$response->assertRedirect(route(\'%s\'', $statement->route());
 
                     if ($statement->data()) {
-                        $assertion .= ', [' . $this->buildParameters($this->data()) . ']';
+                        $parameters = array_map(function ($parameter) {
+                            return '$' . $parameter;
+                        }, $statement->data());
+
+                        $assertion .= ', [' . implode(', ', $parameters) . ']';
                     } elseif (Str::contains($statement->route(), '.')) {
                         [$model, $action] = explode('.', $statement->route());
                         if (in_array($action, ['edit', 'update', 'show', 'destroy'])) {

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -335,7 +335,6 @@ class TestGenerator implements Generator
                         $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
                     } elseif ($statement->operation() === 'delete') {
                         $tested_bits |= self::TESTS_DELETE;
-                        $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
                         $assertions['generic'][] = sprintf('$this->assertDeleted($%s);', $variable);
                     }
                 } elseif ($statement instanceof QueryStatement) {

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -106,10 +106,6 @@ class TestGenerator implements Generator
             $context = Str::singular($controller->prefix());
             $variable = Str::camel($context);
 
-            if (in_array($name, ['edit', 'update', 'show', 'destroy'])) {
-                $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
-            }
-
             foreach ($statements as $statement) {
                 if ($statement instanceof SendStatement) {
                     $this->addImport($controller, 'Illuminate\\Support\\Facades\\Mail');

--- a/tests/Feature/Generator/TestGeneratorTest.php
+++ b/tests/Feature/Generator/TestGeneratorTest.php
@@ -111,6 +111,7 @@ class TestGeneratorTest extends TestCase
         return [
             ['definitions/readme-example.bp', 'tests/Feature/Http/Controllers/PostControllerTest.php', 'tests/readme-example.php'],
             ['definitions/respond-statements.bp', 'tests/Feature/Http/Controllers/Api/PostControllerTest.php', 'tests/respond-statements.php'],
+            ['definitions/full-crud-example.bp', 'tests/Feature/Http/Controllers/PostControllerTest.php', 'tests/full-crud-example.php'],
         ];
     }
 }

--- a/tests/fixtures/definitions/full-crud-example.bp
+++ b/tests/fixtures/definitions/full-crud-example.bp
@@ -1,0 +1,37 @@
+models:
+  Post:
+    title: string:400
+    content: longtext
+    published_at: nullable timestamp
+
+controllers:
+  Post:
+    index:
+      query: all
+      render: posts.index with:posts
+
+    create:
+      render: posts.create with:post
+
+    store:
+      validate: title, content
+      save: post
+      redirect: posts.index
+
+    show:
+      find: post.id
+      render: posts.show with:post
+
+    edit:
+      find: post.id
+      render: posts.edit with:post
+
+    update:
+      validate: title, content
+      find: post.id
+      save: post
+      redirect: posts.index
+
+    destroy:
+      find: post.id
+      delete: post

--- a/tests/fixtures/definitions/full-crud-example.bp
+++ b/tests/fixtures/definitions/full-crud-example.bp
@@ -19,19 +19,15 @@ controllers:
       redirect: posts.index
 
     show:
-      find: post.id
       render: posts.show with:post
 
     edit:
-      find: post.id
       render: posts.edit with:post
 
     update:
       validate: title, content
-      find: post.id
       save: post
       redirect: posts.index
 
     destroy:
-      find: post.id
       delete: post

--- a/tests/fixtures/tests/full-crud-example.php
+++ b/tests/fixtures/tests/full-crud-example.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use JMac\Testing\Traits\AdditionalAssertions;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\PostController
+ */
+class PostControllerTest extends TestCase
+{
+    use AdditionalAssertions, RefreshDatabase, WithFaker;
+
+    /**
+     * @test
+     */
+    public function index_displays_view()
+    {
+        $posts = factory(Post::class, 3)->create();
+
+        $response = $this->get(route('post.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('posts.index');
+        $response->assertViewHas('posts');
+    }
+
+
+    /**
+     * @test
+     */
+    public function create_displays_view()
+    {
+        $response = $this->get(route('post.create'));
+
+        $response->assertOk();
+        $response->assertViewIs('posts.create');
+        $response->assertViewHas('post');
+    }
+
+
+    /**
+     * @test
+     */
+    public function store_uses_form_request_validation()
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\PostController::class,
+            'store',
+            \App\Http\Requests\PostStoreRequest::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function store_saves_and_redirects()
+    {
+        $title = $this->faker->sentence(4);
+        $content = $this->faker->paragraphs(3, true);
+
+        $response = $this->post(route('post.store'), [
+            'title' => $title,
+            'content' => $content,
+        ]);
+
+        $posts = Post::query()
+            ->where('title', $title)
+            ->where('content', $content)
+            ->get();
+        $this->assertCount(1, $posts);
+        $post = $posts->first();
+
+        $response->assertRedirect(route('posts.index'));
+    }
+
+
+    /**
+     * @test
+     */
+    public function show_displays_view()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->get(route('post.show', $post));
+
+        $response->assertOk();
+        $response->assertViewIs('posts.show');
+        $response->assertViewHas('post');
+    }
+
+
+    /**
+     * @test
+     */
+    public function edit_displays_view()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->get(route('post.edit', $post));
+
+        $response->assertOk();
+        $response->assertViewIs('posts.edit');
+        $response->assertViewHas('post');
+    }
+
+
+    /**
+     * @test
+     */
+    public function update_uses_form_request_validation()
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\PostController::class,
+            'update',
+            \App\Http\Requests\PostUpdateRequest::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function update_saves_and_redirects()
+    {
+        $title = $this->faker->sentence(4);
+        $content = $this->faker->paragraphs(3, true);
+        $post = factory(Post::class)->create();
+
+        $response = $this->put(route('post.update', $post), [
+            'title' => $title,
+            'content' => $content,
+        ]);
+
+        $posts = Post::query()
+            ->where('title', $title)
+            ->where('content', $content)
+            ->get();
+        $this->assertCount(1, $posts);
+        $post = $posts->first();
+
+        $response->assertRedirect(route('posts.index'));
+    }
+
+
+    /**
+     * @test
+     */
+    public function destroy_deletes()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->delete(route('post.destroy', $post));
+
+        $this->assertDeleted($post);
+    }
+}

--- a/tests/fixtures/tests/full-crud-example.php
+++ b/tests/fixtures/tests/full-crud-example.php
@@ -126,9 +126,9 @@ class PostControllerTest extends TestCase
      */
     public function update_saves_and_redirects()
     {
+        $post = factory(Post::class)->create();
         $title = $this->faker->sentence(4);
         $content = $this->faker->paragraphs(3, true);
-        $post = factory(Post::class)->create();
 
         $response = $this->put(route('post.update', $post), [
             'title' => $title,


### PR DESCRIPTION
This Fixes duplicated factories being in the tests.

If the controller method is called 'destroy' and contains the 'delete' comand, the factory will be duplicated because of these parts:

```
if (in_array($name, ['edit', 'update', 'show', 'destroy'])) {
    $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
}
```

```
elseif ($statement->operation() === 'delete') {
    $tested_bits |= self::TESTS_DELETE;
    $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
    $assertions['generic'][] = sprintf('$this->assertDeleted($%s);', $variable);
}
```

The same will occur if the method is called 'show' and contains 'find' in the blueprint definition for example.

Closes #142 
