### PR TITLE
Allow use of dashes in .blueprint

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -29,10 +29,13 @@ class Blueprint
         return str_replace('\\', '/', config('blueprint.app_path'));
     }
 
-    public function parse($content)
+    public function parse($content, $strip_dashes = true)
     {
         $content = str_replace(["\r\n", "\r"], "\n", $content);
-        $content = preg_replace('/^(\s*)-\s*/m', '\1', $content);
+
+        if ($strip_dashes) {
+            $content = preg_replace('/^(\s*)-\s*/m', '\1', $content);
+        }
 
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)$/mi', function ($matches) {
             return $matches[1].strtolower($matches[2]).': '.$matches[2];

--- a/src/Commands/EraseCommand.php
+++ b/src/Commands/EraseCommand.php
@@ -47,7 +47,7 @@ class EraseCommand extends Command
         $contents = $this->files->get('.blueprint');
 
         $blueprint = new Blueprint();
-        $generated = $blueprint->parse($contents);
+        $generated = $blueprint->parse($contents, false);
 
         collect($generated)->each(function ($files, $action) {
             if ($action === 'created') {

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -278,7 +278,7 @@ class BlueprintTest extends TestCase
     /**
      * @test
      */
-    public function it_parses_yaml_using_dashed_syntax()
+    public function it_parses_yaml_with_dashed_syntax()
     {
         $definition = $this->fixture('drafts/readme-example-dashes.yaml');
 
@@ -305,6 +305,18 @@ class BlueprintTest extends TestCase
         ];
 
         $this->assertEquals($expected, $this->subject->parse($definition));
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_parsing_without_stripping_dashes()
+    {
+        $sequence = [
+            'numbers' => range(3, 11),
+        ];
+
+        $this->assertEquals($sequence, $this->subject->parse($this->subject->dump($sequence), false));
     }
 
     /**


### PR DESCRIPTION
Since the `.blueprint` file uses a simple array (list) to output generated files, the striping of dashes in `Blueprint::parse` returns a string when called by the `erase` command.

This adds an optional flag to disable that behavior so it may be used internally when parsing the `.blueprint` file.

---
Fixes #270