### PR TITLE
Use strict check on null instead of empty()

### DIFF
--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -232,7 +232,7 @@ class ModelLexer implements Lexer
 
             if (isset(self::$modifiers[strtolower($value)])) {
                 $modifierAttributes = $parts[1] ?? null;
-                if (empty($modifierAttributes)) {
+                if ($modifierAttributes === null) {
                     $modifiers[] = self::$modifiers[strtolower($value)];
                 } else {
                     $modifiers[] = [self::$modifiers[strtolower($value)] => $modifierAttributes];

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -662,6 +662,7 @@ class ModelLexerTest extends TestCase
         return [
             ['default:5', 'default', 5],
             ['default:0.00', 'default', 0.00],
+            ['default:0', 'default', 0],
             ['default:string', 'default', 'string'],
             ["default:'empty'", 'default', "'empty'"],
             ['default:""', 'default', '""'],


### PR DESCRIPTION
This fixes #285, also added the `default:0` modifier as a test case.