### PR TITLE
Fix #247: Implements blueprint:build --only and --skip

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -38,19 +38,19 @@ class Blueprint
         }
 
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)$/mi', function ($matches) {
-            return $matches[1].strtolower($matches[2]).': '.$matches[2];
+            return $matches[1] . strtolower($matches[2]) . ': ' . $matches[2];
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?): true$/mi', function ($matches) {
-            return $matches[1].strtolower($matches[2]).': '.$matches[2];
+            return $matches[1] . strtolower($matches[2]) . ': ' . $matches[2];
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)resource?$/mi', function ($matches) {
-            return $matches[1].'resource: web';
+            return $matches[1] . 'resource: web';
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)uuid(: true)?$/mi', function ($matches) {
-            return $matches[1].'id: uuid primary';
+            return $matches[1] . 'id: uuid primary';
         }, $content);
 
         return Yaml::parse($content);
@@ -70,12 +70,12 @@ class Blueprint
         return $registry;
     }
 
-    public function generate(array $tree): array
+    public function generate(array $tree, array $only = [], array $skip = []): array
     {
         $components = [];
 
         foreach ($this->generators as $generator) {
-            $components = array_merge_recursive($components, $generator->output($tree));
+            $components = array_merge_recursive($components, $generator->output($tree, $only, $skip));
         }
 
         return $components;

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -14,7 +14,7 @@ class Blueprint
 
     public static function relativeNamespace(string $fullyQualifiedClassName)
     {
-        $namespace = config('blueprint.namespace') . '\\';
+        $namespace = config('blueprint.namespace').'\\';
         $reference = ltrim($fullyQualifiedClassName, '\\');
 
         if (Str::startsWith($reference, $namespace)) {
@@ -38,19 +38,19 @@ class Blueprint
         }
 
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)$/mi', function ($matches) {
-            return $matches[1] . strtolower($matches[2]) . ': ' . $matches[2];
+            return $matches[1].strtolower($matches[2]).': '.$matches[2];
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?): true$/mi', function ($matches) {
-            return $matches[1] . strtolower($matches[2]) . ': ' . $matches[2];
+            return $matches[1].strtolower($matches[2]).': '.$matches[2];
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)resource?$/mi', function ($matches) {
-            return $matches[1] . 'resource: web';
+            return $matches[1].'resource: web';
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)uuid(: true)?$/mi', function ($matches) {
-            return $matches[1] . 'id: uuid primary';
+            return $matches[1].'id: uuid primary';
         }, $content);
 
         return Yaml::parse($content);
@@ -75,7 +75,9 @@ class Blueprint
         $components = [];
 
         foreach ($this->generators as $generator) {
-            $components = array_merge_recursive($components, $generator->output($tree, $only, $skip));
+            if ($this->shouldGenerate($generator->types(), $only, $skip)) {
+                $components = array_merge_recursive($components, $generator->output($tree));
+            }
         }
 
         return $components;
@@ -105,5 +107,28 @@ class Blueprint
         }
 
         $this->registerGenerator($generator);
+    }
+
+    protected function shouldGenerate(array $types, array $only, array $skip): bool
+    {
+        if (count($only)) {
+            $matches = 0;
+            foreach ($types as $type) {
+                $matches += in_array($type, $only) ? 1 : 0;
+            }
+
+            return count($types) === $matches;
+        }
+
+        if (count($skip)) {
+            $matches = 0;
+            foreach ($types as $type) {
+                $matches += in_array($type, $skip) ? 1 : 0;
+            }
+
+            return $matches === 0;
+        }
+
+        return true;
     }
 }

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -112,21 +112,21 @@ class Blueprint
     protected function shouldGenerate(array $types, array $only, array $skip): bool
     {
         if (count($only)) {
-            $matches = 0;
+            $found = 0;
             foreach ($types as $type) {
-                $matches += in_array($type, $only) ? 1 : 0;
+                $found += in_array($type, $only) ? 1 : 0;
             }
 
-            return count($types) === $matches;
+            return $found > 0;
         }
 
         if (count($skip)) {
-            $matches = 0;
+            $found = 0;
             foreach ($types as $type) {
-                $matches += in_array($type, $skip) ? 1 : 0;
+                $found += in_array($type, $skip) ? 1 : 0;
             }
 
-            return $matches === 0;
+            return $found === 0;
         }
 
         return true;

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -6,7 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class Builder
 {
-    public static function execute(Blueprint $blueprint, Filesystem $files, string $draft)
+    public static function execute(Blueprint $blueprint, Filesystem $files, string $draft, string $only = '', string $skip = '')
     {
         $cache = [];
         if ($files->exists('.blueprint')) {
@@ -16,7 +16,11 @@ class Builder
         $tokens = $blueprint->parse($files->get($draft));
         $tokens['cache'] = $cache['models'] ?? [];
         $registry = $blueprint->analyze($tokens);
-        $generated = $blueprint->generate($registry);
+
+        $only = array_filter(explode(',', $only));
+        $skip = array_filter(explode(',', $skip));
+
+        $generated = $blueprint->generate($registry, $only, $skip);
 
         $models = array_merge($tokens['cache'], $tokens['models'] ?? []);
 

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -16,8 +16,10 @@ class BuildCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'blueprint:build 
+    protected $signature = 'blueprint:build
                             {draft? : The path to the draft file, default: draft.yaml or draft.yml }
+                            {--only= : Comma seperated list of file classes to generate, skipping the rest }
+                            {--skip= : Comma seperated list of file classes to skip, generating the rest }
                             ';
 
     /**
@@ -55,7 +57,7 @@ class BuildCommand extends Command
         }
 
         $blueprint = resolve(Blueprint::class);
-        $generated = Builder::execute($blueprint, $this->files, $file);
+        $generated = Builder::execute($blueprint, $this->files, $file, $this->option('only'), $this->option('skip'));
 
         collect($generated)->each(function ($files, $action) {
             $this->line(Str::studly($action) . ':', $this->outputStyle($action));

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -18,8 +18,8 @@ class BuildCommand extends Command
      */
     protected $signature = 'blueprint:build
                             {draft? : The path to the draft file, default: draft.yaml or draft.yml }
-                            {--only= : Comma seperated list of file classes to generate, skipping the rest }
-                            {--skip= : Comma seperated list of file classes to skip, generating the rest }
+                            {--only= : Comma separated list of file classes to generate, skipping the rest }
+                            {--skip= : Comma separated list of file classes to skip, generating the rest }
                             ';
 
     /**
@@ -29,7 +29,7 @@ class BuildCommand extends Command
      */
     protected $description = 'Build components from a Blueprint draft';
 
-    /** @var Filesystem $files */
+    /** @var Filesystem */
     protected $files;
 
     /**
@@ -51,8 +51,8 @@ class BuildCommand extends Command
     {
         $file = $this->argument('draft') ?? $this->defaultDraftFile();
 
-        if (!file_exists($file)) {
-            $this->error('Draft file could not be found: ' . ($file ?: 'draft.yaml'));
+        if (! file_exists($file)) {
+            $this->error('Draft file could not be found: '.($file ?: 'draft.yaml'));
             exit(1);
         }
 
@@ -63,9 +63,9 @@ class BuildCommand extends Command
         $generated = Builder::execute($blueprint, $this->files, $file, $only, $skip);
 
         collect($generated)->each(function ($files, $action) {
-            $this->line(Str::studly($action) . ':', $this->outputStyle($action));
+            $this->line(Str::studly($action).':', $this->outputStyle($action));
             collect($files)->each(function ($file) {
-                $this->line('- ' . $file);
+                $this->line('- '.$file);
             });
 
             $this->line('');
@@ -104,7 +104,5 @@ class BuildCommand extends Command
         if (file_exists('draft.yml')) {
             return 'draft.yml';
         }
-
-        return null;
     }
 }

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -56,8 +56,11 @@ class BuildCommand extends Command
             exit(1);
         }
 
+        $only = $this->option('only') ?: '';
+        $skip = $this->option('skip') ?: '';
+
         $blueprint = resolve(Blueprint::class);
-        $generated = Builder::execute($blueprint, $this->files, $file, $this->option('only'), $this->option('skip'));
+        $generated = Builder::execute($blueprint, $this->files, $file, $only, $skip);
 
         collect($generated)->each(function ($files, $action) {
             $this->line(Str::studly($action) . ':', $this->outputStyle($action));

--- a/src/Contracts/Generator.php
+++ b/src/Contracts/Generator.php
@@ -9,5 +9,7 @@ interface Generator
      */
     public function __construct($files);
 
-    public function output(array $tree, array $only, array $skip): array;
+    public function output(array $tree): array;
+
+    public function types(): array;
 }

--- a/src/Contracts/Generator.php
+++ b/src/Contracts/Generator.php
@@ -9,5 +9,5 @@ interface Generator
      */
     public function __construct($files);
 
-    public function output(array $tree): array;
+    public function output(array $tree, array $only, array $skip): array;
 }

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -4,8 +4,8 @@ namespace Blueprint\Generators;
 
 use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
-use Blueprint\Models\Model;
 use Blueprint\Models\Controller;
+use Blueprint\Models\Model;
 use Blueprint\Models\Statements\DispatchStatement;
 use Blueprint\Models\Statements\EloquentStatement;
 use Blueprint\Models\Statements\FireStatement;
@@ -35,49 +35,39 @@ class ControllerGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $stub = $this->files->stub('controller/class.stub');
+        $stub = $this->files->stub('controller/class.stub');
 
-            $this->registerModels($tree);
+        $this->registerModels($tree);
 
-            /** @var \Blueprint\Models\Controller $controller */
-            foreach ($tree['controllers'] as $controller) {
-                $this->addImport($controller, 'Illuminate\\Http\\Request');
+        /** @var \Blueprint\Models\Controller $controller */
+        foreach ($tree['controllers'] as $controller) {
+            $this->addImport($controller, 'Illuminate\\Http\\Request');
 
-                if ($controller->fullyQualifiedNamespace() !== 'App\\Http\\Controllers') {
-                    $this->addImport($controller, 'App\\Http\\Controllers\\Controller');
-                }
-
-                $path = $this->getPath($controller);
-
-                if (!$this->files->exists(dirname($path))) {
-                    $this->files->makeDirectory(dirname($path), 0755, true);
-                }
-
-                $this->files->put($path, $this->populateStub($stub, $controller));
-
-                $output['created'][] = $path;
+            if ($controller->fullyQualifiedNamespace() !== 'App\\Http\\Controllers') {
+                $this->addImport($controller, 'App\\Http\\Controllers\\Controller');
             }
+
+            $path = $this->getPath($controller);
+
+            if (! $this->files->exists(dirname($path))) {
+                $this->files->makeDirectory(dirname($path), 0755, true);
+            }
+
+            $this->files->put($path, $this->populateStub($stub, $controller));
+
+            $output['created'][] = $path;
         }
 
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('controllers', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('controllers', $skip);
-        }
-
-        return true;
+        return ['controllers'];
     }
 
     protected function populateStub(string $stub, Controller $controller)
@@ -102,82 +92,82 @@ class ControllerGenerator implements Generator
             if (in_array($name, ['edit', 'update', 'show', 'destroy'])) {
                 $context = Str::singular($controller->prefix());
                 $reference = $this->fullyQualifyModelReference($controller->namespace(), Str::camel($context));
-                $variable = '$' . Str::camel($context);
+                $variable = '$'.Str::camel($context);
 
                 // TODO: verify controller prefix references a model
                 $search = '     * @return \\Illuminate\\Http\\Response';
-                $method = str_replace($search, '     * @param \\' . $reference . ' ' . $variable . PHP_EOL . $search, $method);
+                $method = str_replace($search, '     * @param \\'.$reference.' '.$variable.PHP_EOL.$search, $method);
 
                 $search = '(Request $request';
-                $method = str_replace($search, $search . ', ' . $context . ' ' . $variable, $method);
+                $method = str_replace($search, $search.', '.$context.' '.$variable, $method);
                 $this->addImport($controller, $reference);
             }
 
             $body = '';
             foreach ($statements as $statement) {
                 if ($statement instanceof SendStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT.$statement->output().PHP_EOL;
                     if ($statement->type() === SendStatement::TYPE_NOTIFICATION_WITH_FACADE) {
                         $this->addImport($controller, 'Illuminate\\Support\\Facades\\Notification');
-                        $this->addImport($controller, config('blueprint.namespace') . '\\Notification\\' . $statement->mail());
+                        $this->addImport($controller, config('blueprint.namespace').'\\Notification\\'.$statement->mail());
                     } elseif ($statement->type() === SendStatement::TYPE_MAIL) {
                         $this->addImport($controller, 'Illuminate\\Support\\Facades\\Mail');
-                        $this->addImport($controller, config('blueprint.namespace') . '\\Mail\\' . $statement->mail());
+                        $this->addImport($controller, config('blueprint.namespace').'\\Mail\\'.$statement->mail());
                     }
                 } elseif ($statement instanceof ValidateStatement) {
-                    $class_name = $controller->name() . Str::studly($name) . 'Request';
+                    $class_name = $controller->name().Str::studly($name).'Request';
 
-                    $fqcn = config('blueprint.namespace') . '\\Http\\Requests\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $class_name;
+                    $fqcn = config('blueprint.namespace').'\\Http\\Requests\\'.($controller->namespace() ? $controller->namespace().'\\' : '').$class_name;
 
-                    $method = str_replace('\Illuminate\Http\Request $request', '\\' . $fqcn . ' $request', $method);
-                    $method = str_replace('(Request $request', '(' . $class_name . ' $request', $method);
+                    $method = str_replace('\Illuminate\Http\Request $request', '\\'.$fqcn.' $request', $method);
+                    $method = str_replace('(Request $request', '('.$class_name.' $request', $method);
 
                     $this->addImport($controller, $fqcn);
                 } elseif ($statement instanceof DispatchStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
-                    $this->addImport($controller, config('blueprint.namespace') . '\\Jobs\\' . $statement->job());
+                    $body .= self::INDENT.$statement->output().PHP_EOL;
+                    $this->addImport($controller, config('blueprint.namespace').'\\Jobs\\'.$statement->job());
                 } elseif ($statement instanceof FireStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
-                    if (!$statement->isNamedEvent()) {
-                        $this->addImport($controller, config('blueprint.namespace') . '\\Events\\' . $statement->event());
+                    $body .= self::INDENT.$statement->output().PHP_EOL;
+                    if (! $statement->isNamedEvent()) {
+                        $this->addImport($controller, config('blueprint.namespace').'\\Events\\'.$statement->event());
                     }
                 } elseif ($statement instanceof RenderStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT.$statement->output().PHP_EOL;
                 } elseif ($statement instanceof ResourceStatement) {
-                    $fqcn = config('blueprint.namespace') . '\\Http\\Resources\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $statement->name();
+                    $fqcn = config('blueprint.namespace').'\\Http\\Resources\\'.($controller->namespace() ? $controller->namespace().'\\' : '').$statement->name();
 
-                    $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return \\' . $fqcn, $method);
+                    $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return \\'.$fqcn, $method);
 
                     $import = $fqcn;
-                    if (!$statement->collection()) {
-                        $import .= ' as ' . $statement->name() . 'Resource';
+                    if (! $statement->collection()) {
+                        $import .= ' as '.$statement->name().'Resource';
                     }
 
                     $this->addImport($controller, $import);
 
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT.$statement->output().PHP_EOL;
                 } elseif ($statement instanceof RedirectStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT.$statement->output().PHP_EOL;
                 } elseif ($statement instanceof RespondStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT.$statement->output().PHP_EOL;
                 } elseif ($statement instanceof SessionStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT.$statement->output().PHP_EOL;
                 } elseif ($statement instanceof EloquentStatement) {
-                    $body .= self::INDENT . $statement->output($controller->prefix(), $name) . PHP_EOL;
+                    $body .= self::INDENT.$statement->output($controller->prefix(), $name).PHP_EOL;
                     $this->addImport($controller, $this->determineModel($controller, $statement->reference()));
                 } elseif ($statement instanceof QueryStatement) {
-                    $body .= self::INDENT . $statement->output($controller->prefix()) . PHP_EOL;
+                    $body .= self::INDENT.$statement->output($controller->prefix()).PHP_EOL;
                     $this->addImport($controller, $this->determineModel($controller, $statement->model()));
                 }
 
                 $body .= PHP_EOL;
             }
 
-            if (!empty($body)) {
+            if (! empty($body)) {
                 $method = str_replace('//', trim($body), $method);
             }
 
-            $methods .= PHP_EOL . $method;
+            $methods .= PHP_EOL.$method;
         }
 
         return trim($methods);
@@ -187,7 +177,7 @@ class ControllerGenerator implements Generator
     {
         $path = str_replace('\\', '/', Blueprint::relativeNamespace($controller->fullyQualifiedClassName()));
 
-        return Blueprint::appPath() . '/' . $path . '.php';
+        return Blueprint::appPath().'/'.$path.'.php';
     }
 
     private function addImport(Controller $controller, $class)
@@ -201,7 +191,7 @@ class ControllerGenerator implements Generator
         sort($imports);
 
         return implode(PHP_EOL, array_map(function ($class) {
-            return 'use ' . $class . ';';
+            return 'use '.$class.';';
         }, $imports));
     }
 
@@ -231,7 +221,7 @@ class ControllerGenerator implements Generator
             return $model->fullyQualifiedClassName();
         }
 
-        return config('blueprint.namespace') . '\\' . ($sub_namespace ? $sub_namespace . '\\' : '') . $model_name;
+        return config('blueprint.namespace').'\\'.($sub_namespace ? $sub_namespace.'\\' : '').$model_name;
     }
 
     private function modelForContext(string $context)
@@ -241,7 +231,7 @@ class ControllerGenerator implements Generator
         }
 
         $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/' . Str::studly($context));
+            return Str::endsWith($key, '/'.Str::studly($context));
         });
 
         if (count($matches) === 1) {

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -35,34 +35,49 @@ class ControllerGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(array $tree, array $only = [], array $skip = []): array
     {
         $output = [];
 
-        $stub = $this->files->stub('controller/class.stub');
+        if ($this->shouldGenerate($only, $skip)) {
+            $stub = $this->files->stub('controller/class.stub');
 
-        $this->registerModels($tree);
+            $this->registerModels($tree);
 
-        /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
-            $this->addImport($controller, 'Illuminate\\Http\\Request');
+            /** @var \Blueprint\Models\Controller $controller */
+            foreach ($tree['controllers'] as $controller) {
+                $this->addImport($controller, 'Illuminate\\Http\\Request');
 
-            if ($controller->fullyQualifiedNamespace() !== 'App\\Http\\Controllers') {
-                $this->addImport($controller, 'App\\Http\\Controllers\\Controller');
+                if ($controller->fullyQualifiedNamespace() !== 'App\\Http\\Controllers') {
+                    $this->addImport($controller, 'App\\Http\\Controllers\\Controller');
+                }
+
+                $path = $this->getPath($controller);
+
+                if (!$this->files->exists(dirname($path))) {
+                    $this->files->makeDirectory(dirname($path), 0755, true);
+                }
+
+                $this->files->put($path, $this->populateStub($stub, $controller));
+
+                $output['created'][] = $path;
             }
-
-            $path = $this->getPath($controller);
-
-            if (!$this->files->exists(dirname($path))) {
-                $this->files->makeDirectory(dirname($path), 0755, true);
-            }
-
-            $this->files->put($path, $this->populateStub($stub, $controller));
-
-            $output['created'][] = $path;
         }
 
         return $output;
+    }
+
+    protected function shouldGenerate(array $only, array $skip): bool
+    {
+        if (count($only)) {
+            return in_array('controllers', $only);
+        }
+
+        if (count($skip)) {
+            return !in_array('controllers', $skip);
+        }
+
+        return true;
     }
 
     protected function populateStub(string $stub, Controller $controller)
@@ -226,7 +241,7 @@ class ControllerGenerator implements Generator
         }
 
         $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/'.Str::studly($context));
+            return Str::endsWith($key, '/' . Str::studly($context));
         });
 
         if (count($matches) === 1) {

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -21,54 +21,44 @@ class FactoryGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $stub = $this->files->stub('factory.stub');
+        $stub = $this->files->stub('factory.stub');
 
-            /** @var \Blueprint\Models\Model $model */
-            foreach ($tree['models'] as $model) {
-                $this->addImport($model, 'Faker\Generator as Faker');
-                $this->addImport($model, $model->fullyQualifiedClassName());
+        /** @var \Blueprint\Models\Model $model */
+        foreach ($tree['models'] as $model) {
+            $this->addImport($model, 'Faker\Generator as Faker');
+            $this->addImport($model, $model->fullyQualifiedClassName());
 
-                $path = $this->getPath($model);
+            $path = $this->getPath($model);
 
-                if (!$this->files->exists(dirname($path))) {
-                    $this->files->makeDirectory(dirname($path), 0755, true);
-                }
-
-                $this->files->put($path, $this->populateStub($stub, $model));
-
-                $output['created'][] = $path;
+            if (! $this->files->exists(dirname($path))) {
+                $this->files->makeDirectory(dirname($path), 0755, true);
             }
+
+            $this->files->put($path, $this->populateStub($stub, $model));
+
+            $output['created'][] = $path;
         }
 
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('factories', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('factories', $skip);
-        }
-
-        return true;
+        return ['factories'];
     }
 
     protected function getPath(Model $model)
     {
         $path = $model->name();
         if ($model->namespace()) {
-            $path = str_replace('\\', '/', $model->namespace()) . '/' . $path;
+            $path = str_replace('\\', '/', $model->namespace()).'/'.$path;
         }
 
-        return 'database/factories/' . $path . 'Factory.php';
+        return 'database/factories/'.$path.'Factory.php';
     }
 
     protected function populateStub(string $stub, Model $model)
@@ -106,11 +96,11 @@ class FactoryGenerator implements Generator
                 } elseif ($foreign !== 'foreign') {
                     $table = $foreign;
 
-                    if (Str::startsWith($column->name(), $foreign . '_')) {
-                        $key = Str::after($column->name(), $foreign . '_');
-                    } elseif (Str::startsWith($column->name(), Str::snake(Str::singular($foreign)) . '_')) {
-                        $key = Str::after($column->name(), Str::snake(Str::singular($foreign)) . '_');
-                    } elseif (!Str::endsWith($column->name(), '_id')) {
+                    if (Str::startsWith($column->name(), $foreign.'_')) {
+                        $key = Str::after($column->name(), $foreign.'_');
+                    } elseif (Str::startsWith($column->name(), Str::snake(Str::singular($foreign)).'_')) {
+                        $key = Str::after($column->name(), Str::snake(Str::singular($foreign)).'_');
+                    } elseif (! Str::endsWith($column->name(), '_id')) {
                         $key = $column->name();
                     }
                 }
@@ -118,50 +108,50 @@ class FactoryGenerator implements Generator
                 $class = Str::studly(Str::singular($table));
 
                 if ($key === 'id') {
-                    $definition .= self::INDENT . "'{$column->name()}' => ";
-                    $definition .= sprintf('factory(%s::class)', '\\' . $model->fullyQualifiedNamespace() . '\\' . $class);
-                    $definition .= ',' . PHP_EOL;
+                    $definition .= self::INDENT."'{$column->name()}' => ";
+                    $definition .= sprintf('factory(%s::class)', '\\'.$model->fullyQualifiedNamespace().'\\'.$class);
+                    $definition .= ','.PHP_EOL;
                 } else {
-                    $definition .= self::INDENT . "'{$column->name()}' => function () {";
+                    $definition .= self::INDENT."'{$column->name()}' => function () {";
                     $definition .= PHP_EOL;
-                    $definition .= self::INDENT . '    ' . sprintf('return factory(%s::class)->create()->%s;', '\\' . $model->fullyQualifiedNamespace() . '\\' . $class, $key);
+                    $definition .= self::INDENT.'    '.sprintf('return factory(%s::class)->create()->%s;', '\\'.$model->fullyQualifiedNamespace().'\\'.$class, $key);
                     $definition .= PHP_EOL;
-                    $definition .= self::INDENT . '},' . PHP_EOL;
+                    $definition .= self::INDENT.'},'.PHP_EOL;
                 }
             } elseif ($column->dataType() === 'id' || ($column->dataType() === 'uuid' && Str::endsWith($column->name(), '_id'))) {
                 $name = Str::beforeLast($column->name(), '_id');
                 $class = Str::studly($column->attributes()[0] ?? $name);
 
-                $definition .= self::INDENT . "'{$column->name()}' => ";
-                $definition .= sprintf('factory(%s::class)', '\\' . $model->fullyQualifiedNamespace() . '\\' . $class);
-                $definition .= ',' . PHP_EOL;
-            } elseif (in_array($column->dataType(), ['enum', 'set']) && !empty($column->attributes())) {
-                $definition .= self::INDENT . "'{$column->name()}' => ";
+                $definition .= self::INDENT."'{$column->name()}' => ";
+                $definition .= sprintf('factory(%s::class)', '\\'.$model->fullyQualifiedNamespace().'\\'.$class);
+                $definition .= ','.PHP_EOL;
+            } elseif (in_array($column->dataType(), ['enum', 'set']) && ! empty($column->attributes())) {
+                $definition .= self::INDENT."'{$column->name()}' => ";
                 $faker = $this->fakerData($column->name()) ?? $this->fakerDataType($column->dataType());
-                $definition .= '$faker->' . $faker;
-                $definition .= ',' . PHP_EOL;
+                $definition .= '$faker->'.$faker;
+                $definition .= ','.PHP_EOL;
                 $definition = str_replace(
                     "/** {$column->dataType()}_attributes **/",
                     json_encode($column->attributes()),
                     $definition
                 );
             } elseif (in_array($column->dataType(), ['decimal', 'double', 'float'])) {
-                $definition .= self::INDENT . "'{$column->name()}' => ";
+                $definition .= self::INDENT."'{$column->name()}' => ";
                 $faker = $this->fakerData($column->name()) ?? $this->fakerDataType($column->dataType());
-                $definition .= '$faker->' . $faker;
-                $definition .= ',' . PHP_EOL;
+                $definition .= '$faker->'.$faker;
+                $definition .= ','.PHP_EOL;
 
                 $precision = min([65, intval($column->attributes()[0] ?? 10)]);
                 $scale = min([30, max([0, intval($column->attributes()[1] ?? 0)])]);
 
                 $definition = str_replace(
                     "/** {$column->dataType()}_attributes **/",
-                    implode(', ', [$scale, 0, (str_repeat(9, $precision - $scale) . '.' . str_repeat(9, $scale))]),
+                    implode(', ', [$scale, 0, (str_repeat(9, $precision - $scale).'.'.str_repeat(9, $scale))]),
                     $definition
                 );
             } elseif (in_array($column->dataType(), ['json', 'jsonb'])) {
                 $default = $column->defaultValue() ?? "'{}'";
-                $definition .= self::INDENT . "'{$column->name()}' => {$default}," . PHP_EOL;
+                $definition .= self::INDENT."'{$column->name()}' => {$default},".PHP_EOL;
             } elseif ($column->dataType() === 'morphs') {
                 if ($column->isNullable()) {
                     continue;
@@ -170,15 +160,15 @@ class FactoryGenerator implements Generator
                 $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_type'", self::fakerDataType('string'), PHP_EOL);
             } elseif ($column->dataType() === 'rememberToken') {
                 $this->addImport($model, 'Illuminate\Support\Str');
-                $definition .= self::INDENT . "'{$column->name()}' => ";
+                $definition .= self::INDENT."'{$column->name()}' => ";
                 $definition .= 'Str::random(10)';
-                $definition .= ',' . PHP_EOL;
+                $definition .= ','.PHP_EOL;
             } else {
-                $definition .= self::INDENT . "'{$column->name()}' => ";
+                $definition .= self::INDENT."'{$column->name()}' => ";
 
                 $type = $column->dataType();
                 if ($column->isUnsigned()) {
-                    $type = 'unsigned' . $type;
+                    $type = 'unsigned'.$type;
                 }
 
                 $faker = self::fakerData($column->name()) ?? (self::fakerDataType($type) ?? self::fakerDataType($column->dataType()));
@@ -187,8 +177,8 @@ class FactoryGenerator implements Generator
                     $faker = 'word';
                 }
 
-                $definition .= '$faker->' . $faker;
-                $definition .= ',' . PHP_EOL;
+                $definition .= '$faker->'.$faker;
+                $definition .= ','.PHP_EOL;
             }
         }
 
@@ -206,7 +196,7 @@ class FactoryGenerator implements Generator
         sort($imports);
 
         return implode(PHP_EOL, array_map(function ($class) {
-            return 'use ' . $class . ';';
+            return 'use '.$class.';';
         }, $imports));
     }
 
@@ -217,7 +207,7 @@ class FactoryGenerator implements Generator
         }
 
         return array_filter($columns, function (Column $column) {
-            return !in_array('nullable', $column->modifiers());
+            return ! in_array('nullable', $column->modifiers());
         });
     }
 

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -41,54 +41,44 @@ class MigrationGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $created_pivot_tables = [];
+        $created_pivot_tables = [];
 
-            $stub = $this->files->stub('migration.stub');
+        $stub = $this->files->stub('migration.stub');
 
-            $sequential_timestamp = \Carbon\Carbon::now()->subSeconds(count($tree['models']));
+        $sequential_timestamp = \Carbon\Carbon::now()->subSeconds(count($tree['models']));
 
-            /** @var \Blueprint\Models\Model $model */
-            foreach ($tree['models'] as $model) {
-                $path = $this->getPath($model, $sequential_timestamp->addSecond());
-                $this->files->put($path, $this->populateStub($stub, $model));
+        /** @var \Blueprint\Models\Model $model */
+        foreach ($tree['models'] as $model) {
+            $path = $this->getPath($model, $sequential_timestamp->addSecond());
+            $this->files->put($path, $this->populateStub($stub, $model));
 
-                $output['created'][] = $path;
+            $output['created'][] = $path;
 
-                if (!empty($model->pivotTables())) {
-                    foreach ($model->pivotTables() as $pivotSegments) {
-                        $pivotTable = $this->getPivotTableName($pivotSegments);
-                        $created_pivot_tables[$pivotTable] = $pivotSegments;
-                    }
+            if (! empty($model->pivotTables())) {
+                foreach ($model->pivotTables() as $pivotSegments) {
+                    $pivotTable = $this->getPivotTableName($pivotSegments);
+                    $created_pivot_tables[$pivotTable] = $pivotSegments;
                 }
             }
+        }
 
-            foreach ($created_pivot_tables as $pivotTable => $pivotSegments) {
-                $path = $this->getPivotTablePath($pivotTable, $sequential_timestamp);
-                $this->files->put($path, $this->populatePivotStub($stub, $pivotSegments));
-                $created_pivot_tables[] = $pivotTable;
-                $output['created'][] = $path;
-            }
+        foreach ($created_pivot_tables as $pivotTable => $pivotSegments) {
+            $path = $this->getPivotTablePath($pivotTable, $sequential_timestamp);
+            $this->files->put($path, $this->populatePivotStub($stub, $pivotSegments));
+            $created_pivot_tables[] = $pivotTable;
+            $output['created'][] = $path;
         }
 
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('migrations', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('migrations', $skip);
-        }
-
-        return true;
+        return ['migrations'];
     }
 
     protected function populateStub(string $stub, Model $model)
@@ -124,11 +114,11 @@ class MigrationGenerator implements Generator
             }
 
             if (in_array($dataType, self::UNSIGNABLE_TYPES) && in_array('unsigned', $column->modifiers())) {
-                $dataType = 'unsigned' . ucfirst($dataType);
+                $dataType = 'unsigned'.ucfirst($dataType);
             }
 
             if (in_array($dataType, self::NULLABLE_TYPES) && $column->isNullable()) {
-                $dataType = 'nullable' . ucfirst($dataType);
+                $dataType = 'nullable'.ucfirst($dataType);
             }
 
             $column_definition = self::INDENT;
@@ -137,10 +127,10 @@ class MigrationGenerator implements Generator
             } elseif ($dataType === 'rememberToken') {
                 $column_definition .= '$table->rememberToken(';
             } else {
-                $column_definition .= '$table->' . $dataType . "('{$column->name()}'";
+                $column_definition .= '$table->'.$dataType."('{$column->name()}'";
             }
 
-            if (!empty($column->attributes()) && !in_array($column->dataType(), ['id', 'uuid'])) {
+            if (! empty($column->attributes()) && ! in_array($column->dataType(), ['id', 'uuid'])) {
                 $column_definition .= ', ';
                 if (in_array($column->dataType(), ['set', 'enum'])) {
                     $column_definition .= json_encode($column->attributes());
@@ -171,45 +161,44 @@ class MigrationGenerator implements Generator
 
                 // TODO: unset the proper modifier
                 $modifiers = collect($modifiers)->reject(function ($modifier) {
-                    return (
-                        (is_array($modifier) && key($modifier) === 'foreign')
+                    return (is_array($modifier) && key($modifier) === 'foreign')
                         || (is_array($modifier) && key($modifier) === 'onDelete')
                         || $modifier === 'foreign'
-                        || ($modifier === 'nullable' && $this->isLaravel7orNewer()));
+                        || ($modifier === 'nullable' && $this->isLaravel7orNewer());
                 });
             }
 
             foreach ($modifiers as $modifier) {
                 if (is_array($modifier)) {
-                    $column_definition .= '->' . key($modifier) . '(' . current($modifier) . ')';
+                    $column_definition .= '->'.key($modifier).'('.current($modifier).')';
                 } elseif ($modifier === 'unsigned' && Str::startsWith($dataType, 'unsigned')) {
                     continue;
                 } elseif ($modifier === 'nullable' && Str::startsWith($dataType, 'nullable')) {
                     continue;
                 } else {
-                    $column_definition .= '->' . $modifier . '()';
+                    $column_definition .= '->'.$modifier.'()';
                 }
             }
 
-            $column_definition .= ';' . PHP_EOL;
-            if (!empty($foreign)) {
-                $column_definition .= $foreign . ';' . PHP_EOL;
+            $column_definition .= ';'.PHP_EOL;
+            if (! empty($foreign)) {
+                $column_definition .= $foreign.';'.PHP_EOL;
             }
 
             $definition .= $column_definition;
         }
 
         if ($model->usesSoftDeletes()) {
-            $definition .= self::INDENT . '$table->' . $model->softDeletesDataType() . '();' . PHP_EOL;
+            $definition .= self::INDENT.'$table->'.$model->softDeletesDataType().'();'.PHP_EOL;
         }
 
         if ($model->morphTo()) {
-            $definition .= self::INDENT . sprintf('$table->unsignedBigInteger(\'%s\');', Str::lower($model->morphTo() . "_id")) . PHP_EOL;
-            $definition .= self::INDENT . sprintf('$table->string(\'%s\');', Str::lower($model->morphTo() . "_type")) . PHP_EOL;
+            $definition .= self::INDENT.sprintf('$table->unsignedBigInteger(\'%s\');', Str::lower($model->morphTo().'_id')).PHP_EOL;
+            $definition .= self::INDENT.sprintf('$table->string(\'%s\');', Str::lower($model->morphTo().'_type')).PHP_EOL;
         }
 
         if ($model->usesTimestamps()) {
-            $definition .= self::INDENT . '$table->' . $model->timestampsDataType() . '();' . PHP_EOL;
+            $definition .= self::INDENT.'$table->'.$model->timestampsDataType().'();'.PHP_EOL;
         }
 
         return trim($definition);
@@ -223,16 +212,16 @@ class MigrationGenerator implements Generator
             $column = Str::before(Str::lower($segment), ':');
             $references = 'id';
             $on = Str::plural($column);
-            $foreign = Str::singular($column) . '_' . $references;
+            $foreign = Str::singular($column).'_'.$references;
 
-            if (!$this->isLaravel7orNewer()) {
-                $definition .= self::INDENT . '$table->unsignedBigInteger(\'' . $foreign . '\');' . PHP_EOL;
+            if (! $this->isLaravel7orNewer()) {
+                $definition .= self::INDENT.'$table->unsignedBigInteger(\''.$foreign.'\');'.PHP_EOL;
             }
 
             if (config('blueprint.use_constraints')) {
-                $definition .= $this->buildForeignKey($foreign, $on, 'id') . ';' . PHP_EOL;
+                $definition .= $this->buildForeignKey($foreign, $on, 'id').';'.PHP_EOL;
             } elseif ($this->isLaravel7orNewer()) {
-                $definition .= self::INDENT . '$table->foreignId(\'' . $foreign . '\');' . PHP_EOL;
+                $definition .= self::INDENT.'$table->foreignId(\''.$foreign.'\');'.PHP_EOL;
             }
         }
 
@@ -252,7 +241,7 @@ class MigrationGenerator implements Generator
             $column = Str::afterLast($column_name, '_');
         }
 
-        if ($type === 'id' && !empty($attributes)) {
+        if ($type === 'id' && ! empty($attributes)) {
             $table = Str::lower(Str::plural($attributes[0]));
         }
 
@@ -262,38 +251,38 @@ class MigrationGenerator implements Generator
 
         if ($this->isLaravel7orNewer() && $type === 'id') {
             $prefix = in_array('nullable', $modifiers)
-                ? '$table->foreignId' . "('{$column_name}')->nullable()"
-                : '$table->foreignId' . "('{$column_name}')";
+                ? '$table->foreignId'."('{$column_name}')->nullable()"
+                : '$table->foreignId'."('{$column_name}')";
 
             if ($on_delete_clause === 'cascade') {
                 $on_delete_suffix = '->cascadeOnDelete()';
             }
-            if ($column_name === Str::singular($table) . '_' . $column) {
-                return self::INDENT . "{$prefix}->constrained(){$on_delete_suffix}";
+            if ($column_name === Str::singular($table).'_'.$column) {
+                return self::INDENT."{$prefix}->constrained(){$on_delete_suffix}";
             }
             if ($column === 'id') {
-                return self::INDENT . "{$prefix}->constrained('{$table}'){$on_delete_suffix}";
+                return self::INDENT."{$prefix}->constrained('{$table}'){$on_delete_suffix}";
             }
 
-            return self::INDENT . "{$prefix}->constrained('{$table}', '{$column}'){$on_delete_suffix}";
+            return self::INDENT."{$prefix}->constrained('{$table}', '{$column}'){$on_delete_suffix}";
         }
 
-        return self::INDENT . '$table->foreign' . "('{$column_name}')->references('{$column}')->on('{$table}'){$on_delete_suffix}";
+        return self::INDENT.'$table->foreign'."('{$column_name}')->references('{$column}')->on('{$table}'){$on_delete_suffix}";
     }
 
     protected function getClassName(Model $model)
     {
-        return 'Create' . Str::studly($model->tableName()) . 'Table';
+        return 'Create'.Str::studly($model->tableName()).'Table';
     }
 
     protected function getPath(Model $model, Carbon $timestamp)
     {
-        return 'database/migrations/' . $timestamp->format('Y_m_d_His') . '_create_' . $model->tableName() . '_table.php';
+        return 'database/migrations/'.$timestamp->format('Y_m_d_His').'_create_'.$model->tableName().'_table.php';
     }
 
     protected function getPivotTablePath($tableName, Carbon $timestamp)
     {
-        return 'database/migrations/' . $timestamp->format('Y_m_d_His') . '_create_' . $tableName . '_table.php';
+        return 'database/migrations/'.$timestamp->format('Y_m_d_His').'_create_'.$tableName.'_table.php';
     }
 
     protected function isLaravel7orNewer()
@@ -303,7 +292,7 @@ class MigrationGenerator implements Generator
 
     protected function getPivotClassName(array $segments)
     {
-        return 'Create' . Str::studly($this->getPivotTableName($segments)) . 'Table';
+        return 'Create'.Str::studly($this->getPivotTableName($segments)).'Table';
     }
 
     protected function getPivotTableName(array $segments)

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -16,7 +16,7 @@ class RouteGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         if (empty($tree['controllers'])) {
             return [];
@@ -27,35 +27,24 @@ class RouteGenerator implements Generator
         /** @var \Blueprint\Models\Controller $controller */
         foreach ($tree['controllers'] as $controller) {
             $type = $controller->isApiResource() ? 'api' : 'web';
-            $routes[$type] .= PHP_EOL . PHP_EOL . $this->buildRoutes($controller);
+            $routes[$type] .= PHP_EOL.PHP_EOL.$this->buildRoutes($controller);
         }
 
         $paths = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            foreach (array_filter($routes) as $type => $definitions) {
-                $path = 'routes/' . $type . '.php';
-                $this->files->append($path, $definitions . PHP_EOL);
-                $paths[] = $path;
-            }
+        foreach (array_filter($routes) as $type => $definitions) {
+            $path = 'routes/'.$type.'.php';
+            $this->files->append($path, $definitions.PHP_EOL);
+            $paths[] = $path;
         }
 
         return ['updated' => $paths];
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('routes', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('routes', $skip);
-        }
-
-        return true;
+        return ['routes'];
     }
-
 
     protected function buildRoutes(Controller $controller)
     {
@@ -83,7 +72,7 @@ class RouteGenerator implements Generator
                 }
             }
 
-            $routes .= ';' . PHP_EOL;
+            $routes .= ';'.PHP_EOL;
         }
 
         $methods = array_diff($methods, Controller::$resourceMethods);

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -16,7 +16,7 @@ class RouteGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(array $tree, array $only = [], array $skip = []): array
     {
         if (empty($tree['controllers'])) {
             return [];
@@ -31,14 +31,31 @@ class RouteGenerator implements Generator
         }
 
         $paths = [];
-        foreach (array_filter($routes) as $type => $definitions) {
-            $path = 'routes/' . $type . '.php';
-            $this->files->append($path, $definitions . PHP_EOL);
-            $paths[] = $path;
+
+        if ($this->shouldGenerate($only, $skip)) {
+            foreach (array_filter($routes) as $type => $definitions) {
+                $path = 'routes/' . $type . '.php';
+                $this->files->append($path, $definitions . PHP_EOL);
+                $paths[] = $path;
+            }
         }
 
         return ['updated' => $paths];
     }
+
+    protected function shouldGenerate(array $only, array $skip): bool
+    {
+        if (count($only)) {
+            return in_array('routes', $only);
+        }
+
+        if (count($skip)) {
+            return !in_array('routes', $skip);
+        }
+
+        return true;
+    }
+
 
     protected function buildRoutes(Controller $controller)
     {

--- a/src/Generators/SeederGenerator.php
+++ b/src/Generators/SeederGenerator.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Blueprint\Generators;
 
 use Blueprint\Contracts\Generator;
@@ -19,7 +18,7 @@ class SeederGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         if (empty($tree['seeders'])) {
             return [];
@@ -27,39 +26,28 @@ class SeederGenerator implements Generator
 
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $stub = $this->files->stub('seeder.stub');
+        $stub = $this->files->stub('seeder.stub');
 
-            $this->registerModels($tree);
+        $this->registerModels($tree);
 
-            foreach ($tree['seeders'] as $model) {
-                $path = $this->getPath($model);
-                $this->files->put($path, $this->populateStub($stub, $model));
+        foreach ($tree['seeders'] as $model) {
+            $path = $this->getPath($model);
+            $this->files->put($path, $this->populateStub($stub, $model));
 
-                $output['created'][] = $path;
-            }
+            $output['created'][] = $path;
         }
 
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('seeders', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('seeders', $skip);
-        }
-
-        return true;
+        return ['seeders'];
     }
-
 
     private function getPath($model)
     {
-        return 'database/seeds/' . $model . 'Seeder.php';
+        return 'database/seeds/'.$model.'Seeder.php';
     }
 
     protected function populateStub(string $stub, string $model)
@@ -72,7 +60,7 @@ class SeederGenerator implements Generator
 
     private function getClassName(string $model)
     {
-        return $model . 'Seeder';
+        return $model.'Seeder';
     }
 
     private function build(string $model)
@@ -92,7 +80,7 @@ class SeederGenerator implements Generator
         }
 
         $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '\\' . Str::studly($context));
+            return Str::endsWith($key, '\\'.Str::studly($context));
         });
 
         if (count($matches) === 1) {
@@ -101,9 +89,9 @@ class SeederGenerator implements Generator
 
         $fqn = config('blueprint.namespace');
         if (config('blueprint.models_namespace')) {
-            $fqn .= '\\' . config('blueprint.models_namespace');
+            $fqn .= '\\'.config('blueprint.models_namespace');
         }
 
-        return $fqn . '\\' . $context;
+        return $fqn.'\\'.$context;
     }
 }

--- a/src/Generators/SeederGenerator.php
+++ b/src/Generators/SeederGenerator.php
@@ -19,26 +19,43 @@ class SeederGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(array $tree, array $only = [], array $skip = []): array
     {
         if (empty($tree['seeders'])) {
             return [];
         }
 
         $output = [];
-        $stub = $this->files->stub('seeder.stub');
 
-        $this->registerModels($tree);
+        if ($this->shouldGenerate($only, $skip)) {
+            $stub = $this->files->stub('seeder.stub');
 
-        foreach ($tree['seeders'] as $model) {
-            $path = $this->getPath($model);
-            $this->files->put($path, $this->populateStub($stub, $model));
+            $this->registerModels($tree);
 
-            $output['created'][] = $path;
+            foreach ($tree['seeders'] as $model) {
+                $path = $this->getPath($model);
+                $this->files->put($path, $this->populateStub($stub, $model));
+
+                $output['created'][] = $path;
+            }
         }
 
         return $output;
     }
+
+    protected function shouldGenerate(array $only, array $skip): bool
+    {
+        if (count($only)) {
+            return in_array('seeders', $only);
+        }
+
+        if (count($skip)) {
+            return !in_array('seeders', $skip);
+        }
+
+        return true;
+    }
+
 
     private function getPath($model)
     {

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -18,42 +18,57 @@ class EventGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(array $tree, array $only = [], array $skip = []): array
     {
         $output = [];
 
-        $stub = $this->files->stub('event.stub');
+        if ($this->shouldGenerate($only, $skip)) {
+            $stub = $this->files->stub('event.stub');
 
-        /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
-            foreach ($controller->methods() as $method => $statements) {
-                foreach ($statements as $statement) {
-                    if (!$statement instanceof FireStatement) {
-                        continue;
+            /** @var \Blueprint\Models\Controller $controller */
+            foreach ($tree['controllers'] as $controller) {
+                foreach ($controller->methods() as $method => $statements) {
+                    foreach ($statements as $statement) {
+                        if (!$statement instanceof FireStatement) {
+                            continue;
+                        }
+
+                        if ($statement->isNamedEvent()) {
+                            continue;
+                        }
+
+                        $path = $this->getPath($statement->event());
+
+                        if ($this->files->exists($path)) {
+                            continue;
+                        }
+
+                        if (!$this->files->exists(dirname($path))) {
+                            $this->files->makeDirectory(dirname($path), 0755, true);
+                        }
+
+                        $this->files->put($path, $this->populateStub($stub, $statement));
+
+                        $output['created'][] = $path;
                     }
-
-                    if ($statement->isNamedEvent()) {
-                        continue;
-                    }
-
-                    $path = $this->getPath($statement->event());
-
-                    if ($this->files->exists($path)) {
-                        continue;
-                    }
-
-                    if (!$this->files->exists(dirname($path))) {
-                        $this->files->makeDirectory(dirname($path), 0755, true);
-                    }
-
-                    $this->files->put($path, $this->populateStub($stub, $statement));
-
-                    $output['created'][] = $path;
                 }
             }
         }
 
         return $output;
+    }
+
+    protected function shouldGenerate(array $only, array $skip): bool
+    {
+        if (count($only)) {
+            return in_array('events', $only);
+        }
+
+        if (count($skip)) {
+            return !in_array('events', $skip);
+        }
+
+        return true;
     }
 
     protected function getPath(string $name)

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -58,7 +58,7 @@ class EventGenerator implements Generator
 
     public function types(): array
     {
-        return ['events'];
+        return ['controllers'];
     }
 
     protected function getPath(string $name)

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -65,7 +65,7 @@ class FormRequestGenerator implements Generator
 
     public function types(): array
     {
-        return ['requests'];
+        return ['controllers', 'requests'];
     }
 
     protected function getPath(Controller $controller, string $name)

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -18,39 +18,55 @@ class JobGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(array $tree, array $only = [], array $skip = []): array
     {
         $output = [];
 
-        $stub = $this->files->stub('job.stub');
+        if ($this->shouldGenerate($only, $skip)) {
+            $stub = $this->files->stub('job.stub');
 
-        /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
-            foreach ($controller->methods() as $method => $statements) {
-                foreach ($statements as $statement) {
-                    if (!$statement instanceof DispatchStatement) {
-                        continue;
+            /** @var \Blueprint\Models\Controller $controller */
+            foreach ($tree['controllers'] as $controller) {
+                foreach ($controller->methods() as $method => $statements) {
+                    foreach ($statements as $statement) {
+                        if (!$statement instanceof DispatchStatement) {
+                            continue;
+                        }
+
+                        $path = $this->getPath($statement->job());
+
+                        if ($this->files->exists($path)) {
+                            continue;
+                        }
+
+                        if (!$this->files->exists(dirname($path))) {
+                            $this->files->makeDirectory(dirname($path), 0755, true);
+                        }
+
+                        $this->files->put($path, $this->populateStub($stub, $statement));
+
+                        $output['created'][] = $path;
                     }
-
-                    $path = $this->getPath($statement->job());
-
-                    if ($this->files->exists($path)) {
-                        continue;
-                    }
-
-                    if (!$this->files->exists(dirname($path))) {
-                        $this->files->makeDirectory(dirname($path), 0755, true);
-                    }
-
-                    $this->files->put($path, $this->populateStub($stub, $statement));
-
-                    $output['created'][] = $path;
                 }
             }
         }
 
         return $output;
     }
+
+    protected function shouldGenerate(array $only, array $skip): bool
+    {
+        if (count($only)) {
+            return in_array('jobs', $only);
+        }
+
+        if (count($skip)) {
+            return !in_array('jobs', $skip);
+        }
+
+        return true;
+    }
+
 
     protected function getPath(string $name)
     {

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -54,7 +54,7 @@ class JobGenerator implements Generator
 
     public function types(): array
     {
-        return ['jobs'];
+        return ['controllers'];
     }
 
     protected function getPath(string $name)

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -18,35 +18,33 @@ class JobGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $stub = $this->files->stub('job.stub');
+        $stub = $this->files->stub('job.stub');
 
-            /** @var \Blueprint\Models\Controller $controller */
-            foreach ($tree['controllers'] as $controller) {
-                foreach ($controller->methods() as $method => $statements) {
-                    foreach ($statements as $statement) {
-                        if (!$statement instanceof DispatchStatement) {
-                            continue;
-                        }
-
-                        $path = $this->getPath($statement->job());
-
-                        if ($this->files->exists($path)) {
-                            continue;
-                        }
-
-                        if (!$this->files->exists(dirname($path))) {
-                            $this->files->makeDirectory(dirname($path), 0755, true);
-                        }
-
-                        $this->files->put($path, $this->populateStub($stub, $statement));
-
-                        $output['created'][] = $path;
+        /** @var \Blueprint\Models\Controller $controller */
+        foreach ($tree['controllers'] as $controller) {
+            foreach ($controller->methods() as $method => $statements) {
+                foreach ($statements as $statement) {
+                    if (! $statement instanceof DispatchStatement) {
+                        continue;
                     }
+
+                    $path = $this->getPath($statement->job());
+
+                    if ($this->files->exists($path)) {
+                        continue;
+                    }
+
+                    if (! $this->files->exists(dirname($path))) {
+                        $this->files->makeDirectory(dirname($path), 0755, true);
+                    }
+
+                    $this->files->put($path, $this->populateStub($stub, $statement));
+
+                    $output['created'][] = $path;
                 }
             }
         }
@@ -54,28 +52,19 @@ class JobGenerator implements Generator
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('jobs', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('jobs', $skip);
-        }
-
-        return true;
+        return ['jobs'];
     }
-
 
     protected function getPath(string $name)
     {
-        return Blueprint::appPath() . '/Jobs/' . $name . '.php';
+        return Blueprint::appPath().'/Jobs/'.$name.'.php';
     }
 
     protected function populateStub(string $stub, DispatchStatement $dispatchStatement)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Jobs', $stub);
+        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Jobs', $stub);
         $stub = str_replace('DummyClass', $dispatchStatement->job(), $stub);
         $stub = str_replace('// properties...', $this->buildConstructor($dispatchStatement), $stub);
 
@@ -94,8 +83,8 @@ class JobGenerator implements Generator
             return trim($constructor);
         }
 
-        $stub = $this->buildProperties($dispatchStatement->data()) . PHP_EOL . PHP_EOL;
-        $stub .= str_replace('__construct()', '__construct(' . $this->buildParameters($dispatchStatement->data()) . ')', $constructor);
+        $stub = $this->buildProperties($dispatchStatement->data()).PHP_EOL.PHP_EOL;
+        $stub .= str_replace('__construct()', '__construct('.$this->buildParameters($dispatchStatement->data()).')', $constructor);
         $stub = str_replace('//', $this->buildAssignments($dispatchStatement->data()), $stub);
 
         return $stub;
@@ -104,7 +93,8 @@ class JobGenerator implements Generator
     private function buildProperties(array $data)
     {
         return trim(array_reduce($data, function ($output, $property) {
-            $output .= '    public $' . $property . ';' . PHP_EOL . PHP_EOL;
+            $output .= '    public $'.$property.';'.PHP_EOL.PHP_EOL;
+
             return $output;
         }, ''));
     }
@@ -112,7 +102,7 @@ class JobGenerator implements Generator
     private function buildParameters(array $data)
     {
         $parameters = array_map(function ($parameter) {
-            return '$' . $parameter;
+            return '$'.$parameter;
         }, $data);
 
         return implode(', ', $parameters);
@@ -121,7 +111,8 @@ class JobGenerator implements Generator
     private function buildAssignments(array $data)
     {
         return trim(array_reduce($data, function ($output, $property) {
-            $output .= '        $this->' . $property . ' = $' . $property . ';' . PHP_EOL;
+            $output .= '        $this->'.$property.' = $'.$property.';'.PHP_EOL;
+
             return $output;
         }, ''));
     }

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -58,7 +58,7 @@ class MailGenerator implements Generator
 
     public function types(): array
     {
-        return ['mails'];
+        return ['controllers'];
     }
 
     protected function getPath(string $name)

--- a/src/Generators/Statements/NotificationGenerator.php
+++ b/src/Generators/Statements/NotificationGenerator.php
@@ -59,7 +59,7 @@ class NotificationGenerator implements Generator
 
     public function types(): array
     {
-        return ['notifications'];
+        return ['controllers'];
     }
 
     protected function getPath(string $name)

--- a/src/Generators/Statements/NotificationGenerator.php
+++ b/src/Generators/Statements/NotificationGenerator.php
@@ -19,43 +19,59 @@ class NotificationGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(array $tree, array $only = [], array $skip = []): array
     {
         $output = [];
 
-        $stub = $this->files->stub('notification.stub');
+        if ($this->shouldGenerate($only, $skip)) {
+            $stub = $this->files->stub('notification.stub');
 
-        /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
-            foreach ($controller->methods() as $method => $statements) {
-                foreach ($statements as $statement) {
-                    if (! $statement instanceof SendStatement) {
-                        continue;
+            /** @var \Blueprint\Models\Controller $controller */
+            foreach ($tree['controllers'] as $controller) {
+                foreach ($controller->methods() as $method => $statements) {
+                    foreach ($statements as $statement) {
+                        if (!$statement instanceof SendStatement) {
+                            continue;
+                        }
+
+                        if (!$statement->isNotification()) {
+                            continue;
+                        }
+
+                        $path = $this->getPath($statement->mail());
+
+                        if ($this->files->exists($path)) {
+                            continue;
+                        }
+
+                        if (!$this->files->exists(dirname($path))) {
+                            $this->files->makeDirectory(dirname($path), 0755, true);
+                        }
+
+                        $this->files->put($path, $this->populateStub($stub, $statement));
+
+                        $output['created'][] = $path;
                     }
-
-                    if (! $statement->isNotification()) {
-                        continue;
-                    }
-
-                    $path = $this->getPath($statement->mail());
-
-                    if ($this->files->exists($path)) {
-                        continue;
-                    }
-
-                    if (!$this->files->exists(dirname($path))) {
-                        $this->files->makeDirectory(dirname($path), 0755, true);
-                    }
-
-                    $this->files->put($path, $this->populateStub($stub, $statement));
-
-                    $output['created'][] = $path;
                 }
             }
         }
 
         return $output;
     }
+
+    protected function shouldGenerate(array $only, array $skip): bool
+    {
+        if (count($only)) {
+            return in_array('notifications', $only);
+        }
+
+        if (count($skip)) {
+            return !in_array('notifications', $skip);
+        }
+
+        return true;
+    }
+
 
     protected function getPath(string $name)
     {

--- a/src/Generators/Statements/NotificationGenerator.php
+++ b/src/Generators/Statements/NotificationGenerator.php
@@ -19,39 +19,37 @@ class NotificationGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $stub = $this->files->stub('notification.stub');
+        $stub = $this->files->stub('notification.stub');
 
-            /** @var \Blueprint\Models\Controller $controller */
-            foreach ($tree['controllers'] as $controller) {
-                foreach ($controller->methods() as $method => $statements) {
-                    foreach ($statements as $statement) {
-                        if (!$statement instanceof SendStatement) {
-                            continue;
-                        }
-
-                        if (!$statement->isNotification()) {
-                            continue;
-                        }
-
-                        $path = $this->getPath($statement->mail());
-
-                        if ($this->files->exists($path)) {
-                            continue;
-                        }
-
-                        if (!$this->files->exists(dirname($path))) {
-                            $this->files->makeDirectory(dirname($path), 0755, true);
-                        }
-
-                        $this->files->put($path, $this->populateStub($stub, $statement));
-
-                        $output['created'][] = $path;
+        /** @var \Blueprint\Models\Controller $controller */
+        foreach ($tree['controllers'] as $controller) {
+            foreach ($controller->methods() as $method => $statements) {
+                foreach ($statements as $statement) {
+                    if (! $statement instanceof SendStatement) {
+                        continue;
                     }
+
+                    if (! $statement->isNotification()) {
+                        continue;
+                    }
+
+                    $path = $this->getPath($statement->mail());
+
+                    if ($this->files->exists($path)) {
+                        continue;
+                    }
+
+                    if (! $this->files->exists(dirname($path))) {
+                        $this->files->makeDirectory(dirname($path), 0755, true);
+                    }
+
+                    $this->files->put($path, $this->populateStub($stub, $statement));
+
+                    $output['created'][] = $path;
                 }
             }
         }
@@ -59,28 +57,19 @@ class NotificationGenerator implements Generator
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('notifications', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('notifications', $skip);
-        }
-
-        return true;
+        return ['notifications'];
     }
-
 
     protected function getPath(string $name)
     {
-        return Blueprint::appPath() . '/Notification/' . $name . '.php';
+        return Blueprint::appPath().'/Notification/'.$name.'.php';
     }
 
     protected function populateStub(string $stub, SendStatement $sendStatement)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Notification', $stub);
+        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Notification', $stub);
         $stub = str_replace('DummyClass', $sendStatement->mail(), $stub);
         $stub = str_replace('// properties...', $this->buildConstructor($sendStatement), $stub);
 
@@ -99,8 +88,8 @@ class NotificationGenerator implements Generator
             return trim($constructor);
         }
 
-        $stub = $this->buildProperties($sendStatement->data()) . PHP_EOL . PHP_EOL;
-        $stub .= str_replace('__construct()', '__construct(' . $this->buildParameters($sendStatement->data()) . ')', $constructor);
+        $stub = $this->buildProperties($sendStatement->data()).PHP_EOL.PHP_EOL;
+        $stub .= str_replace('__construct()', '__construct('.$this->buildParameters($sendStatement->data()).')', $constructor);
         $stub = str_replace('//', $this->buildAssignments($sendStatement->data()), $stub);
 
         return $stub;
@@ -109,7 +98,8 @@ class NotificationGenerator implements Generator
     private function buildProperties(array $data)
     {
         return trim(array_reduce($data, function ($output, $property) {
-            $output .= '    public $' . $property . ';' . PHP_EOL . PHP_EOL;
+            $output .= '    public $'.$property.';'.PHP_EOL.PHP_EOL;
+
             return $output;
         }, ''));
     }
@@ -117,7 +107,7 @@ class NotificationGenerator implements Generator
     private function buildParameters(array $data)
     {
         $parameters = array_map(function ($parameter) {
-            return '$' . $parameter;
+            return '$'.$parameter;
         }, $data);
 
         return implode(', ', $parameters);
@@ -126,7 +116,8 @@ class NotificationGenerator implements Generator
     private function buildAssignments(array $data)
     {
         return trim(array_reduce($data, function ($output, $property) {
-            $output .= '        $this->' . $property . ' = $' . $property . ';' . PHP_EOL;
+            $output .= '        $this->'.$property.' = $'.$property.';'.PHP_EOL;
+
             return $output;
         }, ''));
     }

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -24,37 +24,35 @@ class ResourceGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $stub = $this->files->stub('resource.stub');
+        $stub = $this->files->stub('resource.stub');
 
-            $this->registerModels($tree);
+        $this->registerModels($tree);
 
-            /** @var \Blueprint\Models\Controller $controller */
-            foreach ($tree['controllers'] as $controller) {
-                foreach ($controller->methods() as $method => $statements) {
-                    foreach ($statements as $statement) {
-                        if (!$statement instanceof ResourceStatement) {
-                            continue;
-                        }
-
-                        $path = $this->getPath($statement->name());
-
-                        if ($this->files->exists($path)) {
-                            continue;
-                        }
-
-                        if (!$this->files->exists(dirname($path))) {
-                            $this->files->makeDirectory(dirname($path), 0755, true);
-                        }
-
-                        $this->files->put($path, $this->populateStub($stub, $statement));
-
-                        $output['created'][] = $path;
+        /** @var \Blueprint\Models\Controller $controller */
+        foreach ($tree['controllers'] as $controller) {
+            foreach ($controller->methods() as $method => $statements) {
+                foreach ($statements as $statement) {
+                    if (! $statement instanceof ResourceStatement) {
+                        continue;
                     }
+
+                    $path = $this->getPath($statement->name());
+
+                    if ($this->files->exists($path)) {
+                        continue;
+                    }
+
+                    if (! $this->files->exists(dirname($path))) {
+                        $this->files->makeDirectory(dirname($path), 0755, true);
+                    }
+
+                    $this->files->put($path, $this->populateStub($stub, $statement));
+
+                    $output['created'][] = $path;
                 }
             }
         }
@@ -62,28 +60,19 @@ class ResourceGenerator implements Generator
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('resources', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('resources', $skip);
-        }
-
-        return true;
+        return ['resources'];
     }
-
 
     protected function getPath(string $name)
     {
-        return Blueprint::appPath() . '/Http/Resources/' . $name . '.php';
+        return Blueprint::appPath().'/Http/Resources/'.$name.'.php';
     }
 
     protected function populateStub(string $stub, ResourceStatement $resource)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Http\\Resources', $stub);
+        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Http\\Resources', $stub);
         $stub = str_replace('DummyImport', $resource->collection() ? 'Illuminate\\Http\\Resources\\Json\\ResourceCollection' : 'Illuminate\\Http\\Resources\\Json\\JsonResource', $stub);
         $stub = str_replace('DummyParent', $resource->collection() ? 'ResourceCollection' : 'JsonResource', $stub);
         $stub = str_replace('DummyClass', $resource->name(), $stub);
@@ -104,7 +93,7 @@ class ResourceGenerator implements Generator
         $data = [];
         if ($resource->collection()) {
             $data[] = 'return [';
-            $data[] = self::INDENT . '\'data\' => $this->collection,';
+            $data[] = self::INDENT.'\'data\' => $this->collection,';
             $data[] = '        ];';
 
             return implode(PHP_EOL, $data);
@@ -112,7 +101,7 @@ class ResourceGenerator implements Generator
 
         $data[] = 'return [';
         foreach ($this->visibleColumns($model) as $column) {
-            $data[] = self::INDENT . '\'' . $column . '\' => $this->' . $column . ',';
+            $data[] = self::INDENT.'\''.$column.'\' => $this->'.$column.',';
         }
         $data[] = '        ];';
 
@@ -134,7 +123,7 @@ class ResourceGenerator implements Generator
         }
 
         $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/' . Str::studly($context));
+            return Str::endsWith($key, '/'.Str::studly($context));
         });
 
         if (count($matches) === 1) {

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -62,7 +62,7 @@ class ResourceGenerator implements Generator
 
     public function types(): array
     {
-        return ['resources'];
+        return ['controllers', 'resources'];
     }
 
     protected function getPath(string $name)

--- a/src/Generators/Statements/ViewGenerator.php
+++ b/src/Generators/Statements/ViewGenerator.php
@@ -17,36 +17,34 @@ class ViewGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $stub = $this->files->stub('view.stub');
+        $stub = $this->files->stub('view.stub');
 
-            /** @var \Blueprint\Models\Controller $controller */
-            foreach ($tree['controllers'] as $controller) {
-                foreach ($controller->methods() as $method => $statements) {
-                    foreach ($statements as $statement) {
-                        if (!$statement instanceof RenderStatement) {
-                            continue;
-                        }
-
-                        $path = $this->getPath($statement->view());
-
-                        if ($this->files->exists($path)) {
-                            // TODO: mark skipped...
-                            continue;
-                        }
-
-                        if (!$this->files->exists(dirname($path))) {
-                            $this->files->makeDirectory(dirname($path), 0755, true);
-                        }
-
-                        $this->files->put($path, $this->populateStub($stub, $statement));
-
-                        $output['created'][] = $path;
+        /** @var \Blueprint\Models\Controller $controller */
+        foreach ($tree['controllers'] as $controller) {
+            foreach ($controller->methods() as $method => $statements) {
+                foreach ($statements as $statement) {
+                    if (! $statement instanceof RenderStatement) {
+                        continue;
                     }
+
+                    $path = $this->getPath($statement->view());
+
+                    if ($this->files->exists($path)) {
+                        // TODO: mark skipped...
+                        continue;
+                    }
+
+                    if (! $this->files->exists(dirname($path))) {
+                        $this->files->makeDirectory(dirname($path), 0755, true);
+                    }
+
+                    $this->files->put($path, $this->populateStub($stub, $statement));
+
+                    $output['created'][] = $path;
                 }
             }
         }
@@ -54,22 +52,14 @@ class ViewGenerator implements Generator
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('views', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('views', $skip);
-        }
-
-        return true;
+        return ['views'];
     }
 
     protected function getPath(string $view)
     {
-        return 'resources/views/' . str_replace('.', '/', $view) . '.blade.php';
+        return 'resources/views/'.str_replace('.', '/', $view).'.blade.php';
     }
 
     protected function populateStub(string $stub, RenderStatement $renderStatement)

--- a/src/Generators/Statements/ViewGenerator.php
+++ b/src/Generators/Statements/ViewGenerator.php
@@ -17,39 +17,54 @@ class ViewGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(array $tree, array $only = [], array $skip = []): array
     {
         $output = [];
 
-        $stub = $this->files->stub('view.stub');
+        if ($this->shouldGenerate($only, $skip)) {
+            $stub = $this->files->stub('view.stub');
 
-        /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
-            foreach ($controller->methods() as $method => $statements) {
-                foreach ($statements as $statement) {
-                    if (!$statement instanceof RenderStatement) {
-                        continue;
+            /** @var \Blueprint\Models\Controller $controller */
+            foreach ($tree['controllers'] as $controller) {
+                foreach ($controller->methods() as $method => $statements) {
+                    foreach ($statements as $statement) {
+                        if (!$statement instanceof RenderStatement) {
+                            continue;
+                        }
+
+                        $path = $this->getPath($statement->view());
+
+                        if ($this->files->exists($path)) {
+                            // TODO: mark skipped...
+                            continue;
+                        }
+
+                        if (!$this->files->exists(dirname($path))) {
+                            $this->files->makeDirectory(dirname($path), 0755, true);
+                        }
+
+                        $this->files->put($path, $this->populateStub($stub, $statement));
+
+                        $output['created'][] = $path;
                     }
-
-                    $path = $this->getPath($statement->view());
-
-                    if ($this->files->exists($path)) {
-                        // TODO: mark skipped...
-                        continue;
-                    }
-
-                    if (!$this->files->exists(dirname($path))) {
-                        $this->files->makeDirectory(dirname($path), 0755, true);
-                    }
-
-                    $this->files->put($path, $this->populateStub($stub, $statement));
-
-                    $output['created'][] = $path;
                 }
             }
         }
 
         return $output;
+    }
+
+    protected function shouldGenerate(array $only, array $skip): bool
+    {
+        if (count($only)) {
+            return in_array('views', $only);
+        }
+
+        if (count($skip)) {
+            return !in_array('views', $skip);
+        }
+
+        return true;
     }
 
     protected function getPath(string $view)

--- a/src/Generators/Statements/ViewGenerator.php
+++ b/src/Generators/Statements/ViewGenerator.php
@@ -54,7 +54,7 @@ class ViewGenerator implements Generator
 
     public function types(): array
     {
-        return ['views'];
+        return ['controllers', 'views'];
     }
 
     protected function getPath(string $view)

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Blueprint\Generators;
 
 use Blueprint\Blueprint;
@@ -40,57 +39,47 @@ class TestGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree, array $only = [], array $skip = []): array
+    public function output(array $tree): array
     {
         $output = [];
 
-        if ($this->shouldGenerate($only, $skip)) {
-            $stub = $this->files->get(STUBS_PATH . '/test/class.stub');
+        $stub = $this->files->get(STUBS_PATH.'/test/class.stub');
 
-            $this->registerModels($tree);
+        $this->registerModels($tree);
 
-            /** @var \Blueprint\Models\Controller $controller */
-            foreach ($tree['controllers'] as $controller) {
-                $path = $this->getPath($controller);
+        /** @var \Blueprint\Models\Controller $controller */
+        foreach ($tree['controllers'] as $controller) {
+            $path = $this->getPath($controller);
 
-                if (!$this->files->exists(dirname($path))) {
-                    $this->files->makeDirectory(dirname($path), 0755, true);
-                }
-
-                $this->files->put($path, $this->populateStub($stub, $controller));
-
-                $output['created'][] = $path;
+            if (! $this->files->exists(dirname($path))) {
+                $this->files->makeDirectory(dirname($path), 0755, true);
             }
+
+            $this->files->put($path, $this->populateStub($stub, $controller));
+
+            $output['created'][] = $path;
         }
 
         return $output;
     }
 
-    protected function shouldGenerate(array $only, array $skip): bool
+    public function types(): array
     {
-        if (count($only)) {
-            return in_array('tests', $only);
-        }
-
-        if (count($skip)) {
-            return !in_array('tests', $skip);
-        }
-
-        return true;
+        return ['controllers', 'tests'];
     }
 
     protected function getPath(Controller $controller)
     {
         $path = str_replace('\\', '/', Blueprint::relativeNamespace($controller->fullyQualifiedClassName()));
 
-        return 'tests/Feature/' . $path . 'Test.php';
+        return 'tests/Feature/'.$path.'Test.php';
     }
 
     protected function populateStub(string $stub, Controller $controller)
     {
-        $stub = str_replace('DummyNamespace', 'Tests\\Feature\\' . Blueprint::relativeNamespace($controller->fullyQualifiedNamespace()), $stub);
-        $stub = str_replace('DummyController', '\\' . $controller->fullyQualifiedClassName(), $stub);
-        $stub = str_replace('DummyClass', $controller->className() . 'Test', $stub);
+        $stub = str_replace('DummyNamespace', 'Tests\\Feature\\'.Blueprint::relativeNamespace($controller->fullyQualifiedNamespace()), $stub);
+        $stub = str_replace('DummyController', '\\'.$controller->fullyQualifiedClassName(), $stub);
+        $stub = str_replace('DummyClass', $controller->className().'Test', $stub);
         $stub = str_replace('// test cases...', $this->buildTestCases($controller), $stub);
         $stub = str_replace('// imports...', $this->buildImports($controller), $stub);
 
@@ -122,7 +111,7 @@ class TestGenerator implements Generator
             $variable = Str::camel($context);
 
             $modelNamespace = config('blueprint.models_namespace')
-                ? config('blueprint.namespace') . '\\' . config('blueprint.models_namespace')
+                ? config('blueprint.namespace').'\\'.config('blueprint.models_namespace')
                 : config('blueprint.namespace');
 
             if (in_array($name, ['edit', 'update', 'show', 'destroy'])) {
@@ -133,7 +122,7 @@ class TestGenerator implements Generator
                 if ($statement instanceof SendStatement) {
                     if ($statement->isNotification()) {
                         $this->addImport($controller, 'Illuminate\\Support\\Facades\\Notification');
-                        $this->addImport($controller, config('blueprint.namespace') . '\\Notification\\' . $statement->mail());
+                        $this->addImport($controller, config('blueprint.namespace').'\\Notification\\'.$statement->mail());
 
                         $setup['mock'][] = 'Notification::fake();';
 
@@ -150,23 +139,23 @@ class TestGenerator implements Generator
 
                             foreach ($statement->data() as $data) {
                                 if (Str::studly(Str::singular($data)) === $context) {
-                                    $variables[] .= '$' . $data;
+                                    $variables[] .= '$'.$data;
                                     $conditions[] .= sprintf('$notification->%s->is($%s)', $data, $data);
                                 } else {
                                     [$model, $property] = explode('.', $data);
-                                    $variables[] .= '$' . $model;
+                                    $variables[] .= '$'.$model;
                                     $conditions[] .= sprintf('$notification->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
                                 }
                             }
 
                             if ($variables) {
-                                $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
+                                $assertion .= ' use ('.implode(', ', array_unique($variables)).')';
                             }
 
-                            $assertion .= ' {' . PHP_EOL;
+                            $assertion .= ' {'.PHP_EOL;
                             $assertion .= str_pad(' ', 12);
-                            $assertion .= 'return ' . implode(' && ', $conditions) . ';';
-                            $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
+                            $assertion .= 'return '.implode(' && ', $conditions).';';
+                            $assertion .= PHP_EOL.str_pad(' ', 8).'}';
                         }
 
                         $assertion .= ');';
@@ -174,7 +163,7 @@ class TestGenerator implements Generator
                         $assertions['mock'][] = $assertion;
                     } else {
                         $this->addImport($controller, 'Illuminate\\Support\\Facades\\Mail');
-                        $this->addImport($controller, config('blueprint.namespace') . '\\Mail\\' . $statement->mail());
+                        $this->addImport($controller, config('blueprint.namespace').'\\Mail\\'.$statement->mail());
 
                         $setup['mock'][] = 'Mail::fake();';
 
@@ -186,28 +175,28 @@ class TestGenerator implements Generator
                             $assertion .= ', function ($mail)';
 
                             if ($statement->to()) {
-                                $conditions[] = '$mail->hasTo($' . str_replace('.', '->', $statement->to()) . ')';
+                                $conditions[] = '$mail->hasTo($'.str_replace('.', '->', $statement->to()).')';
                             }
 
                             foreach ($statement->data() as $data) {
                                 if (Str::studly(Str::singular($data)) === $context) {
-                                    $variables[] .= '$' . $data;
+                                    $variables[] .= '$'.$data;
                                     $conditions[] .= sprintf('$mail->%s->is($%s)', $data, $data);
                                 } else {
                                     [$model, $property] = explode('.', $data);
-                                    $variables[] .= '$' . $model;
+                                    $variables[] .= '$'.$model;
                                     $conditions[] .= sprintf('$mail->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
                                 }
                             }
 
                             if ($variables) {
-                                $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
+                                $assertion .= ' use ('.implode(', ', array_unique($variables)).')';
                             }
 
-                            $assertion .= ' {' . PHP_EOL;
+                            $assertion .= ' {'.PHP_EOL;
                             $assertion .= str_pad(' ', 12);
-                            $assertion .= 'return ' . implode(' && ', $conditions) . ';';
-                            $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
+                            $assertion .= 'return '.implode(' && ', $conditions).';';
+                            $assertion .= PHP_EOL.str_pad(' ', 8).'}';
                         }
 
                         $assertion .= ');';
@@ -218,7 +207,7 @@ class TestGenerator implements Generator
                     $this->addTestAssertionsTrait($controller);
 
                     $class = $this->buildFormRequestName($controller, $name);
-                    $test_case = $this->buildFormRequestTestCase($controller->fullyQualifiedClassName(), $name, config('blueprint.namespace') . '\\Http\\Requests\\' . $class) . PHP_EOL . PHP_EOL . $test_case;
+                    $test_case = $this->buildFormRequestTestCase($controller->fullyQualifiedClassName(), $name, config('blueprint.namespace').'\\Http\\Requests\\'.$class).PHP_EOL.PHP_EOL.$test_case;
 
                     if ($statement->data()) {
                         $this->addFakerTrait($controller);
@@ -235,7 +224,7 @@ class TestGenerator implements Generator
                             /** @var \Blueprint\Models\Model $local_model */
                             $local_model = $this->modelForContext($qualifier);
 
-                            if (!is_null($local_model) && $local_model->hasColumn($column)) {
+                            if (! is_null($local_model) && $local_model->hasColumn($column)) {
                                 $local_column = $local_model->column($column);
                                 if (($local_column->dataType() === 'id' || $local_column->dataType() === 'uuid') && ($local_column->attributes() && Str::endsWith($local_column->name(), '_id'))) {
                                     $variable_name = Str::beforeLast($local_column->name(), '_id');
@@ -247,7 +236,7 @@ class TestGenerator implements Generator
                                     }
                                     $faker = sprintf('$%s = factory(%s::class)->create();', Str::beforeLast($local_column->name(), '_id'), Str::studly($reference));
 
-                                    $this->addImport($controller, $modelNamespace . '\\' . Str::studly($reference));
+                                    $this->addImport($controller, $modelNamespace.'\\'.Str::studly($reference));
                                 } else {
                                     $faker = sprintf('$%s = $this->faker->%s;', $data, FactoryGenerator::fakerData($local_column->name()) ?? FactoryGenerator::fakerDataType($local_model->column($column)->dataType()));
                                 }
@@ -256,12 +245,12 @@ class TestGenerator implements Generator
                             }
 
                             $setup['data'][] = $faker;
-                            $request_data[$data] = '$' . $variable_name;
+                            $request_data[$data] = '$'.$variable_name;
                         }
                     }
                 } elseif ($statement instanceof DispatchStatement) {
                     $this->addImport($controller, 'Illuminate\\Support\\Facades\\Queue');
-                    $this->addImport($controller, config('blueprint.namespace') . '\\Jobs\\' . $statement->job());
+                    $this->addImport($controller, config('blueprint.namespace').'\\Jobs\\'.$statement->job());
 
                     $setup['mock'][] = 'Queue::fake();';
 
@@ -274,23 +263,23 @@ class TestGenerator implements Generator
 
                         foreach ($statement->data() as $data) {
                             if (Str::studly(Str::singular($data)) === $context) {
-                                $variables[] .= '$' . $data;
+                                $variables[] .= '$'.$data;
                                 $conditions[] .= sprintf('$job->%s->is($%s)', $data, $data);
                             } else {
                                 [$model, $property] = explode('.', $data);
-                                $variables[] .= '$' . $model;
+                                $variables[] .= '$'.$model;
                                 $conditions[] .= sprintf('$job->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
                             }
                         }
 
                         if ($variables) {
-                            $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
+                            $assertion .= ' use ('.implode(', ', array_unique($variables)).')';
                         }
 
-                        $assertion .= ' {' . PHP_EOL;
+                        $assertion .= ' {'.PHP_EOL;
                         $assertion .= str_pad(' ', 12);
-                        $assertion .= 'return ' . implode(' && ', $conditions) . ';';
-                        $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
+                        $assertion .= 'return '.implode(' && ', $conditions).';';
+                        $assertion .= PHP_EOL.str_pad(' ', 8).'}';
                     }
 
                     $assertion .= ');';
@@ -306,8 +295,8 @@ class TestGenerator implements Generator
                     if ($statement->isNamedEvent()) {
                         $assertion .= $statement->event();
                     } else {
-                        $this->addImport($controller, config('blueprint.namespace') . '\\Events\\' . $statement->event());
-                        $assertion .= $statement->event() . '::class';
+                        $this->addImport($controller, config('blueprint.namespace').'\\Events\\'.$statement->event());
+                        $assertion .= $statement->event().'::class';
                     }
 
                     if ($statement->data()) {
@@ -317,23 +306,23 @@ class TestGenerator implements Generator
 
                         foreach ($statement->data() as $data) {
                             if (Str::studly(Str::singular($data)) === $context) {
-                                $variables[] .= '$' . $data;
+                                $variables[] .= '$'.$data;
                                 $conditions[] .= sprintf('$event->%s->is($%s)', $data, $data);
                             } else {
                                 [$model, $property] = explode('.', $data);
-                                $variables[] .= '$' . $model;
+                                $variables[] .= '$'.$model;
                                 $conditions[] .= sprintf('$event->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
                             }
                         }
 
                         if ($variables) {
-                            $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
+                            $assertion .= ' use ('.implode(', ', array_unique($variables)).')';
                         }
 
-                        $assertion .= ' {' . PHP_EOL;
+                        $assertion .= ' {'.PHP_EOL;
                         $assertion .= str_pad(' ', 12);
-                        $assertion .= 'return ' . implode(' && ', $conditions) . ';';
-                        $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
+                        $assertion .= 'return '.implode(' && ', $conditions).';';
+                        $assertion .= PHP_EOL.str_pad(' ', 8).'}';
                     }
 
                     $assertion .= ');';
@@ -351,7 +340,6 @@ class TestGenerator implements Generator
                         $view_assertions[] = sprintf('$response->assertViewHas(\'%s\');', $data);
                     }
 
-
                     array_unshift($assertions['response'], ...$view_assertions);
                 } elseif ($statement instanceof RedirectStatement) {
                     $tested_bits |= self::TESTS_REDIRECT;
@@ -360,10 +348,10 @@ class TestGenerator implements Generator
 
                     if ($statement->data()) {
                         $parameters = array_map(function ($parameter) {
-                            return '$' . $parameter;
+                            return '$'.$parameter;
                         }, $statement->data());
 
-                        $assertion .= ', [' . implode(', ', $parameters) . ']';
+                        $assertion .= ', ['.implode(', ', $parameters).']';
                     } elseif (Str::contains($statement->route(), '.')) {
                         [$model, $action] = explode('.', $statement->route());
                         if (in_array($action, ['edit', 'update', 'show', 'destroy'])) {
@@ -378,7 +366,7 @@ class TestGenerator implements Generator
                     $tested_bits |= self::TESTS_RESPONDS;
 
                     if ($statement->content()) {
-                        array_unshift($assertions['response'], '$response->assertJson($' . $statement->content() . ');');
+                        array_unshift($assertions['response'], '$response->assertJson($'.$statement->content().');');
                     }
 
                     if ($statement->status() === 200) {
@@ -386,15 +374,15 @@ class TestGenerator implements Generator
                     } elseif ($statement->status() === 204) {
                         array_unshift($assertions['response'], '$response->assertNoContent();');
                     } else {
-                        array_unshift($assertions['response'], '$response->assertNoContent(' . $statement->status() . ');');
+                        array_unshift($assertions['response'], '$response->assertNoContent('.$statement->status().');');
                     }
                 } elseif ($statement instanceof SessionStatement) {
-                    $assertions['response'][] = sprintf('$response->assertSessionHas(\'%s\', %s);', $statement->reference(), '$' . str_replace('.', '->', $statement->reference()));
+                    $assertions['response'][] = sprintf('$response->assertSessionHas(\'%s\', %s);', $statement->reference(), '$'.str_replace('.', '->', $statement->reference()));
                 } elseif ($statement instanceof EloquentStatement) {
                     $this->addRefreshDatabaseTrait($controller);
 
                     $model = $this->determineModel($controller->prefix(), $statement->reference());
-                    $this->addImport($controller, $modelNamespace . '\\' . $model);
+                    $this->addImport($controller, $modelNamespace.'\\'.$model);
 
                     if ($statement->operation() === 'save') {
                         $tested_bits |= self::TESTS_SAVE;
@@ -404,15 +392,15 @@ class TestGenerator implements Generator
                             $plural = Str::plural($variable);
                             $assertion = sprintf('$%s = %s::query()', $plural, $model);
                             foreach ($request_data as $key => $datum) {
-                                $assertion .= PHP_EOL . sprintf('%s->where(\'%s\', %s)', $indent, $key, $datum);
+                                $assertion .= PHP_EOL.sprintf('%s->where(\'%s\', %s)', $indent, $key, $datum);
                             }
-                            $assertion .= PHP_EOL . $indent . '->get();';
+                            $assertion .= PHP_EOL.$indent.'->get();';
 
                             $assertions['sanity'][] = $assertion;
-                            $assertions['sanity'][] = '$this->assertCount(1, $' . $plural . ');';
+                            $assertions['sanity'][] = '$this->assertCount(1, $'.$plural.');';
                             $assertions['sanity'][] = sprintf('$%s = $%s->first();', $variable, $plural);
                         } else {
-                            $assertions['generic'][] = '$this->assertDatabaseHas(' . Str::camel(Str::plural($model)) . ', [ /* ... */ ]);';
+                            $assertions['generic'][] = '$this->assertDatabaseHas('.Str::camel(Str::plural($model)).', [ /* ... */ ]);';
                         }
                     } elseif ($statement->operation() === 'find') {
                         $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
@@ -426,14 +414,14 @@ class TestGenerator implements Generator
 
                     $setup['data'][] = sprintf('$%s = factory(%s::class, 3)->create();', Str::plural($variable), $model);
 
-                    $this->addImport($controller, $modelNamespace . '\\' . $this->determineModel($controller->prefix(), $statement->model()));
+                    $this->addImport($controller, $modelNamespace.'\\'.$this->determineModel($controller->prefix(), $statement->model()));
                 }
             }
 
             $call = sprintf('$response = $this->%s(route(\'%s.%s\'', $this->httpMethodForAction($name), Str::kebab($context), $name);
 
             if (in_array($name, ['edit', 'update', 'show', 'destroy'])) {
-                $call .= ', $' . Str::camel($context);
+                $call .= ', $'.Str::camel($context);
             }
             $call .= ')';
 
@@ -446,23 +434,23 @@ class TestGenerator implements Generator
                     $call .= PHP_EOL;
                 }
 
-                $call .= str_pad(' ', 8) . ']';
+                $call .= str_pad(' ', 8).']';
             }
             $call .= ');';
 
-            $body = implode(PHP_EOL . PHP_EOL, array_map([$this, 'buildLines'], $this->uniqueSetupLines($setup)));
-            $body .= PHP_EOL . PHP_EOL;
-            $body .= str_pad(' ', 8) . $call;
-            $body .= PHP_EOL . PHP_EOL;
-            $body .= implode(PHP_EOL . PHP_EOL, array_map([$this, 'buildLines'], array_filter($assertions)));
+            $body = implode(PHP_EOL.PHP_EOL, array_map([$this, 'buildLines'], $this->uniqueSetupLines($setup)));
+            $body .= PHP_EOL.PHP_EOL;
+            $body .= str_pad(' ', 8).$call;
+            $body .= PHP_EOL.PHP_EOL;
+            $body .= implode(PHP_EOL.PHP_EOL, array_map([$this, 'buildLines'], array_filter($assertions)));
 
             $test_case = str_replace('dummy_test_case', $this->buildTestCaseName($name, $tested_bits), $test_case);
             $test_case = str_replace('// ...', trim($body), $test_case);
 
-            $test_cases .= PHP_EOL . $test_case . PHP_EOL;
+            $test_cases .= PHP_EOL.$test_case.PHP_EOL;
         }
 
-        return trim($this->buildTraits($controller) . PHP_EOL . $test_cases);
+        return trim($this->buildTraits($controller).PHP_EOL.$test_cases);
     }
 
     protected function addTrait(Controller $controller, $trait)
@@ -479,13 +467,13 @@ class TestGenerator implements Generator
         $traits = array_unique($this->traits[$controller->name()]);
         sort($traits);
 
-        return 'use ' . implode(', ', $traits) . ';';
+        return 'use '.implode(', ', $traits).';';
     }
 
     private function testCaseStub()
     {
         if (empty($this->stubs['test-case'])) {
-            $this->stubs['test-case'] = $this->files->get(STUBS_PATH . '/test/case.stub');
+            $this->stubs['test-case'] = $this->files->get(STUBS_PATH.'/test/case.stub');
         }
 
         return $this->stubs['test-case'];
@@ -504,7 +492,7 @@ class TestGenerator implements Generator
         sort($imports);
 
         return implode(PHP_EOL, array_map(function ($class) {
-            return 'use ' . $class . ';';
+            return 'use '.$class.';';
         }, $imports));
     }
 
@@ -524,10 +512,10 @@ class TestGenerator implements Generator
     private function buildFormRequestName(Controller $controller, string $name)
     {
         if (empty($controller->namespace())) {
-            return $controller->name() . Str::studly($name) . 'Request';
+            return $controller->name().Str::studly($name).'Request';
         }
 
-        return $controller->namespace() . '\\' . $controller->name() . Str::studly($name) . 'Request';
+        return $controller->namespace().'\\'.$controller->name().Str::studly($name).'Request';
     }
 
     private function buildFormRequestTestCase(string $controller, string $action, string $form_request)
@@ -604,21 +592,21 @@ END;
         }
 
         if (empty($verifications)) {
-            return $name . '_behaves_as_expected';
+            return $name.'_behaves_as_expected';
         }
 
         $final_verification = array_pop($verifications);
 
         if (empty($verifications)) {
-            return $name . '_' . $final_verification;
+            return $name.'_'.$final_verification;
         }
 
-        return $name . '_' . implode('_', $verifications) . '_and_' . $final_verification;
+        return $name.'_'.implode('_', $verifications).'_and_'.$final_verification;
     }
 
     private function buildLines($lines)
     {
-        return str_pad(' ', 8) . implode(PHP_EOL . str_pad(' ', 8), $lines);
+        return str_pad(' ', 8).implode(PHP_EOL.str_pad(' ', 8), $lines);
     }
 
     private function modelForContext(string $context)
@@ -628,14 +616,12 @@ END;
         }
 
         $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/' . Str::studly($context));
+            return Str::endsWith($key, '/'.Str::studly($context));
         });
 
         if (count($matches) === 1) {
             return $this->models[$matches[0]];
         }
-
-        return null;
     }
 
     private function registerModels(array $tree)

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -40,28 +40,43 @@ class TestGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(array $tree, array $only = [], array $skip = []): array
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH . '/test/class.stub');
+        if ($this->shouldGenerate($only, $skip)) {
+            $stub = $this->files->get(STUBS_PATH . '/test/class.stub');
 
-        $this->registerModels($tree);
+            $this->registerModels($tree);
 
-        /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
-            $path = $this->getPath($controller);
+            /** @var \Blueprint\Models\Controller $controller */
+            foreach ($tree['controllers'] as $controller) {
+                $path = $this->getPath($controller);
 
-            if (!$this->files->exists(dirname($path))) {
-                $this->files->makeDirectory(dirname($path), 0755, true);
+                if (!$this->files->exists(dirname($path))) {
+                    $this->files->makeDirectory(dirname($path), 0755, true);
+                }
+
+                $this->files->put($path, $this->populateStub($stub, $controller));
+
+                $output['created'][] = $path;
             }
-
-            $this->files->put($path, $this->populateStub($stub, $controller));
-
-            $output['created'][] = $path;
         }
 
         return $output;
+    }
+
+    protected function shouldGenerate(array $only, array $skip): bool
+    {
+        if (count($only)) {
+            return in_array('tests', $only);
+        }
+
+        if (count($skip)) {
+            return !in_array('tests', $skip);
+        }
+
+        return true;
     }
 
     protected function getPath(Controller $controller)

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -63,7 +63,7 @@ class BlueprintTest extends TestCase
                     'user_id' => 'id',
                 ],
             ],
-            'seeders' => 'Post, Comment'
+            'seeders' => 'Post, Comment',
         ], $this->subject->parse($blueprint));
     }
 
@@ -78,10 +78,10 @@ class BlueprintTest extends TestCase
             'controllers' => [
                 'UserController' => [
                     'index' => [
-                        'action' => 'detail'
+                        'action' => 'detail',
                     ],
                     'create' => [
-                        'action' => 'additional detail'
+                        'action' => 'additional detail',
                     ],
                 ],
                 'RoleController' => [
@@ -111,9 +111,9 @@ class BlueprintTest extends TestCase
             ],
             'controllers' => [
                 'Context' => [
-                    'resource' => 'web'
-                ]
-            ]
+                    'resource' => 'web',
+                ],
+            ],
         ], $this->subject->parse($blueprint));
     }
 
@@ -130,7 +130,7 @@ class BlueprintTest extends TestCase
                     'id' => 'uuid primary',
                     'timestamps' => 'timestamps',
                 ],
-            ]
+            ],
         ], $this->subject->parse($blueprint));
     }
 
@@ -343,7 +343,7 @@ class BlueprintTest extends TestCase
         $this->assertEquals(
             [
                 'models' => [],
-                'controllers' => []
+                'controllers' => [],
             ],
             $this->subject->analyze($tokens)
         );
@@ -365,7 +365,7 @@ class BlueprintTest extends TestCase
         $this->assertEquals([
             'models' => [],
             'controllers' => [],
-            'mock' => 'lexer'
+            'mock' => 'lexer',
         ], $this->subject->analyze($tokens));
     }
 
@@ -376,24 +376,34 @@ class BlueprintTest extends TestCase
     {
         $generatorOne = \Mockery::mock(Generator::class);
         $tree = ['branch' => ['code', 'attributes']];
-        $only = [];
-        $skip = [];
 
         $generatorOne->expects('output')
-            ->with($tree, $only, $skip)
+            ->with($tree)
             ->andReturn([
                 'created' => ['one/new.php'],
                 'updated' => ['one/existing.php'],
-                'deleted' => ['one/trashed.php']
+                'deleted' => ['one/trashed.php'],
+            ]);
+
+        $generatorOne->expects('types')
+            ->andReturn([
+                'some',
+                'types',
             ]);
 
         $generatorTwo = \Mockery::mock(Generator::class);
         $generatorTwo->expects('output')
-            ->with($tree, $only, $skip)
+            ->with($tree)
             ->andReturn([
                 'created' => ['two/new.php'],
                 'updated' => ['two/existing.php'],
-                'deleted' => ['two/trashed.php']
+                'deleted' => ['two/trashed.php'],
+            ]);
+
+        $generatorTwo->expects('types')
+            ->andReturn([
+                'some',
+                'types',
             ]);
 
         $this->subject->registerGenerator($generatorOne);
@@ -413,18 +423,22 @@ class BlueprintTest extends TestCase
     {
         $generatorOne = \Mockery::mock(Generator::class);
         $tree = ['branch' => ['code', 'attributes']];
-        $only = [];
-        $skip = [];
 
         $generatorOne->expects('output')->never();
 
         $generatorSwap = \Mockery::mock(Generator::class);
         $generatorSwap->expects('output')
-            ->with($tree, $only, $skip)
+            ->with($tree)
             ->andReturn([
                 'created' => ['swapped/new.php'],
                 'updated' => ['swapped/existing.php'],
-                'deleted' => ['swapped/trashed.php']
+                'deleted' => ['swapped/trashed.php'],
+            ]);
+
+        $generatorSwap->expects('types')
+            ->andReturn([
+                'some',
+                'types',
             ]);
 
         $this->subject->registerGenerator($generatorOne);

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -453,6 +453,210 @@ class BlueprintTest extends TestCase
 
     /**
      * @test
+     */
+    public function generate_only_one_specific_type()
+    {
+        $generatorFoo = \Mockery::mock(Generator::class);
+        $tree = ['branch' => ['code', 'attributes']];
+
+        $only = ['bar'];
+        $skip = [];
+
+        $generatorFoo->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['foo.php'],
+            ]);
+
+        $generatorFoo->shouldReceive('types')
+            ->andReturn(['foo']);
+
+        $generatorBar = \Mockery::mock(Generator::class);
+        $generatorBar->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['bar.php'],
+            ]);
+
+        $generatorBar->shouldReceive('types')
+            ->andReturn(['bar']);
+
+        $generatorBaz = \Mockery::mock(Generator::class);
+        $generatorBaz->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['baz.php'],
+            ]);
+
+        $generatorBaz->shouldReceive('types')
+            ->andReturn(['baz']);
+
+        $this->subject->registerGenerator($generatorFoo);
+        $this->subject->registerGenerator($generatorBar);
+        $this->subject->registerGenerator($generatorBaz);
+
+        $actual = $this->subject->generate($tree, $only, $skip);
+
+        $this->assertEquals([
+            'created' => ['bar.php'],
+        ], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function generate_only_specific_types()
+    {
+        $generatorFoo = \Mockery::mock(Generator::class);
+        $tree = ['branch' => ['code', 'attributes']];
+
+        $only = ['foo', 'bar'];
+        $skip = [];
+
+        $generatorFoo->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['foo.php'],
+            ]);
+
+        $generatorFoo->shouldReceive('types')
+            ->andReturn(['foo']);
+
+        $generatorBar = \Mockery::mock(Generator::class);
+        $generatorBar->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['bar.php'],
+            ]);
+
+        $generatorBar->shouldReceive('types')
+            ->andReturn(['bar']);
+
+        $generatorBaz = \Mockery::mock(Generator::class);
+        $generatorBaz->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['baz.php'],
+            ]);
+
+        $generatorBaz->shouldReceive('types')
+            ->andReturn(['baz']);
+
+        $this->subject->registerGenerator($generatorFoo);
+        $this->subject->registerGenerator($generatorBar);
+        $this->subject->registerGenerator($generatorBaz);
+
+        $actual = $this->subject->generate($tree, $only, $skip);
+
+        $this->assertEquals([
+            'created' => ['foo.php', 'bar.php'],
+        ], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function generate_should_skip_one_specific_type()
+    {
+        $generatorFoo = \Mockery::mock(Generator::class);
+        $tree = ['branch' => ['code', 'attributes']];
+
+        $only = [];
+        $skip = ['bar'];
+
+        $generatorFoo->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['foo.php'],
+            ]);
+
+        $generatorFoo->shouldReceive('types')
+            ->andReturn(['foo']);
+
+        $generatorBar = \Mockery::mock(Generator::class);
+        $generatorBar->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['bar.php'],
+            ]);
+
+        $generatorBar->shouldReceive('types')
+            ->andReturn(['bar']);
+
+        $generatorBaz = \Mockery::mock(Generator::class);
+        $generatorBaz->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['baz.php'],
+            ]);
+
+        $generatorBaz->shouldReceive('types')
+            ->andReturn(['baz']);
+
+        $this->subject->registerGenerator($generatorFoo);
+        $this->subject->registerGenerator($generatorBar);
+        $this->subject->registerGenerator($generatorBaz);
+
+        $actual = $this->subject->generate($tree, $only, $skip);
+
+        $this->assertEquals([
+            'created' => ['foo.php', 'baz.php'],
+        ], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function generate_should_skip_specific_types()
+    {
+        $generatorFoo = \Mockery::mock(Generator::class);
+        $tree = ['branch' => ['code', 'attributes']];
+
+        $only = [];
+        $skip = ['bar', 'baz'];
+
+        $generatorFoo->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['foo.php'],
+            ]);
+
+        $generatorFoo->shouldReceive('types')
+            ->andReturn(['foo']);
+
+        $generatorBar = \Mockery::mock(Generator::class);
+        $generatorBar->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['bar.php'],
+            ]);
+
+        $generatorBar->shouldReceive('types')
+            ->andReturn(['bar']);
+
+        $generatorBaz = \Mockery::mock(Generator::class);
+        $generatorBaz->shouldReceive('output')
+            ->with($tree)
+            ->andReturn([
+                'created' => ['baz.php'],
+            ]);
+
+        $generatorBaz->shouldReceive('types')
+            ->andReturn(['baz']);
+
+        $this->subject->registerGenerator($generatorFoo);
+        $this->subject->registerGenerator($generatorBar);
+        $this->subject->registerGenerator($generatorBaz);
+
+        $actual = $this->subject->generate($tree, $only, $skip);
+
+        $this->assertEquals([
+            'created' => ['foo.php'],
+        ], $actual);
+    }
+
+    /**
+     * @test
      * @dataProvider namespacesDataProvider
      */
     public function relative_namespace_removes_namespace_prefix_from_reference($namespace, $expected, $reference)

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -340,11 +340,13 @@ class BlueprintTest extends TestCase
     {
         $tokens = [];
 
-        $this->assertEquals([
-            'models' => [],
-            'controllers' => []
-        ],
-            $this->subject->analyze($tokens));
+        $this->assertEquals(
+            [
+                'models' => [],
+                'controllers' => []
+            ],
+            $this->subject->analyze($tokens)
+        );
     }
 
     /**
@@ -374,8 +376,11 @@ class BlueprintTest extends TestCase
     {
         $generatorOne = \Mockery::mock(Generator::class);
         $tree = ['branch' => ['code', 'attributes']];
+        $only = [];
+        $skip = [];
+
         $generatorOne->expects('output')
-            ->with($tree)
+            ->with($tree, $only, $skip)
             ->andReturn([
                 'created' => ['one/new.php'],
                 'updated' => ['one/existing.php'],
@@ -384,7 +389,7 @@ class BlueprintTest extends TestCase
 
         $generatorTwo = \Mockery::mock(Generator::class);
         $generatorTwo->expects('output')
-            ->with($tree)
+            ->with($tree, $only, $skip)
             ->andReturn([
                 'created' => ['two/new.php'],
                 'updated' => ['two/existing.php'],
@@ -408,11 +413,14 @@ class BlueprintTest extends TestCase
     {
         $generatorOne = \Mockery::mock(Generator::class);
         $tree = ['branch' => ['code', 'attributes']];
+        $only = [];
+        $skip = [];
+
         $generatorOne->expects('output')->never();
 
         $generatorSwap = \Mockery::mock(Generator::class);
         $generatorSwap->expects('output')
-            ->with($tree)
+            ->with($tree, $only, $skip)
             ->andReturn([
                 'created' => ['swapped/new.php'],
                 'updated' => ['swapped/existing.php'],

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -17,6 +17,8 @@ class BuilderTest extends TestCase
         $draft = 'draft blueprint content';
         $tokens = ['some', 'blueprint', 'tokens'];
         $registry = ['controllers' => [1, 2, 3]];
+        $only = [];
+        $skip = [];
         $generated = ['created' => [1, 2], 'updated' => [3]];
 
         $blueprint = \Mockery::mock(Blueprint::class);
@@ -27,7 +29,7 @@ class BuilderTest extends TestCase
             ->with($tokens + ['cache' => []])
             ->andReturn($registry);
         $blueprint->expects('generate')
-            ->with($registry)
+            ->with($registry, $only, $skip)
             ->andReturn($generated);
         $blueprint->expects('dump')
             ->with($generated)
@@ -63,6 +65,8 @@ class BuilderTest extends TestCase
             'models' => [1, 2, 3]
         ];
         $registry = ['registry'];
+        $only = [];
+        $skip = [];
         $generated = ['created' => [1, 2], 'updated' => [3]];
 
         $blueprint = \Mockery::mock(Blueprint::class);
@@ -76,7 +80,7 @@ class BuilderTest extends TestCase
             ->with($tokens + ['cache' => $cache['models']])
             ->andReturn($registry);
         $blueprint->expects('generate')
-            ->with($registry)
+            ->with($registry, $only, $skip)
             ->andReturn($generated);
         $blueprint->expects('dump')
             ->with([


### PR DESCRIPTION
Closes #247 

This is an implementation of the `--only` and `--skip` command line options for the `blueprint:build` command.

Both commands take a comma separated list of 'file classes' (for the lack of a better word), those being:

* controllers
* factories
* migrations
* models
* routes
* seeders
* tests
* events
* requests
* jobs
* mails
* notifications
* resources
* views

The command passes the string values to `Blueprint\Builder::execute()` as additional, optional parameters `$only` and `$skip`. The action body will convert these strings to arrays, and passes those arrays to `$blueprint->generate()` alongside of the `$registry`. This action iterates over the registered  `$this->generators` and for each one call `output()`, again passing the `$tree`, `$only` and `$skip`.

Each registered generator implements `Blueprint\Contracts\Generator`. The contract is updated to include `array $only, array $skip` in the `output()` signature, which demands all of the generators adhere to this.

Inside the `output()` action of each generator, I have wrapped the output generation inside an `if` statement that references a `$this->shouldGenerate()` method, passing the `$only` and `$skip` to that method, which returns a boolean value whether it should generate or not.

Currently, the `shouldGenerate()` utilizes `in_array()` calls, using a hardcoded string to identify the 'file class'. Perhaps this should be extracted to a protected instance variable, but I am unsure what to call it.

With regards to the test suite: of course this blew up everything, as everything Mocked needed to be modified. In this Work in Progress I've managed to get the test suite to green again, but I still need to implement test cases to verify the proper workings of both command line options.

Now, before I do that, I thought it might be wise to put it under early review before continuing.

I am looking forward to all your feedback, so that I can modify/proceed accordingly.
