### PR TITLE
Allow configuration to use `$guarded = [];`

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -69,4 +69,15 @@ return [
     'use_constraints' => false,
 
     'fake_nullables' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models
+    |--------------------------------------------------------------------------
+    |
+    | Here you may choose to use $guarded instead $fillable.
+    |
+    */
+
+    'use_guarded' => false,
 ];

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -92,11 +92,15 @@ class ModelGenerator implements Generator
     {
         $properties = '';
 
-        $columns = $this->fillableColumns($model->columns());
-        if (!empty($columns)) {
-            $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns, false), $this->files->stub('model/fillable.stub'));
+        if (config('blueprint.use_guarded')) {
+            $properties .= $this->files->stub('model/guarded.stub');
         } else {
-            $properties .= $this->files->stub('model/fillable.stub');
+            $columns = $this->fillableColumns($model->columns());
+            if (!empty($columns)) {
+                $properties .= PHP_EOL . str_replace('[]', $this->pretty_print_array($columns, false), $this->files->stub('model/fillable.stub'));
+            } else {
+                $properties .= $this->files->stub('model/fillable.stub');
+            }
         }
 
         $columns = $this->hiddenColumns($model->columns());

--- a/stubs/model/guarded.stub
+++ b/stubs/model/guarded.stub
@@ -1,0 +1,6 @@
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -197,6 +197,7 @@ class ModelGeneratorTest extends TestCase
         $this->files->expects('exists')
             ->with(dirname($path))
             ->andReturnTrue();
+
         $this->files->expects('put')
             ->with($path, $this->fixture($model));
 
@@ -204,6 +205,42 @@ class ModelGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     */
+    public function use_guarded_option_generates_models_with_an_empty_array()
+    {
+        $this->app['config']->set('blueprint.use_guarded', true);
+
+        $this->files->expects('stub')
+            ->with('model/class.stub')
+            ->andReturn(file_get_contents('stubs/model/class.stub'));
+
+        $this->files->expects('stub')
+            ->with('model/guarded.stub')
+            ->andReturn(file_get_contents('stubs/model/guarded.stub'));
+
+        $this->files->expects('stub')
+            ->with('model/casts.stub')
+            ->andReturn(file_get_contents('stubs/model/casts.stub'));
+
+        $this->files->shouldReceive('stub')
+            ->with('model/method.stub')
+            ->andReturn(file_get_contents('stubs/model/method.stub'));
+
+        $this->files->expects('exists')
+            ->with(dirname('app/Comment.php'))
+            ->andReturnTrue();
+
+        $this->files->expects('put')
+            ->with('app/Comment.php', $this->fixture('models/model-guarded.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/model-guarded.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['app/Comment.php']], $this->subject->output($tree));
     }
 
     public function modelTreeDataProvider()

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -210,7 +210,7 @@ class ModelGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function use_guarded_option_generates_models_with_an_empty_array()
+    public function output_generates_models_with_guarded_property_when_config_option_is_set()
     {
         $this->app['config']->set('blueprint.use_guarded', true);
 

--- a/tests/fixtures/definitions/model-guarded.bp
+++ b/tests/fixtures/definitions/model-guarded.bp
@@ -1,0 +1,3 @@
+models:
+  Comment:
+    content: text

--- a/tests/fixtures/models/model-guarded.php
+++ b/tests/fixtures/models/model-guarded.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+}


### PR DESCRIPTION
Use `$guarded` instead of `$fillable` when configuration option is set.

---
Closes #148