### PR TITLE
Generate simple assertions for resource statements

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -12,6 +12,7 @@ use Blueprint\Models\Statements\FireStatement;
 use Blueprint\Models\Statements\QueryStatement;
 use Blueprint\Models\Statements\RedirectStatement;
 use Blueprint\Models\Statements\RenderStatement;
+use Blueprint\Models\Statements\ResourceStatement;
 use Blueprint\Models\Statements\RespondStatement;
 use Blueprint\Models\Statements\SendStatement;
 use Blueprint\Models\Statements\SessionStatement;
@@ -376,6 +377,9 @@ class TestGenerator implements Generator
                     $assertion .= '));';
 
                     array_unshift($assertions['response'], $assertion);
+                } elseif ($statement instanceof ResourceStatement) {
+                    $assertions['response'][] = '$response->assertOk();';
+                    $assertions['response'][] = '$response->assertJsonStructure([]);';
                 } elseif ($statement instanceof RespondStatement) {
                     $tested_bits |= self::TESTS_RESPONDS;
 

--- a/tests/fixtures/tests/api-shorthand-validation.php
+++ b/tests/fixtures/tests/api-shorthand-validation.php
@@ -24,6 +24,9 @@ class CertificateControllerTest extends TestCase
         $certificates = factory(Certificate::class, 3)->create();
 
         $response = $this->get(route('certificate.index'));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -67,6 +70,9 @@ class CertificateControllerTest extends TestCase
             ->get();
         $this->assertCount(1, $certificates);
         $certificate = $certificates->first();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -78,6 +84,9 @@ class CertificateControllerTest extends TestCase
         $certificate = factory(Certificate::class)->create();
 
         $response = $this->get(route('certificate.show', $certificate));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -114,6 +123,9 @@ class CertificateControllerTest extends TestCase
         ]);
 
         $certificate->refresh();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
 
         $this->assertEquals($name, $certificate->name);
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);

--- a/tests/fixtures/tests/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-pascal-case-example.php
@@ -24,6 +24,9 @@ class CertificateControllerTest extends TestCase
         $certificates = factory(Certificate::class, 3)->create();
 
         $response = $this->get(route('certificate.index'));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -67,6 +70,9 @@ class CertificateControllerTest extends TestCase
             ->get();
         $this->assertCount(1, $certificates);
         $certificate = $certificates->first();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -78,6 +84,9 @@ class CertificateControllerTest extends TestCase
         $certificate = factory(Certificate::class)->create();
 
         $response = $this->get(route('certificate.show', $certificate));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -114,6 +123,9 @@ class CertificateControllerTest extends TestCase
         ]);
 
         $certificate->refresh();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
 
         $this->assertEquals($name, $certificate->name);
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);

--- a/tests/fixtures/tests/certificate-type-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-type-pascal-case-example.php
@@ -23,6 +23,9 @@ class CertificateTypeControllerTest extends TestCase
         $certificateTypes = factory(CertificateType::class, 3)->create();
 
         $response = $this->get(route('certificate-type.index'));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -54,6 +57,9 @@ class CertificateTypeControllerTest extends TestCase
             ->get();
         $this->assertCount(1, $certificateTypes);
         $certificateType = $certificateTypes->first();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -65,6 +71,9 @@ class CertificateTypeControllerTest extends TestCase
         $certificateType = factory(CertificateType::class)->create();
 
         $response = $this->get(route('certificate-type.show', $certificateType));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -93,6 +102,9 @@ class CertificateTypeControllerTest extends TestCase
         ]);
 
         $certificateType->refresh();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
 
         $this->assertEquals($name, $certificateType->name);
     }

--- a/tests/fixtures/tests/models-with-custom-namespace.php
+++ b/tests/fixtures/tests/models-with-custom-namespace.php
@@ -23,6 +23,9 @@ class CategoryControllerTest extends TestCase
         $categories = factory(Category::class, 3)->create();
 
         $response = $this->get(route('category.index'));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -60,6 +63,9 @@ class CategoryControllerTest extends TestCase
             ->get();
         $this->assertCount(1, $categories);
         $category = $categories->first();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -71,6 +77,9 @@ class CategoryControllerTest extends TestCase
         $category = factory(Category::class)->create();
 
         $response = $this->get(route('category.show', $category));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
     }
 
 
@@ -103,6 +112,9 @@ class CategoryControllerTest extends TestCase
         ]);
 
         $category->refresh();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
 
         $this->assertEquals($name, $category->name);
         $this->assertEquals($image, $category->image);


### PR DESCRIPTION
There were no assertions being generated for `resource` statements. This adds some basic checks which the developer can fill in to strengthen.