### PR TITLE
Updates for more README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ models:
     title: string:400
     content: longtext
     published_at: nullable timestamp
+    author_id: id:user
 
 controllers:
   Post:
@@ -47,9 +48,9 @@ controllers:
       render: post.index with:posts
 
     store:
-      validate: title, content
+      validate: title, content, author_id
       save: post
-      send: ReviewNotification to:post.author with:post
+      send: ReviewPost to:post.author.email with:post
       dispatch: SyncMedia with:post
       fire: NewPost with:post
       flash: post.title
@@ -64,10 +65,13 @@ From these simple 20 lines of YAML, Blueprint will generate all of the following
 - A _controller_ class for `PostController` with `index` and `store` actions complete with code generated for each [statement](https://blueprint.laravelshift.com/docs/controller-statements/).
 - _Routes_ for the `PostController` actions.
 - A [_form request_](https://laravel.com/docs/validation#form-request-validation) of `StorePostRequest` validating `title` and `content` based on the `Post` model definition.
-- A _mailable_ class for `ReviewNotification` complete with a `post` property set through the _constructor_.
+- A _mailable_ class for `ReviewPost` complete with a `post` property set through the _constructor_.
 - A _job_ class for `SyncMedia` complete with a `post` property set through the _constructor_.
 - An _event_ class for `NewPost` complete with a `post` property set through the _constructor_.
 - A _Blade template_ of `post/index.blade.php` rendered by `PostController@index`.
+
+_**Note:** This example assumes features within a default Laravel application such as the `User` model and `app.blade.php
+ layout. Otherwise, the generated test may have failures._
 
 ## Documentation
 Browse the [Blueprint Docs](https://blueprint.laravelshift.com/) for full details on [defining models](https://blueprint.laravelshift.com/docs/defining-models/), [defining controllers](https://blueprint.laravelshift.com/docs/defining-controllers/), [advanced configuration](https://blueprint.laravelshift.com/docs/advanced-configuration/), and [extending Blueprint](https://blueprint.laravelshift.com/docs/extending-blueprint/).

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -20,8 +20,9 @@ class Rules
             array_push($rules, self::overrideStringRuleForSpecialNames($column->name()));
         }
 
-        if ($column->dataType() === 'id' && Str::endsWith($column->name(), '_id')) {
-            $rules = array_merge($rules, ['integer', 'exists:' . Str::plural(Str::beforeLast($column->name(), '_id')) . ',id']);
+        if ($column->dataType() === 'id' && ($column->attributes() || Str::endsWith($column->name(), '_id'))) {
+            $reference = $column->attributes()[0] ?? Str::beforeLast($column->name(), '_id');
+            $rules = array_merge($rules, ['integer', 'exists:' . Str::plural($reference) . ',id']);
         }
 
         if (in_array($column->dataType(), [

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -208,18 +208,19 @@ class BlueprintTest extends TestCase
                     'title' => 'string:400',
                     'content' => 'longtext',
                     'published_at' => 'nullable timestamp',
+                    'author_id' => 'id:user',
                 ],
             ],
             'controllers' => [
                 'Post' => [
                     'index' => [
-                        'query' => 'all:posts',
+                        'query' => 'all',
                         'render' => 'post.index with:posts',
                     ],
                     'store' => [
-                        'validate' => 'title, content',
+                        'validate' => 'title, content, author_id',
                         'save' => 'post',
-                        'send' => 'ReviewMail to:post.author with:post',
+                        'send' => 'ReviewPost to:post.author.email with:post',
                         'dispatch' => 'SyncMedia with:post',
                         'fire' => 'NewPost with:post',
                         'flash' => 'post.title',
@@ -250,18 +251,19 @@ class BlueprintTest extends TestCase
                     'title' => 'string:400',
                     'content' => 'longtext',
                     'published_at' => 'nullable timestamp',
+                    'author_id' => 'id:user',
                 ],
             ],
             'controllers' => [
                 'Post' => [
                     'index' => [
-                        'query' => 'all:posts',
+                        'query' => 'all',
                         'render' => 'post.index with:posts',
                     ],
                     'store' => [
-                        'validate' => 'title, content',
+                        'validate' => 'title, content, author_id',
                         'save' => 'post',
-                        'send' => 'ReviewMail to:post.author with:post',
+                        'send' => 'ReviewPost to:post.author.email with:post',
                         'dispatch' => 'SyncMedia with:post',
                         'fire' => 'NewPost with:post',
                         'flash' => 'post.title',

--- a/tests/Feature/Generator/Statements/MailGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/MailGeneratorTest.php
@@ -137,16 +137,16 @@ class MailGeneratorTest extends TestCase
             ->with('src/path/Mail')
             ->andReturnFalse();
         $this->files->expects('exists')
-            ->with('src/path/Mail/ReviewMail.php')
+            ->with('src/path/Mail/ReviewPost.php')
             ->andReturnFalse();
         $this->files->expects('makeDirectory')
             ->with('src/path/Mail', 0755, true);
         $this->files->expects('put')
-            ->with('src/path/Mail/ReviewMail.php', $this->fixture('mailables/mail-configured.php'));
+            ->with('src/path/Mail/ReviewPost.php', $this->fixture('mailables/mail-configured.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/readme-example.yaml'));
         $tree = $this->blueprint->analyze($tokens);
 
-        $this->assertEquals(['created' => ['src/path/Mail/ReviewMail.php']], $this->subject->output($tree));
+        $this->assertEquals(['created' => ['src/path/Mail/ReviewPost.php']], $this->subject->output($tree));
     }
 }

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -155,7 +155,7 @@ class StatementLexerTest extends TestCase
     public function it_returns_a_send_statement()
     {
         $tokens = [
-            'send' => 'ReviewMail'
+            'send' => 'ReviewPost'
         ];
 
         $actual = $this->subject->analyze($tokens);
@@ -163,7 +163,7 @@ class StatementLexerTest extends TestCase
         $this->assertCount(1, $actual);
         $this->assertInstanceOf(SendStatement::class, $actual[0]);
 
-        $this->assertEquals('ReviewMail', $actual[0]->mail());
+        $this->assertEquals('ReviewPost', $actual[0]->mail());
         $this->assertNull($actual[0]->to());
         $this->assertSame([], $actual[0]->data());
     }
@@ -174,7 +174,7 @@ class StatementLexerTest extends TestCase
     public function it_returns_a_send_statement_to_only()
     {
         $tokens = [
-            'send' => 'ReviewMail to:post.author'
+            'send' => 'ReviewPost to:post.author'
         ];
 
         $actual = $this->subject->analyze($tokens);
@@ -182,7 +182,7 @@ class StatementLexerTest extends TestCase
         $this->assertCount(1, $actual);
         $this->assertInstanceOf(SendStatement::class, $actual[0]);
 
-        $this->assertEquals('ReviewMail', $actual[0]->mail());
+        $this->assertEquals('ReviewPost', $actual[0]->mail());
         $this->assertEquals('post.author', $actual[0]->to());
         $this->assertSame([], $actual[0]->data());
     }
@@ -193,7 +193,7 @@ class StatementLexerTest extends TestCase
     public function it_returns_a_send_statement_with_only()
     {
         $tokens = [
-            'send' => 'ReviewMail with:foo, bar, baz'
+            'send' => 'ReviewPost with:foo, bar, baz'
         ];
 
         $actual = $this->subject->analyze($tokens);
@@ -201,7 +201,7 @@ class StatementLexerTest extends TestCase
         $this->assertCount(1, $actual);
         $this->assertInstanceOf(SendStatement::class, $actual[0]);
 
-        $this->assertEquals('ReviewMail', $actual[0]->mail());
+        $this->assertEquals('ReviewPost', $actual[0]->mail());
         $this->assertNull($actual[0]->to());
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
     }
@@ -212,7 +212,7 @@ class StatementLexerTest extends TestCase
     public function it_returns_a_send_statement_to_and_with()
     {
         $tokens = [
-            'send' => 'ReviewMail to:post.author with:foo, bar, baz'
+            'send' => 'ReviewPost to:post.author with:foo, bar, baz'
         ];
 
         $actual = $this->subject->analyze($tokens);
@@ -220,7 +220,7 @@ class StatementLexerTest extends TestCase
         $this->assertCount(1, $actual);
         $this->assertInstanceOf(SendStatement::class, $actual[0]);
 
-        $this->assertEquals('ReviewMail', $actual[0]->mail());
+        $this->assertEquals('ReviewPost', $actual[0]->mail());
         $this->assertEquals('post.author', $actual[0]->to());
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
     }

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -98,6 +98,36 @@ class RulesTest extends TestCase
 
     /**
      * @test
+     */
+    public function forColumn_return_exists_rule_for_id_column()
+    {
+        $column = new Column('user_id', 'id');
+
+        $this->assertContains('exists:users,id', Rules::fromColumn('context', $column));
+    }
+
+    /**
+     * @test
+     */
+    public function forColumn_return_exists_rule_id_column_with_attribute()
+    {
+        $column = new Column('author_id', 'id', [], ['user']);
+
+        $this->assertContains('exists:users,id', Rules::fromColumn('context', $column));
+    }
+
+    /**
+     * @test
+     */
+    public function forColumn_return_exists_rule_for_the_unique_modifier()
+    {
+        $column = new Column('column', 'string', ['unique']);
+
+        $this->assertContains('unique:connection.table,column', Rules::fromColumn('connection.table', $column));
+    }
+
+    /**
+     * @test
      * @dataProvider relationshipColumnProvider
      */
     public function forColumn_returns_exists_rule_for_foreign_keys($name, $table)
@@ -146,16 +176,6 @@ class RulesTest extends TestCase
         $column = new Column('test', $data_type);
 
         $this->assertContains('date', Rules::fromColumn('context', $column));
-    }
-
-    /**
-     * @test
-     */
-    public function forColumn_return_exists_rule_for_the_unique_modifier()
-    {
-        $column = new Column('column', 'string', ['unique']);
-
-        $this->assertContains('unique:connection.table,column', Rules::fromColumn('connection.table', $column));
     }
 
     /**

--- a/tests/fixtures/controllers/readme-example.php
+++ b/tests/fixtures/controllers/readme-example.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use App\Events\NewPost;
 use App\Http\Requests\PostStoreRequest;
 use App\Jobs\SyncMedia;
-use App\Mail\ReviewMail;
+use App\Mail\ReviewPost;
 use App\Post;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
@@ -31,7 +31,7 @@ class PostController extends Controller
     {
         $post = Post::create($request->all());
 
-        Mail::to($post->author)->send(new ReviewMail($post));
+        Mail::to($post->author->email)->send(new ReviewPost($post));
 
         SyncMedia::dispatch($post);
 

--- a/tests/fixtures/drafts/readme-example.yaml
+++ b/tests/fixtures/drafts/readme-example.yaml
@@ -3,17 +3,18 @@ models:
     title: string:400
     content: longtext
     published_at: nullable timestamp
+    author_id: id:user
 
 controllers:
   Post:
     index:
-      query: all:posts
+      query: all
       render: post.index with:posts
 
     store:
-      validate: title, content
+      validate: title, content, author_id
       save: post
-      send: ReviewMail to:post.author with:post
+      send: ReviewPost to:post.author.email with:post
       dispatch: SyncMedia with:post
       fire: NewPost with:post
       flash: post.title

--- a/tests/fixtures/factories/fake-nullables.php
+++ b/tests/fixtures/factories/fake-nullables.php
@@ -9,5 +9,6 @@ $factory->define(Post::class, function (Faker $faker) {
     return [
         'title' => $faker->sentence(4),
         'content' => $faker->paragraphs(3, true),
+        'author_id' => factory(\App\User::class),
     ];
 });

--- a/tests/fixtures/form-requests/form-request-configured.php
+++ b/tests/fixtures/form-requests/form-request-configured.php
@@ -26,6 +26,7 @@ class PostStoreRequest extends FormRequest
         return [
             'title' => 'required|string|max:400',
             'content' => 'required|string',
+            'author_id' => 'required|integer|exists:users,id',
         ];
     }
 }

--- a/tests/fixtures/mailables/mail-configured.php
+++ b/tests/fixtures/mailables/mail-configured.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 
-class ReviewMail extends Mailable
+class ReviewPost extends Mailable
 {
     use Queueable, SerializesModels;
 

--- a/tests/fixtures/migrations/readme-example.php
+++ b/tests/fixtures/migrations/readme-example.php
@@ -18,6 +18,7 @@ class CreatePostsTable extends Migration
             $table->string('title', 400);
             $table->longText('content');
             $table->timestamp('published_at')->nullable();
+            $table->unsignedBigInteger('author_id');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/models/readme-example-phpdoc.php
+++ b/tests/fixtures/models/readme-example-phpdoc.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $title
  * @property string $content
  * @property \Carbon\Carbon $published_at
+ * @property int $author_id
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  */
@@ -23,6 +24,7 @@ class Post extends Model
         'title',
         'content',
         'published_at',
+        'author_id',
     ];
 
     /**
@@ -32,6 +34,7 @@ class Post extends Model
      */
     protected $casts = [
         'id' => 'integer',
+        'author_id' => 'integer',
     ];
 
     /**
@@ -42,4 +45,13 @@ class Post extends Model
     protected $dates = [
         'published_at',
     ];
+
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function author()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
 }

--- a/tests/fixtures/models/readme-example.php
+++ b/tests/fixtures/models/readme-example.php
@@ -15,6 +15,7 @@ class Post extends Model
         'title',
         'content',
         'published_at',
+        'author_id',
     ];
 
     /**
@@ -24,6 +25,7 @@ class Post extends Model
      */
     protected $casts = [
         'id' => 'integer',
+        'author_id' => 'integer',
     ];
 
     /**
@@ -34,4 +36,10 @@ class Post extends Model
     protected $dates = [
         'published_at',
     ];
+
+
+    public function author()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
 }


### PR DESCRIPTION
This corrects the example in the `README` to properly generate an `author` relationship on the `Post` model.

In doing so this revealed a few boundary cases, including the generated code for the `exists` validation rule when the `id` attribute is set. As well as incorrect setup for the test case.

Also found a bug for the generated assertions when using a Notification. I have opened a new issue for that in #274.

---
Fixes #248