### PR TITLE
feat: add support for `cascade`, `set null`, `restrict`, and `no action` for onDelete actions

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -94,4 +94,24 @@ return [
     */
 
     'use_guarded' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Foreign Key ON DELETE action
+    |--------------------------------------------------------------------------
+    |
+    | By default, Blueprint will set the `ON DELETE` action to 'cascade'.
+    |
+    | restrict / no action:
+    |   - No action is performed with the child data when the parent data is deleted.
+    | cascade:
+    |   - The child data is either deleted when the parent data is deleted.
+    | set null:
+    |   - The child data is set to NULL when the parent data is deleted.
+    |
+    | Supported: 'cascade', 'set_null', 'restrict', 'no_action'
+    |
+    */
+
+    'on_delete' => 'cascade',
 ];

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -19,7 +19,9 @@ class MigrationGenerator implements Generator
 
     const ON_DELETE_CLAUSES = [
         'cascade' => "->onDelete('cascade')",
-        'set_null' => "->onDelete('SET NULL')",
+        'restrict' => "->onDelete('restrict')",
+        'set_null' => "->onDelete('set null')",
+        'no_action' => "->onDelete('no action')",
     ];
 
     const UNSIGNABLE_TYPES = [
@@ -245,26 +247,17 @@ class MigrationGenerator implements Generator
                 ? '$table->foreignId' . "('{$column_name}')->nullable()"
                 : '$table->foreignId' . "('{$column_name}')";
 
-            if ($on_delete_clause==='cascade') {
+            if ($on_delete_clause === 'cascade') {
                 $on_delete_suffix = '->cascadeOnDelete()';
-                if ($column_name === Str::singular($table) . '_' . $column) {
-                    return self::INDENT . "{$prefix}->constrained(){$on_delete_suffix}";
-                }
-                if ($column === 'id') {
-                    return self::INDENT . "{$prefix}->constrained('{$table}'){$on_delete_suffix}";
-                }
-
-                return self::INDENT . "{$prefix}->constrained('{$table}', '{$column}'){$on_delete_suffix}";
-            } elseif ($on_delete_clause==='set_null') {
-                if ($column_name === Str::singular($table) . '_' . $column) {
-                    return self::INDENT . "{$prefix}->constrained(){$on_delete_suffix}";
-                }
-                if ($column === 'id') {
-                    return self::INDENT . "{$prefix}->constrained('{$table}'){$on_delete_suffix}";
-                }
-
-                return self::INDENT . "{$prefix}->constrained('{$table}', '{$column}'){$on_delete_suffix}";
             }
+            if ($column_name === Str::singular($table) . '_' . $column) {
+                return self::INDENT . "{$prefix}->constrained(){$on_delete_suffix}";
+            }
+            if ($column === 'id') {
+                return self::INDENT . "{$prefix}->constrained('{$table}'){$on_delete_suffix}";
+            }
+
+            return self::INDENT . "{$prefix}->constrained('{$table}', '{$column}'){$on_delete_suffix}";
         }
 
         return self::INDENT . '$table->foreign' . "('{$column_name}')->references('{$column}')->on('{$table}'){$on_delete_suffix}";

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -236,11 +236,7 @@ class MigrationGenerator implements Generator
             $table = Str::lower(Str::plural($attributes[0]));
         }
 
-        $on_delete_clause = collect($modifiers)->filter(function ($modifier) {
-            return (is_array($modifier) && key($modifier) === 'onDelete');
-        })->flatten()->first(function ($clause) {
-            return in_array($clause, array_keys(self::ON_DELETE_CLAUSES), true);
-        }, 'cascade');
+        $on_delete_clause = config('blueprint.on_delete', 'cascade');
 
         $on_delete_suffix = self::ON_DELETE_CLAUSES[$on_delete_clause];
 

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -94,6 +94,7 @@ class ModelLexer implements Lexer
         'index' => 'index',
         'primary' => 'primary',
         'foreign' => 'foreign',
+        'ondelete' => 'onDelete',
     ];
 
     public function analyze(array $tokens): array

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -395,6 +395,8 @@ class MigrationGeneratorTest extends TestCase
      */
     public function output_creates_foreign_keys_with_nullable_chained_correctly()
     {
+        $this->app->config->set('blueprint.on_delete', 'set_null');
+
         $this->files->expects('stub')
             ->with('migration.stub')
             ->andReturn(file_get_contents('stubs/migration.stub'));
@@ -419,6 +421,8 @@ class MigrationGeneratorTest extends TestCase
      */
     public function output_creates_foreign_keys_with_nullable_chained_correctly_laravel6()
     {
+        $this->app->config->set('blueprint.on_delete', 'set_null');
+
         $app = \Mockery::mock();
         $app->shouldReceive('version')
             ->withNoArgs()

--- a/tests/fixtures/definitions/nullable-chaining.bp
+++ b/tests/fixtures/definitions/nullable-chaining.bp
@@ -1,4 +1,4 @@
 models:
   Cart:
     name: string
-    user_id: id foreign nullable ondelete:set_null
+    user_id: id foreign nullable

--- a/tests/fixtures/definitions/nullable-chaining.bp
+++ b/tests/fixtures/definitions/nullable-chaining.bp
@@ -1,4 +1,4 @@
 models:
   Cart:
     name: string
-    user_id: id foreign nullable
+    user_id: id foreign nullable ondelete:set_null

--- a/tests/fixtures/migrations/nullable-chaining-laravel6.php
+++ b/tests/fixtures/migrations/nullable-chaining-laravel6.php
@@ -17,7 +17,7 @@ class CreateCartsTable extends Migration
             $table->bigIncrements('id');
             $table->string('name');
             $table->unsignedBigInteger('user_id')->nullable();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('SET NULL');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/nullable-chaining-laravel6.php
+++ b/tests/fixtures/migrations/nullable-chaining-laravel6.php
@@ -17,7 +17,7 @@ class CreateCartsTable extends Migration
             $table->bigIncrements('id');
             $table->string('name');
             $table->unsignedBigInteger('user_id')->nullable();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('SET NULL');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/nullable-chaining.php
+++ b/tests/fixtures/migrations/nullable-chaining.php
@@ -16,7 +16,7 @@ class CreateCartsTable extends Migration
         Schema::create('carts', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->foreignId('user_id')->nullable()->constrained()->onDelete('SET NULL');
+            $table->foreignId('user_id')->nullable()->constrained()->onDelete('set null');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/nullable-chaining.php
+++ b/tests/fixtures/migrations/nullable-chaining.php
@@ -16,7 +16,7 @@ class CreateCartsTable extends Migration
         Schema::create('carts', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->onDelete('SET NULL');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
- Update `ModelLexer` to parse `onDelete` modifier
- Update `MigrationGenerator` to generate  both `cascade` and `set_null` clauses.
- Update fixtures to Test `MigrationGenerator`.


Usage:
```
models:
  Cart:
    name: string
    user_id: id foreign nullable ondelete:set_null
```
Closes #213