### PR TITLE
Fix Windows end of line and path issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,11 +66,6 @@ jobs:
           key: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}
 
-      - uses: jasonmccreary/PHP-Lint@fetch-signature
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -1,0 +1,16 @@
+name: PHPLint
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: jasonmccreary/PHP-Lint@fetch-signature
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -2,10 +2,10 @@
 
 namespace Blueprint;
 
+use Blueprint\Contracts\Generator;
 use Blueprint\Contracts\Lexer;
 use Illuminate\Support\Str;
 use Symfony\Component\Yaml\Yaml;
-use Blueprint\Contracts\Generator;
 
 class Blueprint
 {
@@ -22,6 +22,11 @@ class Blueprint
         }
 
         return $reference;
+    }
+
+    public static function appPath()
+    {
+        return str_replace('\\', '/', config('blueprint.app_path'));
     }
 
     public function parse($content)

--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -77,10 +77,10 @@ class TraceCommand extends Command
 
     private function appClasses()
     {
-        $dir = config('blueprint.app_path');
+        $dir = Blueprint::appPath('app');
 
         if (config('blueprint.models_namespace')) {
-            $dir .= DIRECTORY_SEPARATOR . str_replace('\\', '/', config('blueprint.models_namespace'));
+            $dir .= '/' . str_replace('\\', '/', config('blueprint.models_namespace'));
         }
 
         if (!$this->files->exists($dir)) {
@@ -89,9 +89,9 @@ class TraceCommand extends Command
 
         return array_map(function (\SplFIleInfo $file) {
             return str_replace(
-                [config('blueprint.app_path') . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR],
+                [Blueprint::appPath() . '/', '/'],
                 [config('blueprint.namespace') . '\\', '\\'],
-                $file->getPath() . DIRECTORY_SEPARATOR . $file->getBasename('.php')
+                $file->getPath() . '/' . $file->getBasename('.php')
             );
         }, $this->files->allFiles($dir));
     }

--- a/src/FileMixins.php
+++ b/src/FileMixins.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Blueprint;
 
 class FileMixins
@@ -11,7 +10,7 @@ class FileMixins
     {
         return function ($path) {
             if (!isset($this->stubs[$path])) {
-                $this->stubs[$path] = $this->get(STUBS_PATH . DIRECTORY_SEPARATOR . $path);
+                $this->stubs[$path] = $this->get(STUBS_PATH . '/' . $path);
             }
 
             return $this->stubs[$path];

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -167,7 +167,7 @@ class ControllerGenerator implements Generator
     {
         $path = str_replace('\\', '/', Blueprint::relativeNamespace($controller->fullyQualifiedClassName()));
 
-        return config('blueprint.app_path') . '/' . $path . '.php';
+        return Blueprint::appPath() . '/' . $path . '.php';
     }
 
     private function addImport(Controller $controller, $class)

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -243,7 +243,7 @@ class ModelGenerator implements Generator
         }
 
         $stub = str_replace('use Illuminate\\Database\\Eloquent\\Model;', 'use Illuminate\\Database\\Eloquent\\Model;' . PHP_EOL . 'use Illuminate\\Database\\Eloquent\\SoftDeletes;', $stub);
-        $stub = preg_replace('/^\\{$/m', '{' . PHP_EOL . '    use SoftDeletes;' . PHP_EOL, $stub);
+        $stub = Str::replaceFirst('{', '{' . PHP_EOL . '    use SoftDeletes;' . PHP_EOL, $stub);
 
         return $stub;
     }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -157,7 +157,7 @@ class ModelGenerator implements Generator
     {
         $path = str_replace('\\', '/', Blueprint::relativeNamespace($model->fullyQualifiedClassName()));
 
-        return config('blueprint.app_path') . '/' . $path . '.php';
+        return Blueprint::appPath() . '/' . $path . '.php';
     }
 
     private function fillableColumns(array $columns)

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -233,7 +233,7 @@ class ModelGenerator implements Generator
             $output = preg_replace('/^(\s+)[^=]+=>\s+/m', '$1', $output);
         }
 
-        return trim($output);
+        return trim(str_replace("\n", PHP_EOL, $output));
     }
 
     private function addTraits(Model $model, $stub)

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Blueprint\Generators\Statements;
 
+use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Statements\FireStatement;
 
@@ -57,7 +58,7 @@ class EventGenerator implements Generator
 
     protected function getPath(string $name)
     {
-        return config('blueprint.app_path') . '/Events/' . $name . '.php';
+        return Blueprint::appPath() . '/Events/' . $name . '.php';
     }
 
     protected function populateStub(string $stub, FireStatement $fireStatement)

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Blueprint\Generators\Statements;
 
+use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Controller;
 use Blueprint\Models\Statements\ValidateStatement;
@@ -64,7 +65,7 @@ class FormRequestGenerator implements Generator
 
     protected function getPath(Controller $controller, string $name)
     {
-        return config('blueprint.app_path') . '/Http/Requests/' . ($controller->namespace() ? $controller->namespace() . '/' : '') . $name . '.php';
+        return Blueprint::appPath() . '/Http/Requests/' . ($controller->namespace() ? $controller->namespace() . '/' : '') . $name . '.php';
     }
 
     protected function populateStub(string $stub, string $name, $context, ValidateStatement $validateStatement, Controller $controller)

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Blueprint\Generators\Statements;
 
+use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Statements\DispatchStatement;
 
@@ -53,7 +54,7 @@ class JobGenerator implements Generator
 
     protected function getPath(string $name)
     {
-        return config('blueprint.app_path') . '/Jobs/' . $name . '.php';
+        return Blueprint::appPath() . '/Jobs/' . $name . '.php';
     }
 
     protected function populateStub(string $stub, DispatchStatement $dispatchStatement)

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Blueprint\Generators\Statements;
 
+use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Statements\SendStatement;
 
@@ -53,7 +54,7 @@ class MailGenerator implements Generator
 
     protected function getPath(string $name)
     {
-        return config('blueprint.app_path') . '/Mail/' . $name . '.php';
+        return Blueprint::appPath() . '/Mail/' . $name . '.php';
     }
 
     protected function populateStub(string $stub, SendStatement $sendStatement)

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Blueprint\Generators\Statements;
 
+use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Controller;
 use Blueprint\Models\Model;
@@ -61,7 +62,7 @@ class ResourceGenerator implements Generator
 
     protected function getPath(string $name)
     {
-        return config('blueprint.app_path').'/Http/Resources/'.$name.'.php';
+        return Blueprint::appPath().'/Http/Resources/'.$name.'.php';
     }
 
     protected function populateStub(string $stub, ResourceStatement $resource)

--- a/src/Generators/Statements/ViewGenerator.php
+++ b/src/Generators/Statements/ViewGenerator.php
@@ -54,7 +54,7 @@ class ViewGenerator implements Generator
 
     protected function getPath(string $view)
     {
-        return 'resources/views/' . str_replace('.', DIRECTORY_SEPARATOR, $view) . '.blade.php';
+        return 'resources/views/' . str_replace('.', '/', $view) . '.blade.php';
     }
 
     protected function populateStub(string $stub, RenderStatement $renderStatement)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     public function fixture(string $path)
     {
-        return file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR));
+        return file_get_contents(__DIR__ . '/' . 'fixtures' . '/' . ltrim($path, '/'));
     }
 }


### PR DESCRIPTION
This PR fixes the build for Windows by normalizing output to use `PHP_EOL` and the Unix directory separator throughout.

*Note:* while the _stubs_ and _fixtures_ use Unix line endings, PHP seems to handle this conversion implicitly on read.

---
Supersedes #153