### PR TITLE
Add reference factory support to validation shorthand

### DIFF
--- a/tests/fixtures/drafts/model-reference-validate.yaml
+++ b/tests/fixtures/drafts/model-reference-validate.yaml
@@ -1,7 +1,7 @@
 models:
   Certificate:
     name: string
-    certificate_type_id: id
+    certificate_type_id: id:certificate_type
     reference: string
     document: string
     expiry_date: date

--- a/tests/fixtures/tests/api-shorthand-validation.php
+++ b/tests/fixtures/tests/api-shorthand-validation.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Certificate;
+use App\CertificateType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
@@ -44,14 +45,14 @@ class CertificateControllerTest extends TestCase
     public function store_saves()
     {
         $name = $this->faker->name;
-        $certificate_type_id = $this->faker->randomDigitNotNull;
+        $certificate_type = factory(CertificateType::class)->create();
         $reference = $this->faker->word;
         $document = $this->faker->word;
         $expiry_date = $this->faker->date();
 
         $response = $this->post(route('certificate.store'), [
             'name' => $name,
-            'certificate_type_id' => $certificate_type_id,
+            'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
             'expiry_date' => $expiry_date,
@@ -59,7 +60,7 @@ class CertificateControllerTest extends TestCase
 
         $certificates = Certificate::query()
             ->where('name', $name)
-            ->where('certificate_type_id', $certificate_type_id)
+            ->where('certificate_type_id', $certificate_type->id)
             ->where('reference', $reference)
             ->where('document', $document)
             ->where('expiry_date', $expiry_date)
@@ -99,14 +100,14 @@ class CertificateControllerTest extends TestCase
     {
         $certificate = factory(Certificate::class)->create();
         $name = $this->faker->name;
-        $certificate_type_id = $this->faker->randomDigitNotNull;
+        $certificate_type = factory(CertificateType::class)->create();
         $reference = $this->faker->word;
         $document = $this->faker->word;
         $expiry_date = $this->faker->date();
 
         $response = $this->put(route('certificate.update', $certificate), [
             'name' => $name,
-            'certificate_type_id' => $certificate_type_id,
+            'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
             'expiry_date' => $expiry_date,


### PR DESCRIPTION
I saw you left a TODO in #280 and while i was migrating this change to my pest add-on I added support to generate the reference factories in tests. 

So with a draft of:

```yml
models:
  Certificate:
    name: string
    certificate_type_id: id:certificate_type
    reference: string
    document: string
    expiry_date: date
    remarks: text nullable

controllers:
  Certificate:
    resource: api
```

**Before**
```php
$certificate_type_id = $this->faker->randomDigitNotNull;
```

**After**
```php
$certificate_type = factory(CertificateType::class)->create();
```

**Changes**
The private `generateReferenceFactory` function has been added to the `TestGenerator` with the factory generation code recently moved there as the same logic is now applied in two locations. 

I don't really like using the array references as arguments but its the best I could come up within then given structure. 

In the addon I am maintaining I switched this  to a [PendingOutput](https://github.com/fidum/laravel-blueprint-pestphp-addon/blob/master/src/Builders/PendingOutput.php) object so that I could manage output in any function. 

I look forward to your feedback 🙌 