### PR TITLE
Add support for dashed YAML syntax

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -32,6 +32,7 @@ class Blueprint
     public function parse($content)
     {
         $content = str_replace(["\r\n", "\r"], "\n", $content);
+        $content = preg_replace('/^(\s*)-\s*/m', '\1', $content);
 
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)$/mi', function ($matches) {
             return $matches[1].strtolower($matches[2]).': '.$matches[2];

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -278,6 +278,38 @@ class BlueprintTest extends TestCase
     /**
      * @test
      */
+    public function it_parses_yaml_using_dashed_syntax()
+    {
+        $definition = $this->fixture('drafts/readme-example-dashes.yaml');
+
+        $expected = [
+            'models' => [
+                'Post' => [
+                    'title' => 'string:400',
+                    'content' => 'longtext',
+                ],
+            ],
+            'controllers' => [
+                'Post' => [
+                    'index' => [
+                        'query' => 'all:posts',
+                        'render' => 'post.index with:posts',
+                    ],
+                    'store' => [
+                        'validate' => 'title, content',
+                        'save' => 'post',
+                        'redirect' => 'post.index',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->subject->parse($definition));
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_a_custom_error_when_parsing_fails()
     {
         $this->expectException(ParseException::class);

--- a/tests/fixtures/drafts/readme-example-dashes.yaml
+++ b/tests/fixtures/drafts/readme-example-dashes.yaml
@@ -1,0 +1,15 @@
+- models:
+  - Post:
+    - title: string:400
+    - content: longtext
+
+- controllers:
+  - Post:
+    - index:
+       - query: all:posts
+       - render: post.index with:posts
+
+    - store:
+      - validate: title, content
+      - save: post
+      - redirect: post.index


### PR DESCRIPTION
This allows you to use the _dashed_ YAML syntax when crafting your draft files.

---
Closes: #251