### PR TITLE
Generate basic code for Eloquent update statements

### DIFF
--- a/src/Lexers/StatementLexer.php
+++ b/src/Lexers/StatementLexer.php
@@ -53,10 +53,12 @@ class StatementLexer implements Lexer
                     $statements[] = $this->analyzeResource($statement);
                     break;
                 case 'save':
-                case 'update':
                 case 'delete':
                 case 'find':
                     $statements[] = new EloquentStatement($command, $statement);
+                    break;
+                case 'update':
+                    $statements[] = $this->analyzeUpdate($statement);
                     break;
                 case 'flash':
                 case 'store':
@@ -178,5 +180,16 @@ class StatementLexer implements Lexer
         }
 
         return new ResourceStatement($reference, !is_null($collection), $collection === 'paginate');
+    }
+
+    private function analyzeUpdate($statement)
+    {
+        if (!Str::contains($statement, ',')) {
+            return new EloquentStatement('update', $statement);
+        }
+
+        $columns = preg_split('/,([ \t]+)?/', $statement);
+
+        return new EloquentStatement('update', null, $columns);
     }
 }

--- a/src/Models/Statements/EloquentStatement.php
+++ b/src/Models/Statements/EloquentStatement.php
@@ -17,10 +17,16 @@ class EloquentStatement
      */
     private $reference;
 
-    public function __construct(string $operation, string $reference)
+    /**
+     * @var array
+     */
+    private $columns;
+
+    public function __construct(string $operation, ?string $reference, array $columns = [])
     {
         $this->operation = $operation;
         $this->reference = $reference;
+        $this->columns = $columns;
     }
 
     public function operation(): string
@@ -28,9 +34,14 @@ class EloquentStatement
         return $this->operation;
     }
 
-    public function reference(): string
+    public function reference(): ?string
     {
         return $this->reference;
+    }
+
+    public function columns(): array
+    {
+        return $this->columns;
     }
 
     public function output(string $controller_prefix, string $context): string
@@ -47,6 +58,17 @@ class EloquentStatement
             } else {
                 $code = "$" . Str::camel($model) . '->save();';
             }
+        }
+
+        if ($this->operation() == 'update') {
+            $columns = '';
+            if (!empty($this->columns())) {
+                $columns = implode(', ', array_map(function ($column) {
+                    return sprintf("'%s' => \$%s", $column, $column);
+                }, $this->columns()));
+            }
+
+            $code = "$" . Str::camel($model) . '->update([' . $columns . ']);';
         }
 
         if ($this->operation() == 'find') {

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -263,6 +263,25 @@ class StatementLexerTest extends TestCase
 
     /**
      * @test
+     */
+    public function it_returns_an_update_eloquent_statement_with_columns()
+    {
+        $tokens = [
+            'update' => 'name, title, age'
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertCount(1, $actual);
+        $this->assertInstanceOf(EloquentStatement::class, $actual[0]);
+
+        $this->assertSame('update', $actual[0]->operation());
+        $this->assertNull($actual[0]->reference());
+        $this->assertSame(['name', 'title', 'age'], $actual[0]->columns());
+    }
+
+    /**
+     * @test
      * @dataProvider sessionTokensProvider
      */
     public function it_returns_a_session_statement($operation, $reference)

--- a/tests/Unit/Models/Statements/EloquentStatementTest.php
+++ b/tests/Unit/Models/Statements/EloquentStatementTest.php
@@ -53,6 +53,26 @@ class EloquentStatementTest extends TestCase
     /**
      * @test
      */
+    public function output_generates_code_for_update_using_model()
+    {
+        $subject = new EloquentStatement('update', 'post');
+
+        $this->assertEquals('$post->update([]);', $subject->output('', ''));
+    }
+
+    /**
+     * @test
+     */
+    public function output_generates_code_for_update_using_column_list()
+    {
+        $subject = new EloquentStatement('update', null, ['name', 'title', 'age']);
+
+        $this->assertEquals('$user->update([\'name\' => $name, \'title\' => $title, \'age\' => $age]);', $subject->output('User', ''));
+    }
+
+    /**
+     * @test
+     */
     public function output_generates_code_for_delete()
     {
         $subject = new EloquentStatement('delete', 'post');

--- a/tests/fixtures/controllers/certificate-controller.php
+++ b/tests/fixtures/controllers/certificate-controller.php
@@ -50,6 +50,8 @@ class CertificateController extends Controller
      */
     public function update(CertificateUpdateRequest $request, Certificate $certificate)
     {
+        $certificate->update([]);
+
         return new CertificateResource($certificate);
     }
 

--- a/tests/fixtures/controllers/certificate-type-controller.php
+++ b/tests/fixtures/controllers/certificate-type-controller.php
@@ -50,6 +50,8 @@ class CertificateTypeController extends Controller
      */
     public function update(CertificateTypeUpdateRequest $request, CertificateType $certificateType)
     {
+        $certificateType->update([]);
+
         return new CertificateTypeResource($certificateType);
     }
 

--- a/tests/fixtures/controllers/custom-models-namespace.php
+++ b/tests/fixtures/controllers/custom-models-namespace.php
@@ -50,6 +50,8 @@ class TagController extends Controller
      */
     public function update(TagUpdateRequest $request, Tag $tag)
     {
+        $tag->update([]);
+
         return new TagResource($tag);
     }
 


### PR DESCRIPTION
While the `update: model` syntax was _lexed_, it was not outputting the generated code.

I'd still like to support pairing this with a `validate` statement for additional developer convenience. But I'll open a separate issue for that as this resolves the initial bug.

---
Closes #185