### PR TITLE
Register custom type to support MySQL enums

### DIFF
--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -134,14 +134,14 @@ class TraceCommand extends Command
 
         $columns = $schema->listTableColumns($table, $database);
 
-        $uses_enums = collect($columns)->contains(function($column) {
+        $uses_enums = collect($columns)->contains(function ($column) {
             return $column->getType() instanceof \Blueprint\EnumType;
         });
 
         if ($uses_enums) {
             $definitions = $model->getConnection()->getDoctrineConnection()->fetchAll($schema->getDatabasePlatform()->getListTableColumnsSQL($table, $database));
 
-            collect($columns)->filter(function($column) {
+            collect($columns)->filter(function ($column) {
                 return $column->getType() instanceof \Blueprint\EnumType;
             })->each(function (&$column, $key) use ($definitions) {
                 $definition = collect($definitions)->where('Field', $key)->first();

--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -3,6 +3,8 @@
 namespace Blueprint\Commands;
 
 use Blueprint\Blueprint;
+use Blueprint\EnumType;
+use Doctrine\DBAL\Types\Type;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
@@ -119,12 +121,34 @@ class TraceCommand extends Command
         $table = $model->getConnection()->getTablePrefix() . $model->getTable();
         $schema = $model->getConnection()->getDoctrineSchemaManager();
 
+        if (!Type::hasType('enum')) {
+            Type::addType('enum', EnumType::class);
+            $databasePlatform = $schema->getDatabasePlatform();
+            $databasePlatform->registerDoctrineTypeMapping('enum', 'enum');
+        }
+
         $database = null;
         if (strpos($table, '.')) {
-            list($database, $table) = explode('.', $table);
+            [$database, $table] = explode('.', $table);
         }
 
         $columns = $schema->listTableColumns($table, $database);
+
+        $uses_enums = collect($columns)->contains(function($column) {
+            return $column->getType() instanceof \Blueprint\EnumType;
+        });
+
+        if ($uses_enums) {
+            $definitions = $model->getConnection()->getDoctrineConnection()->fetchAll($schema->getDatabasePlatform()->getListTableColumnsSQL($table, $database));
+
+            collect($columns)->filter(function($column) {
+                return $column->getType() instanceof \Blueprint\EnumType;
+            })->each(function (&$column, $key) use ($definitions) {
+                $definition = collect($definitions)->where('Field', $key)->first();
+
+                $column->options = \Blueprint\EnumType::extractOptions($definition['Type']);
+            });
+        }
 
         return $columns;
     }
@@ -160,9 +184,11 @@ class TraceCommand extends Command
             if ($column->getLength() > 65535) {
                 $type = 'longtext';
             }
+        } elseif ($type === 'enum' && !empty($column->options)) {
+            $type .= ':' . implode(',', $column->options);
         }
 
-        // TODO: enums, guid/uuid
+        // TODO: guid/uuid
 
         $attributes[] = $type;
 
@@ -201,6 +227,7 @@ class TraceCommand extends Command
             'datetimetz' => 'datetimetz',
             'datetimetz_immutable' => 'datetimetz',
             'decimal' => 'decimal',
+            'enum' => 'enum',
             'float' => 'float',
             'guid' => 'string',
             'integer' => 'integer',

--- a/src/EnumType.php
+++ b/src/EnumType.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Blueprint;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class EnumType extends Type
+{
+    const ENUM = 'enum';
+
+    protected $values = [];
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        $values = array_map(function ($val) {
+            return "'" . $val . "'";
+        }, $this->values);
+
+        return "ENUM(" . implode(", ", $values) . ")";
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return $value;
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (!in_array($value, $this->values)) {
+            throw new \InvalidArgumentException("Invalid '" . $this->getName() . "' value.");
+        }
+        return $value;
+    }
+
+    public function getName()
+    {
+        return self::ENUM;
+    }
+
+    public static function extractOptions($definition)
+    {
+        $options = explode(',', preg_replace('/enum\((?P<options>(.*))\)/', '$1', $definition));
+
+        return array_map(function ($option) {
+            $raw_value = str_replace("''", "'", trim($option, "'"));
+
+            if (!preg_match('/\s/', $raw_value)) {
+                return $raw_value;
+            }
+
+            return sprintf('"%s"', $raw_value);
+        }, $options);
+    }
+}

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -127,10 +127,7 @@ class MigrationGenerator implements Generator
             if (!empty($column->attributes()) && !in_array($column->dataType(), ['id', 'uuid'])) {
                 $column_definition .= ', ';
                 if (in_array($column->dataType(), ['set', 'enum'])) {
-                    $options = array_map(function ($attribute) {
-                        return trim($attribute, '"');
-                    }, $column->attributes());
-                    $column_definition .= json_encode($options);
+                    $column_definition .= json_encode($column->attributes());
                 } else {
                     $column_definition .= implode(', ', $column->attributes());
                 }

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -127,7 +127,10 @@ class MigrationGenerator implements Generator
             if (!empty($column->attributes()) && !in_array($column->dataType(), ['id', 'uuid'])) {
                 $column_definition .= ', ';
                 if (in_array($column->dataType(), ['set', 'enum'])) {
-                    $column_definition .= json_encode($column->attributes());
+                    $options = array_map(function ($attribute) {
+                        return trim($attribute, '"');
+                    }, $column->attributes());
+                    $column_definition .= json_encode($options);
                 } else {
                     $column_definition .= implode(', ', $column->attributes());
                 }

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -221,6 +221,12 @@ class ModelLexer implements Lexer
                 $data_type = self::$dataTypes[strtolower($value)];
                 if (!empty($attributes)) {
                     $attributes = explode(',', $attributes);
+
+                    if ($data_type === 'enum') {
+                        $attributes = array_map(function ($attribute) {
+                            return trim($attribute, '"');
+                        }, $attributes);
+                    }
                 }
             }
 

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -640,6 +640,7 @@ class MigrationGeneratorTest extends TestCase
             ['drafts/uuid-shorthand.yaml', 'database/migrations/timestamp_create_people_table.php', 'migrations/uuid-shorthand.php'],
             ['drafts/unconventional-foreign-key.yaml', 'database/migrations/timestamp_create_states_table.php', 'migrations/unconventional-foreign-key.php'],
             ['drafts/resource-statements.yaml', 'database/migrations/timestamp_create_users_table.php', 'migrations/resource-statements.php'],
+            ['drafts/enum-options.yaml', 'database/migrations/timestamp_create_messages_table.php', 'migrations/enum-options.php'],
         ];
     }
 }

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -652,6 +652,7 @@ class ModelLexerTest extends TestCase
             ['char:10', 'char', [10]],
             ['string:1000', 'string', [1000]],
             ['enum:one,two,three,four', 'enum', ['one', 'two', 'three', 'four']],
+            ['enum:"Jason McCreary",Shift,O\'Doul', 'enum', ['Jason McCreary', 'Shift', 'O\'Doul']],
             ['set:1,2,3,4', 'set', [1, 2, 3, 4]],
         ];
     }

--- a/tests/Unit/EnumTypeTest.php
+++ b/tests/Unit/EnumTypeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit;
+
+use Blueprint\Blueprint;
+use Blueprint\Builder;
+use Illuminate\Filesystem\Filesystem;
+use Tests\TestCase;
+
+/**
+ * @covers \Blueprint\EnumType
+ */
+class EnumTypeTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider enumOptionsDataProvider
+     */
+    public function it_returns_options_for_enum($definition, $expected)
+    {
+        $this->assertEquals($expected, \Blueprint\EnumType::extractOptions($definition));
+    }
+
+    public function enumOptionsDataProvider()
+    {
+        return [
+            ["enum('1','2','3')", [1, 2, 3]],
+            ["enum('One','Two','Three')", ['One', 'Two', 'Three']],
+            ["enum('Spaced and quoted names','John Doe','Connon O''Brien','O''Doul')", ['"Spaced and quoted names"', '"John Doe"','"Connon O\'Brien"', 'O\'Doul']],
+        ];
+    }
+}

--- a/tests/fixtures/drafts/enum-options.yaml
+++ b/tests/fixtures/drafts/enum-options.yaml
@@ -1,0 +1,4 @@
+models:
+  Message:
+    type: enum:SMS,Email,Push
+    name: enum:1,"Jason McCreary",O'Brein,4 nullable

--- a/tests/fixtures/migrations/enum-options.php
+++ b/tests/fixtures/migrations/enum-options.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->enum('type', ["SMS","Email","Push"]);
+            $table->enum('name', ["1","Jason McCreary","O'Brein","4"])->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('messages');
+    }
+}


### PR DESCRIPTION
This adds enum support when running the `trace` command on existing models which define a column of type `enum`. 

**Note:** while other RDBMSes may _support_ the `enum` type, this is currently only tested on MySQL.

---
Fixes #218