### PR TITLE
Only generate unique test setup statements

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -371,7 +371,7 @@ class TestGenerator implements Generator
             }
             $call .= ');';
 
-            $body = implode(PHP_EOL . PHP_EOL, array_map([$this, 'buildLines'], array_filter($setup)));
+            $body = implode(PHP_EOL . PHP_EOL, array_map([$this, 'buildLines'], $this->uniqueSetupLines($setup)));
             $body .= PHP_EOL . PHP_EOL;
             $body .= str_pad(' ', 8) . $call;
             $body .= PHP_EOL . PHP_EOL;
@@ -448,7 +448,7 @@ class TestGenerator implements Generator
             return $controller->name() . Str::studly($name) . 'Request';
         }
 
-        return $controller->namespace() .'\\'. $controller->name() . Str::studly($name) . 'Request';
+        return $controller->namespace() . '\\' . $controller->name() . Str::studly($name) . 'Request';
     }
 
     private function buildFormRequestTestCase(string $controller, string $action, string $form_request)
@@ -571,5 +571,14 @@ END;
         }
 
         return [null, $field];
+    }
+
+    private function uniqueSetupLines(array $setup)
+    {
+        return collect($setup)->filter()
+            ->map(function ($lines) {
+                return array_unique($lines);
+            })
+            ->toArray();
     }
 }

--- a/tests/Feature/Generator/TestGeneratorTest.php
+++ b/tests/Feature/Generator/TestGeneratorTest.php
@@ -111,6 +111,7 @@ class TestGeneratorTest extends TestCase
         return [
             ['definitions/readme-example.bp', 'tests/Feature/Http/Controllers/PostControllerTest.php', 'tests/readme-example.php'],
             ['definitions/respond-statements.bp', 'tests/Feature/Http/Controllers/Api/PostControllerTest.php', 'tests/respond-statements.php'],
+            ['definitions/full-crud-example.bp', 'tests/Feature/Http/Controllers/PostControllerTest.php', 'tests/full-crud-example.php'],
         ];
     }
 }

--- a/tests/fixtures/definitions/full-crud-example.bp
+++ b/tests/fixtures/definitions/full-crud-example.bp
@@ -1,0 +1,37 @@
+models:
+  Post:
+    title: string:400
+    content: longtext
+    published_at: nullable timestamp
+
+controllers:
+  Post:
+    index:
+      query: all
+      render: posts.index with:posts
+
+    create:
+      render: posts.create with:post
+
+    store:
+      validate: title, content
+      save: post
+      redirect: posts.index
+
+    show:
+      find: post.id
+      render: posts.show with:post
+
+    edit:
+      find: post.id
+      render: posts.edit with:post
+
+    update:
+      validate: title, content
+      find: post.id
+      save: post
+      redirect: posts.index
+
+    destroy:
+      find: post.id
+      delete: post

--- a/tests/fixtures/tests/full-crud-example.php
+++ b/tests/fixtures/tests/full-crud-example.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use JMac\Testing\Traits\AdditionalAssertions;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\PostController
+ */
+class PostControllerTest extends TestCase
+{
+    use AdditionalAssertions, RefreshDatabase, WithFaker;
+
+    /**
+     * @test
+     */
+    public function index_displays_view()
+    {
+        $posts = factory(Post::class, 3)->create();
+
+        $response = $this->get(route('post.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('posts.index');
+        $response->assertViewHas('posts');
+    }
+
+
+    /**
+     * @test
+     */
+    public function create_displays_view()
+    {
+        $response = $this->get(route('post.create'));
+
+        $response->assertOk();
+        $response->assertViewIs('posts.create');
+        $response->assertViewHas('post');
+    }
+
+
+    /**
+     * @test
+     */
+    public function store_uses_form_request_validation()
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\PostController::class,
+            'store',
+            \App\Http\Requests\PostStoreRequest::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function store_saves_and_redirects()
+    {
+        $title = $this->faker->sentence(4);
+        $content = $this->faker->paragraphs(3, true);
+
+        $response = $this->post(route('post.store'), [
+            'title' => $title,
+            'content' => $content,
+        ]);
+
+        $posts = Post::query()
+            ->where('title', $title)
+            ->where('content', $content)
+            ->get();
+        $this->assertCount(1, $posts);
+        $post = $posts->first();
+
+        $response->assertRedirect(route('posts.index'));
+    }
+
+
+    /**
+     * @test
+     */
+    public function show_displays_view()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->get(route('post.show', $post));
+
+        $response->assertOk();
+        $response->assertViewIs('posts.show');
+        $response->assertViewHas('post');
+    }
+
+
+    /**
+     * @test
+     */
+    public function edit_displays_view()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->get(route('post.edit', $post));
+
+        $response->assertOk();
+        $response->assertViewIs('posts.edit');
+        $response->assertViewHas('post');
+    }
+
+
+    /**
+     * @test
+     */
+    public function update_uses_form_request_validation()
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\PostController::class,
+            'update',
+            \App\Http\Requests\PostUpdateRequest::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function update_saves_and_redirects()
+    {
+        $title = $this->faker->sentence(4);
+        $content = $this->faker->paragraphs(3, true);
+        $post = factory(Post::class)->create();
+
+        $response = $this->put(route('post.update', $post), [
+            'title' => $title,
+            'content' => $content,
+        ]);
+
+        $posts = Post::query()
+            ->where('title', $title)
+            ->where('content', $content)
+            ->get();
+        $this->assertCount(1, $posts);
+        $post = $posts->first();
+
+        $response->assertRedirect(route('posts.index'));
+    }
+
+
+    /**
+     * @test
+     */
+    public function destroy_deletes()
+    {
+        $post = factory(Post::class)->create();
+
+        $response = $this->delete(route('post.destroy', $post));
+
+        $this->assertDeleted($post);
+    }
+}

--- a/tests/fixtures/tests/full-crud-example.php
+++ b/tests/fixtures/tests/full-crud-example.php
@@ -126,9 +126,9 @@ class PostControllerTest extends TestCase
      */
     public function update_saves_and_redirects()
     {
+        $post = factory(Post::class)->create();
         $title = $this->faker->sentence(4);
         $content = $this->faker->paragraphs(3, true);
-        $post = factory(Post::class)->create();
 
         $response = $this->put(route('post.update', $post), [
             'title' => $title,


### PR DESCRIPTION
Under certain combinations of statements and controller actions, some of the code generated for the test case setup was duplicated. Particularly the `factory` generation.

This simply adds some good old collection filtering to ensure only unique lines are generated.

---
Supersedes #144