### PR TITLE
TestGenerator generates valid store_saves()

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -176,7 +176,16 @@ class TestGenerator implements Generator
                                 $faker = 'word';
                             }
 
-                            $setup['data'][] = sprintf('$%s = $this->faker->%s;', $data, $faker);
+                            if ($controller->isApiResource()) {
+                                if ($name === 'update') {
+                                    $setup['data'][] = sprintf('$update = factory(%s)->make();', $local_model->name() . '::class');
+                                } else {
+                                    $setup['data'][] = sprintf('$%s = factory(%s)->make();', $data, $local_model->name() . '::class');
+                                }
+                            } else {
+                                $setup['data'][] = sprintf('$%s = $this->faker->%s;', $data, $faker);
+                            }
+
                             $request_data[$data] = '$' . $data;
                         }
                     }
@@ -320,7 +329,7 @@ class TestGenerator implements Generator
                     if ($statement->operation() === 'save') {
                         $tested_bits |= self::TESTS_SAVE;
 
-                        if ($request_data) {
+                        if ($request_data && !$controller->isApiResource()) {
                             $indent = str_pad(' ', 12);
                             $plural = Str::plural($variable);
                             $assertion = sprintf('$%s = %s::query()', $plural, $model);
@@ -332,6 +341,15 @@ class TestGenerator implements Generator
                             $assertions['sanity'][] = $assertion;
                             $assertions['sanity'][] = '$this->assertCount(1, $' . $plural . ');';
                             $assertions['sanity'][] = sprintf('$%s = $%s->first();', $variable, $plural);
+                        } elseif ($request_data && $controller->isApiResource()) {
+                            $indent = str_pad(' ', 12);
+                            $plural = Str::plural($variable);
+                            $assertion = sprintf('$%s = %s::query()', $plural, $model);
+                            $assertion .= PHP_EOL . sprintf('%s->where(\'id\', $response[\'data\'][\'id\'])', $indent);
+                            $assertion .= PHP_EOL . $indent . '->get();';
+
+                            $assertions['sanity'][] = $assertion;
+                            $assertions['sanity'][] = '$this->assertCount(1, $' . $plural . ');';
                         } else {
                             $assertions['generic'][] = '$this->assertDatabaseHas(' . Str::camel(Str::plural($model)) . ', [ /* ... */ ]);';
                         }
@@ -358,7 +376,7 @@ class TestGenerator implements Generator
             }
             $call .= ')';
 
-            if ($request_data) {
+            if ($request_data && !$controller->isApiResource()) {
                 $call .= ', [';
                 $call .= PHP_EOL;
                 foreach ($request_data as $key => $datum) {
@@ -369,7 +387,30 @@ class TestGenerator implements Generator
 
                 $call .= str_pad(' ', 8) . ']';
             }
+
+            if ($request_data && $controller->isApiResource()) {
+                $call .= ', ';
+                $datum = array_values($request_data)[0];
+                if ($name === 'update') {
+                    $call .= sprintf('$update->toArray()');
+                } else {
+                    $call .= sprintf('%s->toArray()', $datum);
+                }
+            }
+
             $call .= ');';
+
+            if ($name === 'store' && $controller->isApiResource()) {
+                $indent = str_pad(' ', 8);
+                $call .= PHP_EOL;
+                $call .= PHP_EOL;
+                $call .= sprintf('%s$response->assertCreated();', $indent);
+            } elseif ($name === 'update' && $controller->isApiResource()) {
+                $indent = str_pad(' ', 8);
+                $call .= PHP_EOL;
+                $call .= PHP_EOL;
+                $call .= sprintf('%s$response->assertOk();', $indent);
+            }
 
             $body = implode(PHP_EOL . PHP_EOL, array_map([$this, 'buildLines'], $this->uniqueSetupLines($setup)));
             $body .= PHP_EOL . PHP_EOL;

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -405,7 +405,7 @@ class TestGenerator implements Generator
                 $call .= PHP_EOL;
                 $call .= PHP_EOL;
                 $call .= sprintf('%s$response->assertCreated();', $indent);
-            } elseif ($name === 'update' && $controller->isApiResource()) {
+            } elseif (in_array($name, ['update', 'index', 'show']) && $controller->isApiResource()) {
                 $indent = str_pad(' ', 8);
                 $call .= PHP_EOL;
                 $call .= PHP_EOL;

--- a/tests/fixtures/tests/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-pascal-case-example.php
@@ -23,6 +23,8 @@ class CertificateControllerTest extends TestCase
         $certificates = factory(Certificate::class, 3)->create();
 
         $response = $this->get(route('certificate.index'));
+
+        $response->assertOk();
     }
 
 
@@ -64,6 +66,8 @@ class CertificateControllerTest extends TestCase
         $certificate = factory(Certificate::class)->create();
 
         $response = $this->get(route('certificate.show', $certificate));
+
+        $response->assertOk();
     }
 
 

--- a/tests/fixtures/tests/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-pascal-case-example.php
@@ -43,17 +43,16 @@ class CertificateControllerTest extends TestCase
      */
     public function store_saves()
     {
-        $certificate = $this->faker->word;
+        $certificate = factory(Certificate::class)->make();
 
-        $response = $this->post(route('certificate.store'), [
-            'certificate' => $certificate,
-        ]);
+        $response = $this->post(route('certificate.store'), $certificate->toArray());
+
+        $response->assertCreated();
 
         $certificates = Certificate::query()
-            ->where('certificate', $certificate)
+            ->where('id', $response['data']['id'])
             ->get();
         $this->assertCount(1, $certificates);
-        $certificate = $certificates->first();
     }
 
 
@@ -86,11 +85,11 @@ class CertificateControllerTest extends TestCase
     public function update_behaves_as_expected()
     {
         $certificate = factory(Certificate::class)->create();
-        $certificate = $this->faker->word;
+        $update = factory(Certificate::class)->make();
 
-        $response = $this->put(route('certificate.update', $certificate), [
-            'certificate' => $certificate,
-        ]);
+        $response = $this->put(route('certificate.update', $certificate), $update->toArray());
+
+        $response->assertOk();
     }
 
 

--- a/tests/fixtures/tests/certificate-type-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-type-pascal-case-example.php
@@ -43,17 +43,16 @@ class CertificateTypeControllerTest extends TestCase
      */
     public function store_saves()
     {
-        $certificateType = $this->faker->word;
+        $certificateType = factory(CertificateType::class)->make();
 
-        $response = $this->post(route('certificate-type.store'), [
-            'certificateType' => $certificateType,
-        ]);
+        $response = $this->post(route('certificate-type.store'), $certificateType->toArray());
+
+        $response->assertCreated();
 
         $certificateTypes = CertificateType::query()
-            ->where('certificateType', $certificateType)
+            ->where('id', $response['data']['id'])
             ->get();
         $this->assertCount(1, $certificateTypes);
-        $certificateType = $certificateTypes->first();
     }
 
 
@@ -86,11 +85,11 @@ class CertificateTypeControllerTest extends TestCase
     public function update_behaves_as_expected()
     {
         $certificateType = factory(CertificateType::class)->create();
-        $certificateType = $this->faker->word;
+        $update = factory(CertificateType::class)->make();
 
-        $response = $this->put(route('certificate-type.update', $certificateType), [
-            'certificateType' => $certificateType,
-        ]);
+        $response = $this->put(route('certificate-type.update', $certificateType), $update->toArray());
+
+        $response->assertOk();
     }
 
 

--- a/tests/fixtures/tests/certificate-type-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-type-pascal-case-example.php
@@ -23,6 +23,8 @@ class CertificateTypeControllerTest extends TestCase
         $certificateTypes = factory(CertificateType::class, 3)->create();
 
         $response = $this->get(route('certificate-type.index'));
+
+        $response->assertOk();
     }
 
 
@@ -64,6 +66,8 @@ class CertificateTypeControllerTest extends TestCase
         $certificateType = factory(CertificateType::class)->create();
 
         $response = $this->get(route('certificate-type.show', $certificateType));
+
+        $response->assertOk();
     }
 
 


### PR DESCRIPTION
Fixes #207 

First, I updated the fixtures in the testsuite. I did this by taking the generated tests and modifying them manually to tests that work while at the same time being very similar. I tried to be as minimal as possible, to make sure that the changes to the TestGenerator would also be minimal and not break the other cases.

The changes presented in this PR aren't pretty, but it gets the job done. I leveraged `$controller->isApiResource()` quite a bit in both existing as new conditionals throughout the `TestGenerator.php`, in order to get it to generate the correct test method bodies.

As i was coding it, the `update_behaves_as_expected()` started to fail, so I took the liberty to fix that in this PR as well. The HTTP status for an update action is a 200, whereas the HTTP status for a store action is 201.

After getting the `store_saves()` and `update_behaves_as_expected()` to work, it was very little work to also get rid of those 'Risky' tests that didn't assert anything. I know it's bad form to combine fixes into one PR, but it was literally changing one conditional and adding the `$response->assertOk()` to the fixtures. And also: I mentioned in the original issue that the whole test could use some tender love and care, so I took that liberty here.

Now, at least, when using the `resource: api` shorthand, you will get a testsuite that fully runs without errors or risky tests:
```sh
❯ php artisan blueprint:build                                                                                                                                                   Created:
- database/migrations/2020_05_19_214721_create_certificates_table.php
- database/migrations/2020_05_19_214722_create_certificate_types_table.php
- app/Certificate.php
- app/CertificateType.php
- database/factories/CertificateFactory.php
- database/factories/CertificateTypeFactory.php
- app/Http/Controllers/CertificateController.php
- app/Http/Controllers/CertificateTypeController.php
- app/Http/Requests/CertificateStoreRequest.php
- app/Http/Requests/CertificateUpdateRequest.php
- app/Http/Requests/CertificateTypeStoreRequest.php
- app/Http/Requests/CertificateTypeUpdateRequest.php
- app/Http/Resources/CertificateCollection.php
- app/Http/Resources/Certificate.php
- app/Http/Resources/CertificateTypeCollection.php
- app/Http/Resources/CertificateType.php
- tests/Feature/Http/Controllers/CertificateControllerTest.php
- tests/Feature/Http/Controllers/CertificateTypeControllerTest.php

Updated:
- routes/api.php


❯ phpunit                                                                                                                                                             PHPUnit 9.1.4 by Sebastian Bergmann and contributors.

................                                                  16 / 16 (100%)

Time: 00:00.437, Memory: 32.00 MB

OK (16 tests, 28 assertions)
```


I am sure that there's probably some repeated code, or code that can be cleaned up and tidied a bit more, but it's quite late and I have had a long day, so leave them here and I'll be happy to rework it tomorrow.