### PR TITLE
Support for foreign data type shorthand

### DIFF
--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -205,7 +205,7 @@ class ModelLexer implements Lexer
         $data_type = null;
         $modifiers = [];
 
-        $tokens = preg_split('#".*?"(*SKIP)(*F)|\s+#', $definition);
+        $tokens = preg_split('#".*?"(*SKIP)(*FAIL)|\s+#', $definition);
         foreach ($tokens as $token) {
             $parts = explode(':', $token);
             $value = $parts[0];

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -186,7 +186,7 @@ class ModelLexer implements Lexer
 
     private function buildColumn(string $name, string $definition)
     {
-        $data_type = 'string';
+        $data_type = null;
         $modifiers = [];
 
         $tokens = preg_split('#".*?"(*SKIP)(*F)|\s+#', $definition);
@@ -215,6 +215,14 @@ class ModelLexer implements Lexer
                     $modifiers[] = [self::$modifiers[strtolower($value)] => $modifierAttributes];
                 }
             }
+        }
+
+        if (is_null($data_type)) {
+            $is_foreign_key = collect($modifiers)->contains(function ($modifier) {
+                return (is_array($modifier) && key($modifier) === 'foreign') || $modifier === 'foreign';
+            });
+
+            $data_type = $is_foreign_key ? 'id' : 'string';
         }
 
         return new Column($name, $data_type, $modifiers, $attributes ?? []);

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -150,6 +150,7 @@ class FactoryGeneratorTest extends TestCase
             ['definitions/model-modifiers.bp', 'database/factories/ModifierFactory.php', 'factories/model-modifiers.php'],
             ['definitions/model-key-constraints.bp', 'database/factories/OrderFactory.php', 'factories/model-key-constraints.php'],
             ['definitions/unconventional-foreign-key.bp', 'database/factories/StateFactory.php', 'factories/unconventional-foreign-key.php'],
+            ['definitions/foreign-key-shorthand.bp', 'database/factories/CommentFactory.php', 'factories/foreign-key-shorthand.php'],
         ];
     }
 }

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -73,6 +73,29 @@ class MigrationGeneratorTest extends TestCase
     /**
      * @test
      */
+    public function output_writes_migration_for_foreign_shorthand()
+    {
+        $this->files->expects('stub')
+            ->with('migration.stub')
+            ->andReturn(file_get_contents('stubs/migration.stub'));
+
+        $now = Carbon::now();
+        Carbon::setTestNow($now);
+
+        $timestamp_path = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comments_table.php');
+
+        $this->files->expects('put')
+            ->with($timestamp_path, $this->fixture('migrations/foreign-key-shorthand.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/foreign-key-shorthand.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$timestamp_path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     */
     public function output_uses_past_timestamp_for_multiple_migrations()
     {
         $this->files->expects('stub')
@@ -268,7 +291,6 @@ class MigrationGeneratorTest extends TestCase
 
         $this->assertEquals(['created' => [$model_migration, $pivot_migration]], $this->subject->output($tree));
     }
-
 
     /**
      * @test

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -425,6 +425,7 @@ class ModelGeneratorTest extends TestCase
             ['definitions/soft-deletes.bp', 'app/Comment.php', 'models/soft-deletes-phpdoc.php'],
             ['definitions/relationships.bp', 'app/Comment.php', 'models/relationships-phpdoc.php'],
             ['definitions/disable-auto-columns.bp', 'app/State.php', 'models/disable-auto-columns-phpdoc.php'],
+            ['definitions/foreign-key-shorthand.bp', 'app/Comment.php', 'models/foreign-key-shorthand-phpdoc.php'],
         ];
     }
 }

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -421,6 +421,76 @@ class ModelLexerTest extends TestCase
     /**
      * @test
      */
+    public function it_sets_belongs_to_with_foreign_attributes()
+    {
+        $tokens = [
+            'models' => [
+                'Model' => [
+                    'post_id' => 'id foreign',
+                    'author_id' => 'id foreign:users',
+                    'uid' => 'id:user foreign:users.id',
+                    'cntry_id' => 'foreign:countries',
+                    'ccid' => 'foreign:countries.code',
+                ],
+            ],
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertIsArray($actual['models']);
+        $this->assertCount(1, $actual['models']);
+
+        $model = $actual['models']['Model'];
+        $this->assertEquals('Model', $model->name());
+        $this->assertTrue($model->usesTimestamps());
+        $this->assertFalse($model->usesSoftDeletes());
+
+        $columns = $model->columns();
+        $this->assertCount(6, $columns);
+        $this->assertEquals('id', $columns['id']->name());
+        $this->assertEquals('id', $columns['id']->dataType());
+        $this->assertEquals([], $columns['id']->attributes());
+        $this->assertEquals([], $columns['id']->modifiers());
+
+        $this->assertEquals('post_id', $columns['post_id']->name());
+        $this->assertEquals('id', $columns['post_id']->dataType());
+        $this->assertEquals([], $columns['post_id']->attributes());
+        $this->assertEquals(['foreign'], $columns['post_id']->modifiers());
+
+        $this->assertEquals('author_id', $columns['author_id']->name());
+        $this->assertEquals('id', $columns['author_id']->dataType());
+        $this->assertEquals([], $columns['author_id']->attributes());
+        $this->assertEquals([['foreign' => 'users']], $columns['author_id']->modifiers());
+
+        $this->assertEquals('uid', $columns['uid']->name());
+        $this->assertEquals('id', $columns['uid']->dataType());
+        $this->assertEquals(['user'], $columns['uid']->attributes());
+        $this->assertEquals([['foreign' => 'users.id']], $columns['uid']->modifiers());
+
+        $this->assertEquals('cntry_id', $columns['cntry_id']->name());
+        $this->assertEquals('id', $columns['cntry_id']->dataType());
+        $this->assertEquals([], $columns['cntry_id']->attributes());
+        $this->assertEquals([['foreign' => 'countries']], $columns['cntry_id']->modifiers());
+
+        $this->assertEquals('ccid', $columns['ccid']->name());
+        $this->assertEquals('id', $columns['ccid']->dataType());
+        $this->assertEquals([], $columns['ccid']->attributes());
+        $this->assertEquals([['foreign' => 'countries.code']], $columns['ccid']->modifiers());
+
+        $relationships = $model->relationships();
+        $this->assertCount(1, $relationships);
+        $this->assertEquals([
+            'post_id',
+            'user:author_id',
+            'user:uid',
+            'country:cntry_id',
+            'country.code:ccid',
+        ], $relationships['belongsTo']);
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_traced_models()
     {
         $tokens = [

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -384,6 +384,43 @@ class ModelLexerTest extends TestCase
     /**
      * @test
      */
+    public function it_converts_foreign_shorthand_to_id()
+    {
+        $tokens = [
+            'models' => [
+                'Model' => [
+                    'post_id' => 'foreign',
+                    'author_id' => 'foreign:user',
+                ],
+            ],
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertIsArray($actual['models']);
+        $this->assertCount(1, $actual['models']);
+
+        $model = $actual['models']['Model'];
+        $this->assertEquals('Model', $model->name());
+        $this->assertTrue($model->usesTimestamps());
+        $this->assertFalse($model->usesSoftDeletes());
+
+        $columns = $model->columns();
+        $this->assertCount(3, $columns);
+        $this->assertEquals('id', $columns['id']->name());
+        $this->assertEquals('id', $columns['id']->dataType());
+        $this->assertEquals([], $columns['id']->modifiers());
+        $this->assertEquals('post_id', $columns['post_id']->name());
+        $this->assertEquals('id', $columns['post_id']->dataType());
+        $this->assertEquals(['foreign'], $columns['post_id']->modifiers());
+        $this->assertEquals('author_id', $columns['author_id']->name());
+        $this->assertEquals('id', $columns['author_id']->dataType());
+        $this->assertEquals([['foreign' => 'user']], $columns['author_id']->modifiers());
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_traced_models()
     {
         $tokens = [

--- a/tests/fixtures/definitions/foreign-key-shorthand.bp
+++ b/tests/fixtures/definitions/foreign-key-shorthand.bp
@@ -1,0 +1,5 @@
+models:
+  Comment:
+    post_id: foreign
+    author_id: foreign:user
+    ccid: foreign:countries.code

--- a/tests/fixtures/factories/foreign-key-shorthand.php
+++ b/tests/fixtures/factories/foreign-key-shorthand.php
@@ -1,0 +1,16 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Comment;
+use Faker\Generator as Faker;
+
+$factory->define(Comment::class, function (Faker $faker) {
+    return [
+        'post_id' => factory(\App\Post::class),
+        'author_id' => factory(\App\User::class),
+        'ccid' => function () {
+            return factory(\App\Country::class)->create()->code;
+        },
+    ];
+});

--- a/tests/fixtures/migrations/foreign-key-shorthand.php
+++ b/tests/fixtures/migrations/foreign-key-shorthand.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('author_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('ccid')->constrained('countries', 'code')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}

--- a/tests/fixtures/models/foreign-key-shorthand-phpdoc.php
+++ b/tests/fixtures/models/foreign-key-shorthand-phpdoc.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $post_id
+ * @property int $author_id
+ * @property int $ccid
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class Comment extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'post_id',
+        'author_id',
+        'ccid',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'post_id' => 'integer',
+        'author_id' => 'integer',
+        'ccid' => 'integer',
+    ];
+
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function post()
+    {
+        return $this->belongsTo(\App\Post::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function author()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function country()
+    {
+        return $this->belongsTo(\App\Country::class, 'ccid', 'code');
+    }
+}


### PR DESCRIPTION
This adds support for using a `foreign` _shorthand_ when definition models to automatically be treated as a belongs to relationship.

**Before**
```yaml
models:
  Comment:
    post_id: id foreign
```

**After**
```yaml
models:
  Comment:
    post_id: foreign
```
---
Closes #219