### PR TITLE
Add method to swap registered generators

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -94,7 +94,7 @@ class Blueprint
 
     public function swapGenerator(string $concrete, Generator $generator)
     {
-        foreach($this->generators as $key => $registeredGenerator) {
+        foreach ($this->generators as $key => $registeredGenerator) {
             if (get_class($registeredGenerator) === $concrete) {
                 unset($this->generators[$key]);
             }

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -91,4 +91,15 @@ class Blueprint
     {
         $this->generators[] = $generator;
     }
+
+    public function swapGenerator(string $concrete, Generator $generator)
+    {
+        foreach($this->generators as $key => $registeredGenerator) {
+            if (get_class($registeredGenerator) === $concrete) {
+                unset($this->generators[$key]);
+            }
+        }
+
+        $this->registerGenerator($generator);
+    }
 }

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Contracts\Lexer;
-use Illuminate\Support\Facades\Log;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Tests\TestCase;
 


### PR DESCRIPTION
Closes #236 

Currently there is no way to override the default registered generators. This PR adds a `swapGenerator` method that was discussed in #236 with a matching test! 