### PR TITLE
fix: ignore models that extend Jenssegers\Mongodb\Eloquent\Model

### DIFF
--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -103,9 +103,10 @@ class TraceCommand extends Command
         }
 
         $reflectionClass = new \ReflectionClass($class);
-        if (!$reflectionClass->isSubclassOf(\Illuminate\Database\Eloquent\Model::class)) {
+        if (!$reflectionClass->isSubclassOf(\Illuminate\Database\Eloquent\Model::class) || $reflectionClass->isSubclassOf('Jenssegers\Mongodb\Eloquent\Model')) {
             return null;
         }
+
 
         return $this->laravel->make($class);
     }


### PR DESCRIPTION
Closes #239