### PR TITLE
fix: update regular expression to support windows

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -26,20 +26,22 @@ class Blueprint
 
     public function parse($content)
     {
+        $content = str_replace(["\r\n", "\r"], "\n", $content);
+
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)$/mi', function ($matches) {
-            return $matches[1] . strtolower($matches[2]) . ': ' . $matches[2];
+            return $matches[1].strtolower($matches[2]).': '.$matches[2];
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?): true$/mi', function ($matches) {
-            return $matches[1] . strtolower($matches[2]) . ': ' . $matches[2];
+            return $matches[1].strtolower($matches[2]).': '.$matches[2];
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)resource(: true)?$/mi', function ($matches) {
-            return $matches[1] . 'resource: all';
+            return $matches[1].'resource: all';
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)uuid(: true)?$/mi', function ($matches) {
-            return $matches[1] . 'id: uuid primary';
+            return $matches[1].'id: uuid primary';
         }, $content);
 
         return Yaml::parse($content);

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -216,6 +216,77 @@ class BlueprintTest extends TestCase
     /**
      * @test
      */
+    public function it_parses_the_readme_example_with_carriage_return_and_line_feed()
+    {
+        // NOTE: This test gives a false positive on MacOS.
+        // It must pass on Mac (OS 9 and below) and Windows OS for confidence.
+        $blueprint = $this->fixture('definitions/readme-example.bp');
+
+        $LF = "\n"; // Line Feed: Unix
+        $CR = "\r"; // Carriage Return: Mac (OS 9 and below)
+        $CRLF = "\r\n"; // Carriage Return and Line Feed: Windows
+
+        $blueprintCR = str_replace($LF, $CR, $blueprint);
+        $blueprintCRLF = str_replace($LF, $CRLF, $blueprint);
+
+        $this->assertEquals([
+            'models' => [
+                'Post' => [
+                    'title' => 'string:400',
+                    'content' => 'longtext',
+                    'published_at' => 'nullable timestamp',
+                ],
+            ],
+            'controllers' => [
+                'Post' => [
+                    'index' => [
+                        'query' => 'all:posts',
+                        'render' => 'post.index with:posts',
+                    ],
+                    'store' => [
+                        'validate' => 'title, content',
+                        'save' => 'post',
+                        'send' => 'ReviewNotification to:post.author with:post',
+                        'dispatch' => 'SyncMedia with:post',
+                        'fire' => 'NewPost with:post',
+                        'flash' => 'post.title',
+                        'redirect' => 'post.index',
+                    ],
+                ],
+            ],
+        ], $this->subject->parse($blueprintCR));
+
+        $this->assertEquals([
+            'models' => [
+                'Post' => [
+                    'title' => 'string:400',
+                    'content' => 'longtext',
+                    'published_at' => 'nullable timestamp',
+                ],
+            ],
+            'controllers' => [
+                'Post' => [
+                    'index' => [
+                        'query' => 'all:posts',
+                        'render' => 'post.index with:posts',
+                    ],
+                    'store' => [
+                        'validate' => 'title, content',
+                        'save' => 'post',
+                        'send' => 'ReviewNotification to:post.author with:post',
+                        'dispatch' => 'SyncMedia with:post',
+                        'fire' => 'NewPost with:post',
+                        'flash' => 'post.title',
+                        'redirect' => 'post.index',
+                    ],
+                ],
+            ],
+        ], $this->subject->parse($blueprintCRLF));
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_a_custom_error_when_parsing_fails()
     {
         $this->expectException(ParseException::class);

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -216,20 +216,18 @@ class BlueprintTest extends TestCase
     /**
      * @test
      */
-    public function it_parses_the_readme_example_with_carriage_return_and_line_feed()
+    public function it_parses_the_readme_example_with_different_platform_eols()
     {
-        // NOTE: This test gives a false positive on MacOS.
-        // It must pass on Mac (OS 9 and below) and Windows OS for confidence.
-        $blueprint = $this->fixture('definitions/readme-example.bp');
+        $definition = $this->fixture('definitions/readme-example.bp');
 
-        $LF = "\n"; // Line Feed: Unix
-        $CR = "\r"; // Carriage Return: Mac (OS 9 and below)
-        $CRLF = "\r\n"; // Carriage Return and Line Feed: Windows
+        $LF = "\n";
+        $CR = "\r";
+        $CRLF = "\r\n";
 
-        $blueprintCR = str_replace($LF, $CR, $blueprint);
-        $blueprintCRLF = str_replace($LF, $CRLF, $blueprint);
+        $definition_mac_eol = str_replace($LF, $CR, $definition);
+        $definition_windows_eol = str_replace($LF, $CRLF, $definition);
 
-        $this->assertEquals([
+        $expected = [
             'models' => [
                 'Post' => [
                     'title' => 'string:400',
@@ -254,34 +252,10 @@ class BlueprintTest extends TestCase
                     ],
                 ],
             ],
-        ], $this->subject->parse($blueprintCR));
-
-        $this->assertEquals([
-            'models' => [
-                'Post' => [
-                    'title' => 'string:400',
-                    'content' => 'longtext',
-                    'published_at' => 'nullable timestamp',
-                ],
-            ],
-            'controllers' => [
-                'Post' => [
-                    'index' => [
-                        'query' => 'all:posts',
-                        'render' => 'post.index with:posts',
-                    ],
-                    'store' => [
-                        'validate' => 'title, content',
-                        'save' => 'post',
-                        'send' => 'ReviewNotification to:post.author with:post',
-                        'dispatch' => 'SyncMedia with:post',
-                        'fire' => 'NewPost with:post',
-                        'flash' => 'post.title',
-                        'redirect' => 'post.index',
-                    ],
-                ],
-            ],
-        ], $this->subject->parse($blueprintCRLF));
+        ];
+        
+        $this->assertEquals($expected, $this->subject->parse($definition_mac_eol));
+        $this->assertEquals($expected, $this->subject->parse($definition_windows_eol));
     }
 
     /**


### PR DESCRIPTION
> `$` By default, the match must occur at the end of the string or before `\n` at the end of the string; in multiline mode, it must occur before the end of the line or before `\n` at the end of the line.
> https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference

closes #138