### PR TITLE
Fix resource always generating API routes

### DIFF
--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -22,21 +22,22 @@ class RouteGenerator implements Generator
             return [];
         }
 
-        $routes = '';
-        $path = 'routes/web.php';
+        $routes = ['api' => '', 'web' => ''];
+
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {
-            $routes .= PHP_EOL . PHP_EOL . $this->buildRoutes($controller);
-
-            if ($controller->isApiResource()) {
-                $path = 'routes/api.php';
-            }
+            $type = $controller->isApiResource() ? 'api' : 'web';
+            $routes[$type] .= PHP_EOL . PHP_EOL . $this->buildRoutes($controller);
         }
-        $routes .= PHP_EOL;
 
-        $this->files->append($path, $routes);
+        $paths = [];
+        foreach (array_filter($routes) as $type => $definitions) {
+            $path = 'routes/' . $type . '.php';
+            $this->files->append($path, $definitions . PHP_EOL);
+            $paths[] = $path;
+        }
 
-        return ['updated' => [$path]];
+        return ['updated' => $paths];
     }
 
     protected function buildRoutes(Controller $controller)

--- a/src/Lexers/ControllerLexer.php
+++ b/src/Lexers/ControllerLexer.php
@@ -29,14 +29,16 @@ class ControllerLexer implements Lexer
         foreach ($tokens['controllers'] as $name => $definition) {
             $controller = new Controller($name);
 
-            if ($this->isResource($definition)) {
-                $original = $definition;
-                $definition = $this->generateResourceTokens($controller, $this->methodsForResource($definition['resource']));
-                // unset shorthand
-                unset($original['resource']);
-                // this gives the ability to both use a shorthand and override some methods
-                $definition = array_merge($definition, $original);
-                $controller->setApiResource(true);
+            if (isset($definition['resource'])) {
+                $resource_definition = $this->generateResourceTokens($controller, $this->methodsForResource($definition['resource']));
+
+                if ($definition['resource'] === 'api') {
+                    $controller->setApiResource(true);
+                }
+
+                unset($definition['resource']);
+
+                $definition = array_merge($resource_definition, $definition);
             }
 
             foreach ($definition as $method => $body) {
@@ -47,11 +49,6 @@ class ControllerLexer implements Lexer
         }
 
         return $registry;
-    }
-
-    private function isResource(array $definition)
-    {
-        return isset($definition['resource']) && is_string($definition['resource']);
     }
 
     private function generateResourceTokens(Controller $controller, array $methods)

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -34,7 +34,7 @@ class RouteGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function output_writes_nothing_for_empty_tree()
+    public function output_generates_nothing_for_empty_tree()
     {
         $this->files->shouldNotHaveReceived('append');
 
@@ -45,7 +45,7 @@ class RouteGeneratorTest extends TestCase
      * @test
      * @dataProvider controllerTreeDataProvider
      */
-    public function output_writes_migration_for_route_tree($definition, $routes)
+    public function output_generates_web_routes($definition, $routes)
     {
         $path = 'routes/web.php';
         $this->files->expects('append')
@@ -60,19 +60,31 @@ class RouteGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function output_writes_migration_for_route_tree_api_routes()
+    public function output_generates_api_routes()
     {
-        $definition = "definitions/api-routes-example.bp";
-        $routes = "routes/api-routes.php";
-        $path = 'routes/api.php';
-
         $this->files->expects('append')
-            ->with($path, $this->fixture($routes));
+            ->with('routes/api.php', $this->fixture('routes/api-routes.php'));
 
-        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tokens = $this->blueprint->parse($this->fixture('definitions/api-routes-example.bp'));
         $tree = $this->blueprint->analyze($tokens);
 
-        $this->assertEquals(['updated' => [$path]], $this->subject->output($tree));
+        $this->assertEquals(['updated' => ['routes/api.php']], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     */
+    public function output_generates_routes_for_mixed_resources()
+    {
+        $this->files->expects('append')
+            ->with('routes/api.php', $this->fixture('routes/multiple-resource-controllers-api.php'));
+        $this->files->expects('append')
+            ->with('routes/web.php', $this->fixture('routes/multiple-resource-controllers-web.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('definitions/multiple-resource-controllers.bp'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['updated' => ['routes/api.php', 'routes/web.php']], $this->subject->output($tree));
     }
 
     public function controllerTreeDataProvider()

--- a/tests/Feature/Lexers/ControllerLexerTest.php
+++ b/tests/Feature/Lexers/ControllerLexerTest.php
@@ -429,6 +429,4 @@ class ControllerLexerTest extends TestCase
         $this->assertCount(5, $controller->methods());
         $this->assertTrue($controller->isApiResource());
     }
-
-
 }

--- a/tests/Feature/Lexers/ControllerLexerTest.php
+++ b/tests/Feature/Lexers/ControllerLexerTest.php
@@ -380,4 +380,55 @@ class ControllerLexerTest extends TestCase
         $this->assertCount(1, $methods['custom']);
         $this->assertEquals('custom-statements', $methods['custom'][0]);
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_resource_controllers_with_api_flag_set()
+    {
+        $tokens = [
+            'controllers' => [
+                'Page' => [
+                    'resource' => 'web',
+                ],
+                'File' => [
+                    'resource' => 'api',
+                ],
+                'Category' => [
+                    'resource' => 'web',
+                ],
+                'Gallery' => [
+                    'resource' => 'api',
+                ],
+            ]
+        ];
+
+        $this->statementLexer->shouldReceive('analyze');
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertCount(4, $actual['controllers']);
+
+        $controller = $actual['controllers']['Page'];
+        $this->assertEquals('PageController', $controller->className());
+        $this->assertCount(7, $controller->methods());
+        $this->assertFalse($controller->isApiResource());
+
+        $controller = $actual['controllers']['File'];
+        $this->assertEquals('FileController', $controller->className());
+        $this->assertCount(5, $controller->methods());
+        $this->assertTrue($controller->isApiResource());
+
+        $controller = $actual['controllers']['Category'];
+        $this->assertEquals('CategoryController', $controller->className());
+        $this->assertCount(7, $controller->methods());
+        $this->assertFalse($controller->isApiResource());
+
+        $controller = $actual['controllers']['Gallery'];
+        $this->assertEquals('GalleryController', $controller->className());
+        $this->assertCount(5, $controller->methods());
+        $this->assertTrue($controller->isApiResource());
+    }
+
+
 }

--- a/tests/fixtures/definitions/multiple-resource-controllers.bp
+++ b/tests/fixtures/definitions/multiple-resource-controllers.bp
@@ -1,0 +1,35 @@
+models:
+  Page:
+    page_name: string
+    page_slug: string
+    page_content: longtext
+    order: integer nullable
+
+  File:
+    file_name: string
+    file_path: text
+    relationships:
+      belongsToMany: Category
+
+  Category:
+    category_name: string
+    relationships:
+      belongsToMany: File
+
+  Gallery:
+    gallery_name: string
+    images: longtext
+    order: integer nullable
+
+controllers:
+  Page:
+    resource
+
+  File:
+    resource: api
+
+  Category:
+    resource
+
+  Gallery:
+    resource: api

--- a/tests/fixtures/routes/multiple-resource-controllers-api.php
+++ b/tests/fixtures/routes/multiple-resource-controllers-api.php
@@ -1,0 +1,5 @@
+
+
+Route::apiResource('file', 'FileController');
+
+Route::apiResource('gallery', 'GalleryController');

--- a/tests/fixtures/routes/multiple-resource-controllers-web.php
+++ b/tests/fixtures/routes/multiple-resource-controllers-web.php
@@ -1,0 +1,5 @@
+
+
+Route::resource('page', 'PageController');
+
+Route::resource('category', 'CategoryController');


### PR DESCRIPTION
Fixes bug introduced in #210 where all `resource` controller were generating API routes.

---
Closes #225 