### PR TITLE
Build command improvements

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -50,7 +50,7 @@ class BuildCommand extends Command
         $file = $this->argument('draft') ?? $this->defaultDraftFile();
 
         if (!file_exists($file)) {
-            $this->error('Draft file could not be found: ' . $file);
+            $this->error('Draft file could not be found: ' . ($file ?: 'draft.yaml'));
             exit(1);
         }
 

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -16,7 +16,9 @@ class BuildCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'blueprint:build {draft?}';
+    protected $signature = 'blueprint:build 
+                            {draft? : The path to the draft file, default: draft.yaml or draft.yaml }
+                            ';
 
     /**
      * The console command description.

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -80,13 +80,14 @@ class BuildCommand extends Command
 
     private function outputStyle($action)
     {
-        if ($action === 'deleted') {
-            return 'error';
-        } elseif ($action === 'updated') {
-            return 'comment';
+        switch ($action) {
+            case 'deleted':
+                return 'error';
+            case 'updated':
+                return 'comment';
+            default:
+                return 'info';
         }
-
-        return 'info';
     }
 
     private function defaultDraftFile()

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -42,7 +42,7 @@ class BuildCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return mixed
+     * @return void
      */
     public function handle()
     {
@@ -50,6 +50,7 @@ class BuildCommand extends Command
 
         if (!file_exists($file)) {
             $this->error('Draft file could not be found: ' . $file);
+            exit(1);
         }
 
         $blueprint = resolve(Blueprint::class);

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -32,7 +32,6 @@ class BuildCommand extends Command
 
     /**
      * @param Filesystem $files
-     * @param \Illuminate\Contracts\View\Factory $view
      */
     public function __construct(Filesystem $files)
     {

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -81,14 +81,13 @@ class BuildCommand extends Command
 
     private function outputStyle($action)
     {
-        switch ($action) {
-            case 'deleted':
-                return 'error';
-            case 'updated':
-                return 'comment';
-            default:
-                return 'info';
+        if ($action === 'deleted') {
+            return 'error';
+        } elseif ($action === 'updated') {
+            return 'comment';
         }
+
+        return 'info';
     }
 
     private function defaultDraftFile()


### PR DESCRIPTION
2 Changes:

- If the draft file is not found it will exit the command, preventing exceptions.
Before:
![image](https://user-images.githubusercontent.com/11543163/83200901-41118b80-a13c-11ea-88da-6fb7dddd604f.png)
After:
![image](https://user-images.githubusercontent.com/11543163/83201233-f6444380-a13c-11ea-8def-c03593c5fba9.png)


- Add info for the `draft argument

Right now there's no info about the optional argument:
![before](https://user-images.githubusercontent.com/11543163/83200688-c8aaca80-a13b-11ea-9a38-f1c6a49f8783.png)

With this PR we will have the info for the `draft` argument:
![after](https://user-images.githubusercontent.com/11543163/83200717-d8c2aa00-a13b-11ea-83c7-4a94e5b7babd.png)
