### PR TITLE
feat: add support for rememberToken() shorthand

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -14,6 +14,8 @@ class FactoryGenerator implements Generator
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     private $files;
 
+    private $imports = [];
+
     public function __construct($files)
     {
         $this->files = $files;
@@ -27,6 +29,8 @@ class FactoryGenerator implements Generator
 
         /** @var \Blueprint\Models\Model $model */
         foreach ($tree['models'] as $model) {
+            $this->addImport($model, 'Faker\Generator as Faker');
+
             $path = $this->getPath($model);
 
             if (!$this->files->exists(dirname($path))) {
@@ -56,6 +60,7 @@ class FactoryGenerator implements Generator
         $stub = str_replace('DummyModel', $model->fullyQualifiedClassName(), $stub);
         $stub = str_replace('DummyClass', $model->name(), $stub);
         $stub = str_replace('// definition...', $this->buildDefinition($model), $stub);
+        $stub = str_replace('// imports...', $this->buildImports($model), $stub);
 
         return $stub;
     }
@@ -144,6 +149,11 @@ class FactoryGenerator implements Generator
                 }
                 $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_id'", self::fakerDataType('id'), PHP_EOL);
                 $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_type'", self::fakerDataType('string'), PHP_EOL);
+            } elseif ($column->dataType() === 'rememberToken') {
+                $this->addImport($model, 'Illuminate\Support\Str');
+                $definition .= self::INDENT . "'{$column->name()}' => ";
+                $definition .= 'Str::random(10)';
+                $definition .= ',' . PHP_EOL;
             } else {
                 $definition .= self::INDENT . "'{$column->name()}' => ";
                 $faker = self::fakerData($column->name()) ?? self::fakerDataType($column->dataType());
@@ -153,6 +163,21 @@ class FactoryGenerator implements Generator
         }
 
         return trim($definition);
+    }
+
+    private function addImport(Model $model, $class)
+    {
+        $this->imports[$model->name()][] = $class;
+    }
+
+    private function buildImports(Model $model)
+    {
+        $imports = array_unique($this->imports[$model->name()]);
+        sort($imports);
+
+        return implode(PHP_EOL, array_map(function ($class) {
+            return 'use ' . $class . ';';
+        }, $imports));
     }
 
     private function fillableColumns(array $columns): array

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -30,6 +30,7 @@ class FactoryGenerator implements Generator
         /** @var \Blueprint\Models\Model $model */
         foreach ($tree['models'] as $model) {
             $this->addImport($model, 'Faker\Generator as Faker');
+            $this->addImport($model, $model->fullyQualifiedClassName());
 
             $path = $this->getPath($model);
 
@@ -171,8 +172,6 @@ class FactoryGenerator implements Generator
 
     private function buildImports(Model $model)
     {
-        $this->addImport($model, $model->fullyQualifiedClassName());
-
         $imports = array_unique($this->imports[$model->name()]);
         sort($imports);
 

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -57,7 +57,6 @@ class FactoryGenerator implements Generator
 
     protected function populateStub(string $stub, Model $model)
     {
-        $stub = str_replace('DummyModel', $model->fullyQualifiedClassName(), $stub);
         $stub = str_replace('DummyClass', $model->name(), $stub);
         $stub = str_replace('// definition...', $this->buildDefinition($model), $stub);
         $stub = str_replace('// imports...', $this->buildImports($model), $stub);
@@ -172,6 +171,8 @@ class FactoryGenerator implements Generator
 
     private function buildImports(Model $model)
     {
+        $this->addImport($model, $model->fullyQualifiedClassName());
+
         $imports = array_unique($this->imports[$model->name()]);
         sort($imports);
 

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -111,6 +111,8 @@ class MigrationGenerator implements Generator
             $column_definition = self::INDENT;
             if ($dataType === 'bigIncrements' && $this->isLaravel7orNewer()) {
                 $column_definition .= '$table->id(';
+            } elseif ($dataType === 'rememberToken') {
+                $column_definition .= '$table->rememberToken(';
             } else {
                 $column_definition .= '$table->' . $dataType . "('{$column->name()}'";
             }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -204,6 +204,7 @@ class ModelGenerator implements Generator
             'deleted_at',
             'created_at',
             'updated_at',
+            'remember_token',
         ]);
     }
 

--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -2,7 +2,6 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-use DummyModel;
 // imports...
 
 $factory->define(DummyClass::class, function (Faker $faker) {

--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -3,7 +3,7 @@
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use DummyModel;
-use Faker\Generator as Faker;
+// imports...
 
 $factory->define(DummyClass::class, function (Faker $faker) {
     return [

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -48,7 +48,7 @@ class FactoryGeneratorTest extends TestCase
      * @test
      * @dataProvider modelTreeDataProvider
      */
-    public function output_writes_migration_for_model_tree($definition, $path, $migration)
+    public function output_writes_factory_for_model_tree($definition, $path, $factory)
     {
         $this->files->expects('stub')
             ->with('factory.stub')
@@ -59,7 +59,7 @@ class FactoryGeneratorTest extends TestCase
             ->andReturnTrue();
 
         $this->files->expects('put')
-            ->with($path, $this->fixture($migration));
+            ->with($path, $this->fixture($factory));
 
         $tokens = $this->blueprint->parse($this->fixture($definition));
         $tree = $this->blueprint->analyze($tokens);
@@ -151,6 +151,7 @@ class FactoryGeneratorTest extends TestCase
             ['definitions/model-key-constraints.bp', 'database/factories/OrderFactory.php', 'factories/model-key-constraints.php'],
             ['definitions/unconventional-foreign-key.bp', 'database/factories/StateFactory.php', 'factories/unconventional-foreign-key.php'],
             ['definitions/foreign-key-shorthand.bp', 'database/factories/CommentFactory.php', 'factories/foreign-key-shorthand.php'],
+            ['definitions/resource-statements.bp', 'database/factories/UserFactory.php', 'factories/resource-statements.php'],
         ];
     }
 }

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -523,6 +523,7 @@ class MigrationGeneratorTest extends TestCase
             ['definitions/disable-auto-columns.bp', 'database/migrations/timestamp_create_states_table.php', 'migrations/disable-auto-columns.php'],
             ['definitions/uuid-shorthand.bp', 'database/migrations/timestamp_create_people_table.php', 'migrations/uuid-shorthand.php'],
             ['definitions/unconventional-foreign-key.bp', 'database/migrations/timestamp_create_states_table.php', 'migrations/unconventional-foreign-key.php'],
+            ['definitions/resource-statements.bp', 'database/migrations/timestamp_create_users_table.php', 'migrations/resource-statements.php'],
         ];
     }
 }

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -55,7 +55,7 @@ class ModelGeneratorTest extends TestCase
             ->with('model/fillable.stub')
             ->andReturn(file_get_contents('stubs/model/fillable.stub'));
 
-        if ($definition === 'definitions/nested-components.bp') {
+        if (in_array($definition, ['definitions/nested-components.bp','definitions/resource-statements.bp'])) {
             $this->files->expects('stub')
                 ->with('model/hidden.stub')
                 ->andReturn(file_get_contents('stubs/model/hidden.stub'));
@@ -415,6 +415,7 @@ class ModelGeneratorTest extends TestCase
             ['definitions/relationships.bp', 'app/Comment.php', 'models/relationships.php'],
             ['definitions/unconventional.bp', 'app/Team.php', 'models/unconventional.php'],
             ['definitions/nested-components.bp', 'app/Admin/User.php', 'models/nested-components.php'],
+            ['definitions/resource-statements.bp', 'app/User.php', 'models/resource-statements.php'],
         ];
     }
 

--- a/tests/fixtures/factories/resource-statements.php
+++ b/tests/fixtures/factories/resource-statements.php
@@ -1,0 +1,16 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\User;
+use Faker\Generator as Faker;
+use Illuminate\Support\Str;
+
+$factory->define(User::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'email' => $faker->safeEmail,
+        'password' => $faker->password,
+        'remember_token' => Str::random(10),
+    ];
+});

--- a/tests/fixtures/migrations/resource-statements.php
+++ b/tests/fixtures/migrations/resource-statements.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+}

--- a/tests/fixtures/models/resource-statements.php
+++ b/tests/fixtures/models/resource-statements.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+}


### PR DESCRIPTION
- Add the shorthand to `Blueprint::parse`
- Update the `MigrationGenerator` for `rememberToken`
- Update the `FactoryGenerator` for `remember_token` columns
- Update the `ModelGenerator` to hide the attribute

Closes #228