### PR TITLE
Use factory for referenced relationships in validation statements

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -660,15 +660,15 @@ END;
     ): bool {
         if (
             ($local_column->dataType() === 'id' || $local_column->dataType() === 'uuid')
-            && ($local_column->attributes() && Str::endsWith($local_column->name(), '_id'))
+            && ($local_column->attributes() || Str::endsWith($local_column->name(), '_id'))
         ) {
-            $variable_name = Str::beforeLast($local_column->name(), '_id');
-            $reference = $variable_name;
+            $reference = Str::beforeLast($local_column->name(), '_id');
+            $variable_name = $reference .'->id';
 
             if ($local_column->attributes()) {
                 $reference = $local_column->attributes()[0];
-                $variable_name .= '->id';
             }
+
             $faker = sprintf('$%s = factory(%s::class)->create();', Str::beforeLast($local_column->name(), '_id'), Str::studly($reference));
 
             $this->addImport($controller, $modelNamespace.'\\'.Str::studly($reference));

--- a/tests/fixtures/drafts/model-reference-validate.yaml
+++ b/tests/fixtures/drafts/model-reference-validate.yaml
@@ -1,7 +1,7 @@
 models:
   Certificate:
     name: string
-    certificate_type_id: id
+    certificate_type_id: id:certificate_type
     reference: string
     document: string
     expiry_date: date

--- a/tests/fixtures/drafts/model-reference-validate.yaml
+++ b/tests/fixtures/drafts/model-reference-validate.yaml
@@ -1,11 +1,15 @@
 models:
   Certificate:
     name: string
-    certificate_type_id: id:certificate_type
+    certificate_type_id: id
     reference: string
     document: string
     expiry_date: date
-    remarks: text nullable
+    remarks: nullable text
+  CertificateType:
+    name: string
+    relationships:
+      hasMany: Certificate
 
 controllers:
   Certificate:

--- a/tests/fixtures/tests/api-shorthand-validation.php
+++ b/tests/fixtures/tests/api-shorthand-validation.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Certificate;
+use App\CertificateType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
@@ -44,14 +45,14 @@ class CertificateControllerTest extends TestCase
     public function store_saves()
     {
         $name = $this->faker->name;
-        $certificate_type_id = $this->faker->randomDigitNotNull;
+        $certificate_type = factory(CertificateType::class)->create();
         $reference = $this->faker->word;
         $document = $this->faker->word;
         $expiry_date = $this->faker->date();
 
         $response = $this->post(route('certificate.store'), [
             'name' => $name,
-            'certificate_type_id' => $certificate_type_id,
+            'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
             'expiry_date' => $expiry_date,
@@ -59,7 +60,7 @@ class CertificateControllerTest extends TestCase
 
         $certificates = Certificate::query()
             ->where('name', $name)
-            ->where('certificate_type_id', $certificate_type_id)
+            ->where('certificate_type_id', $certificate_type->id)
             ->where('reference', $reference)
             ->where('document', $document)
             ->where('expiry_date', $expiry_date)
@@ -99,14 +100,14 @@ class CertificateControllerTest extends TestCase
     {
         $certificate = factory(Certificate::class)->create();
         $name = $this->faker->name;
-        $certificate_type_id = $this->faker->randomDigitNotNull;
+        $certificate_type = factory(CertificateType::class)->create();
         $reference = $this->faker->word;
         $document = $this->faker->word;
         $expiry_date = $this->faker->date();
 
         $response = $this->put(route('certificate.update', $certificate), [
             'name' => $name,
-            'certificate_type_id' => $certificate_type_id,
+            'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
             'expiry_date' => $expiry_date,

--- a/tests/fixtures/tests/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-pascal-case-example.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Certificate;
+use App\CertificateType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
@@ -44,14 +45,14 @@ class CertificateControllerTest extends TestCase
     public function store_saves()
     {
         $name = $this->faker->name;
-        $certificate_type_id = $this->faker->randomDigitNotNull;
+        $certificate_type = factory(CertificateType::class)->create();
         $reference = $this->faker->word;
         $document = $this->faker->word;
         $expiry_date = $this->faker->date();
 
         $response = $this->post(route('certificate.store'), [
             'name' => $name,
-            'certificate_type_id' => $certificate_type_id,
+            'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
             'expiry_date' => $expiry_date,
@@ -59,7 +60,7 @@ class CertificateControllerTest extends TestCase
 
         $certificates = Certificate::query()
             ->where('name', $name)
-            ->where('certificate_type_id', $certificate_type_id)
+            ->where('certificate_type_id', $certificate_type->id)
             ->where('reference', $reference)
             ->where('document', $document)
             ->where('expiry_date', $expiry_date)
@@ -99,14 +100,14 @@ class CertificateControllerTest extends TestCase
     {
         $certificate = factory(Certificate::class)->create();
         $name = $this->faker->name;
-        $certificate_type_id = $this->faker->randomDigitNotNull;
+        $certificate_type = factory(CertificateType::class)->create();
         $reference = $this->faker->word;
         $document = $this->faker->word;
         $expiry_date = $this->faker->date();
 
         $response = $this->put(route('certificate.update', $certificate), [
             'name' => $name,
-            'certificate_type_id' => $certificate_type_id,
+            'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
             'expiry_date' => $expiry_date,


### PR DESCRIPTION
This finalizes #207 and supersedes the work done in #281 to bring full support for properly using factories to set up fake data within tests for referenced models.