### PR TITLE
fix: wrong model imports in tests

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -314,8 +314,12 @@ class TestGenerator implements Generator
                 } elseif ($statement instanceof EloquentStatement) {
                     $this->addRefreshDatabaseTrait($controller);
 
+                    $modelNamespace = config('blueprint.models_namespace')
+                        ? config('blueprint.namespace') . '\\' . config('blueprint.models_namespace')
+                        : config('blueprint.namespace');
+
                     $model = $this->determineModel($controller->prefix(), $statement->reference());
-                    $this->addImport($controller, config('blueprint.namespace') . '\\' . $model);
+                    $this->addImport($controller, $modelNamespace . '\\' . $model);
 
                     if ($statement->operation() === 'save') {
                         $tested_bits |= self::TESTS_SAVE;
@@ -347,7 +351,11 @@ class TestGenerator implements Generator
 
                     $setup['data'][] = sprintf('$%s = factory(%s::class, 3)->create();', Str::plural($variable), $model);
 
-                    $this->addImport($controller, config('blueprint.namespace') . '\\' . $this->determineModel($controller->prefix(), $statement->model()));
+                    $modelNamespace = config('blueprint.models_namespace')
+                        ? config('blueprint.namespace') . '\\' . config('blueprint.models_namespace')
+                        : config('blueprint.namespace');
+
+                    $this->addImport($controller, $modelNamespace . '\\' . $this->determineModel($controller->prefix(), $statement->model()));
                 }
             }
 

--- a/tests/Feature/Generator/TestGeneratorTest.php
+++ b/tests/Feature/Generator/TestGeneratorTest.php
@@ -139,6 +139,39 @@ class TestGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['tests/Feature/Http/Controllers/UserControllerTest.php']], $this->subject->output($tree));
     }
 
+    /**
+     * @test
+     */
+    public function output_generates_tests_with_models_with_custom_namespace_correctly()
+    {
+        $definition = 'drafts/models-with-custom-namespace.yaml';
+        $path = 'tests/Feature/Http/Controllers/CategoryControllerTest.php';
+        $test = 'tests/models-with-custom-namespace.php';
+
+        $this->app['config']->set('blueprint.models_namespace', 'Models');
+
+        $this->files->expects('get')
+            ->with('stubs/test/class.stub')
+            ->andReturn(file_get_contents('stubs/test/class.stub'));
+
+        $this->files->expects('get')
+            ->with('stubs/test/case.stub')
+            ->andReturn(file_get_contents('stubs/test/case.stub'));
+        $dirname = dirname($path);
+        $this->files->expects('exists')
+            ->with($dirname)
+            ->andReturnFalse();
+        $this->files->expects('makeDirectory')
+        ->with($dirname, 0755, true);
+        $this->files->expects('put')
+            ->with($path, $this->fixture($test));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
     public function controllerTreeDataProvider()
     {
         return [

--- a/tests/fixtures/drafts/models-with-custom-namespace.yaml
+++ b/tests/fixtures/drafts/models-with-custom-namespace.yaml
@@ -1,0 +1,13 @@
+models:
+  Category:
+    name: string:30
+    image: string
+    parent_id: id:Category nullable
+    active: boolean default:true
+    relationships:
+      hasMany: Category
+    softDeletes
+
+controllers:
+  Category:
+    resource: api

--- a/tests/fixtures/tests/models-with-custom-namespace.php
+++ b/tests/fixtures/tests/models-with-custom-namespace.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use JMac\Testing\Traits\AdditionalAssertions;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\CategoryController
+ */
+class CategoryControllerTest extends TestCase
+{
+    use AdditionalAssertions, RefreshDatabase, WithFaker;
+
+    /**
+     * @test
+     */
+    public function index_behaves_as_expected()
+    {
+        $categories = factory(Category::class, 3)->create();
+
+        $response = $this->get(route('category.index'));
+    }
+
+
+    /**
+     * @test
+     */
+    public function store_uses_form_request_validation()
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\CategoryController::class,
+            'store',
+            \App\Http\Requests\CategoryStoreRequest::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function store_saves()
+    {
+        $category = $this->faker->word;
+
+        $response = $this->post(route('category.store'), [
+            'category' => $category,
+        ]);
+
+        $categories = Category::query()
+            ->where('category', $category)
+            ->get();
+        $this->assertCount(1, $categories);
+        $category = $categories->first();
+    }
+
+
+    /**
+     * @test
+     */
+    public function show_behaves_as_expected()
+    {
+        $category = factory(Category::class)->create();
+
+        $response = $this->get(route('category.show', $category));
+    }
+
+
+    /**
+     * @test
+     */
+    public function update_uses_form_request_validation()
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\CategoryController::class,
+            'update',
+            \App\Http\Requests\CategoryUpdateRequest::class
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function update_behaves_as_expected()
+    {
+        $category = factory(Category::class)->create();
+        $category = $this->faker->word;
+
+        $response = $this->put(route('category.update', $category), [
+            'category' => $category,
+        ]);
+    }
+
+
+    /**
+     * @test
+     */
+    public function destroy_deletes_and_responds_with()
+    {
+        $category = factory(Category::class)->create();
+
+        $response = $this->delete(route('category.destroy', $category));
+
+        $response->assertOk();
+
+        $this->assertDeleted($category);
+    }
+}


### PR DESCRIPTION
This pull request is a quick fix for the wrong model imports in tests.

But as @jasonmccreary mentioned in #254 a better solution would be a central registry for models.

---
Closes #254