### PR TITLE
fix: confirm api resource methods

### DIFF
--- a/src/Lexers/ControllerLexer.php
+++ b/src/Lexers/ControllerLexer.php
@@ -30,9 +30,10 @@ class ControllerLexer implements Lexer
             $controller = new Controller($name);
 
             if (isset($definition['resource'])) {
-                $resource_definition = $this->generateResourceTokens($controller, $this->methodsForResource($definition['resource']));
+                $resource_methods = $this->methodsForResource($definition['resource']);
+                $resource_definition = $this->generateResourceTokens($controller, $resource_methods);
 
-                if ($definition['resource'] === 'api') {
+                if ($this->hasAPIResourceMethods($resource_methods)) {
                     $controller->setApiResource(true);
                 }
 
@@ -139,6 +140,13 @@ class ControllerLexer implements Lexer
             return ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
         }
 
-        return array_map('trim', explode(',', $type));
+        return array_map('trim', explode(',', strtolower($type)));
+    }
+
+    private function hasAPIResourceMethods(array $methods)
+    {
+        return collect($methods)->every(function ($item, $key) {
+            return Str::startsWith($item, 'api.');
+        });
     }
 }

--- a/src/Lexers/ControllerLexer.php
+++ b/src/Lexers/ControllerLexer.php
@@ -33,7 +33,7 @@ class ControllerLexer implements Lexer
                 $resource_methods = $this->methodsForResource($definition['resource']);
                 $resource_definition = $this->generateResourceTokens($controller, $resource_methods);
 
-                if ($this->hasAPIResourceMethods($resource_methods)) {
+                if ($this->hasOnlyApiResourceMethods($resource_methods)) {
                     $controller->setApiResource(true);
                 }
 
@@ -143,7 +143,7 @@ class ControllerLexer implements Lexer
         return array_map('trim', explode(',', strtolower($type)));
     }
 
-    private function hasAPIResourceMethods(array $methods)
+    private function hasOnlyApiResourceMethods(array $methods)
     {
         return collect($methods)->every(function ($item, $key) {
             return Str::startsWith($item, 'api.');

--- a/tests/Feature/Lexers/ControllerLexerTest.php
+++ b/tests/Feature/Lexers/ControllerLexerTest.php
@@ -202,7 +202,7 @@ class ControllerLexerTest extends TestCase
         $tokens = [
             'controllers' => [
                 'Comment' => [
-                    'resource' => 'api'
+                    'resource' => 'api.index, api.store, api.show, api.update'
                 ]
             ]
         ];
@@ -232,12 +232,6 @@ class ControllerLexerTest extends TestCase
                 'resource' => 'comment'
             ])
             ->andReturn(['api-update-statements']);
-        $this->statementLexer->expects('analyze')
-            ->with([
-                'delete' => 'comment',
-                'respond' => 200
-            ])
-            ->andReturn(['api-destroy-statements']);
 
         $actual = $this->subject->analyze($tokens);
 
@@ -248,7 +242,7 @@ class ControllerLexerTest extends TestCase
         $this->assertTrue($controller->isApiResource());
 
         $methods = $controller->methods();
-        $this->assertCount(5, $methods);
+        $this->assertCount(4, $methods);
 
         $this->assertCount(1, $methods['index']);
         $this->assertEquals('api-index-statements', $methods['index'][0]);
@@ -258,8 +252,6 @@ class ControllerLexerTest extends TestCase
         $this->assertEquals('api-show-statements', $methods['show'][0]);
         $this->assertCount(1, $methods['update']);
         $this->assertEquals('api-update-statements', $methods['update'][0]);
-        $this->assertCount(1, $methods['destroy']);
-        $this->assertEquals('api-destroy-statements', $methods['destroy'][0]);
     }
 
     /**

--- a/tests/fixtures/definitions/multiple-resource-controllers.bp
+++ b/tests/fixtures/definitions/multiple-resource-controllers.bp
@@ -26,10 +26,10 @@ controllers:
     resource
 
   File:
-    resource: api
+    resource: api.store, api.show, api.update
 
   Category:
-    resource
+    resource: index, api.destroy
 
   Gallery:
     resource: api

--- a/tests/fixtures/routes/multiple-resource-controllers-api.php
+++ b/tests/fixtures/routes/multiple-resource-controllers-api.php
@@ -1,5 +1,5 @@
 
 
-Route::apiResource('file', 'FileController');
+Route::apiResource('file', 'FileController')->except('index', 'destroy');
 
 Route::apiResource('gallery', 'GalleryController');

--- a/tests/fixtures/routes/multiple-resource-controllers-web.php
+++ b/tests/fixtures/routes/multiple-resource-controllers-web.php
@@ -2,4 +2,4 @@
 
 Route::resource('page', 'PageController');
 
-Route::resource('category', 'CategoryController');
+Route::resource('category', 'CategoryController')->only('index', 'destroy');


### PR DESCRIPTION
- confirm all resource methods for an API controller are prefixed with `api.`

- if you are mixing "api" and "web" routes in the same controller, then they should all be "web" routes.
eg.

`draft.yaml`:
```yaml
controllers:
  Category:
    resource: index, api.destroy
```

`web.php`:
```yaml
Route::resource('category', 'CategoryController')->only('index', 'destroy');
```

closes #241
supersedes pr #242