### PR TITLE
fix: factory generation for smallInteger and tinyInteger dataTypes

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -249,6 +249,8 @@ class FactoryGenerator implements Generator
             'unsignedsmallinteger' => 'randomDigitNotNull',
             'biginteger' => 'randomNumber()',
             'smallint' => 'randomNumber()',
+            'tinyinteger' => 'randomNumber()',
+            'smallinteger' => 'randomNumber()',
             'decimal' => 'randomFloat(/** decimal_attributes **/)',
             'float' => 'randomFloat(/** float_attributes **/)',
             'longtext' => 'text',

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -152,6 +152,7 @@ class FactoryGeneratorTest extends TestCase
             ['drafts/unconventional-foreign-key.yaml', 'database/factories/StateFactory.php', 'factories/unconventional-foreign-key.php'],
             ['drafts/foreign-key-shorthand.yaml', 'database/factories/CommentFactory.php', 'factories/foreign-key-shorthand.php'],
             ['drafts/resource-statements.yaml', 'database/factories/UserFactory.php', 'factories/resource-statements.php'],
+            ['drafts/factory-smallint-and-tinyint.yaml', 'database/factories/ModelFactory.php', 'factories/factory-smallint-and-tinyint.php'],
         ];
     }
 }

--- a/tests/fixtures/drafts/factory-smallint-and-tinyint.yaml
+++ b/tests/fixtures/drafts/factory-smallint-and-tinyint.yaml
@@ -1,0 +1,4 @@
+models:
+  Model:
+    market_type: tinyInteger
+    deposit: smallInteger unsigned

--- a/tests/fixtures/factories/factory-smallint-and-tinyint.php
+++ b/tests/fixtures/factories/factory-smallint-and-tinyint.php
@@ -1,0 +1,13 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Model;
+use Faker\Generator as Faker;
+
+$factory->define(Model::class, function (Faker $faker) {
+    return [
+        'market_type' => $faker->randomNumber(),
+        'deposit' => $faker->randomNumber(),
+    ];
+});


### PR DESCRIPTION
This pull request fixes the factory generation for `smallInteger` and `tinyInteger` dataTypes.

---
Closes #255 