### PR TITLE
Update with request data when using validation

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -104,6 +104,8 @@ class ControllerGenerator implements Generator
             }
 
             $body = '';
+            $using_validation = false;
+
             foreach ($statements as $statement) {
                 if ($statement instanceof SendStatement) {
                     $body .= self::INDENT.$statement->output().PHP_EOL;
@@ -115,6 +117,7 @@ class ControllerGenerator implements Generator
                         $this->addImport($controller, config('blueprint.namespace').'\\Mail\\'.$statement->mail());
                     }
                 } elseif ($statement instanceof ValidateStatement) {
+                    $using_validation = true;
                     $class_name = $controller->name().Str::studly($name).'Request';
 
                     $fqcn = config('blueprint.namespace').'\\Http\\Requests\\'.($controller->namespace() ? $controller->namespace().'\\' : '').$class_name;
@@ -153,7 +156,7 @@ class ControllerGenerator implements Generator
                 } elseif ($statement instanceof SessionStatement) {
                     $body .= self::INDENT.$statement->output().PHP_EOL;
                 } elseif ($statement instanceof EloquentStatement) {
-                    $body .= self::INDENT.$statement->output($controller->prefix(), $name).PHP_EOL;
+                    $body .= self::INDENT.$statement->output($controller->prefix(), $name, $using_validation).PHP_EOL;
                     $this->addImport($controller, $this->determineModel($controller, $statement->reference()));
                 } elseif ($statement instanceof QueryStatement) {
                     $body .= self::INDENT.$statement->output($controller->prefix()).PHP_EOL;

--- a/src/Models/Statements/EloquentStatement.php
+++ b/src/Models/Statements/EloquentStatement.php
@@ -44,7 +44,7 @@ class EloquentStatement
         return $this->columns;
     }
 
-    public function output(string $controller_prefix, string $context): string
+    public function output(string $controller_prefix, string $context, bool $using_validation = false): string
     {
         $model = $this->determineModel($controller_prefix);
         $code = '';
@@ -61,14 +61,17 @@ class EloquentStatement
         }
 
         if ($this->operation() == 'update') {
-            $columns = '';
             if (!empty($this->columns())) {
                 $columns = implode(', ', array_map(function ($column) {
                     return sprintf("'%s' => \$%s", $column, $column);
                 }, $this->columns()));
-            }
 
-            $code = "$" . Str::camel($model) . '->update([' . $columns . ']);';
+                $code = "$" . Str::camel($model) . '->update([' . $columns . ']);';
+            } elseif ($using_validation) {
+                $code = "$" . Str::camel($model) . '->update($request->validated());';
+            } else {
+                $code = "$" . Str::camel($model) . '->update([]);';
+            }
         }
 
         if ($this->operation() == 'find') {

--- a/tests/fixtures/controllers/certificate-controller.php
+++ b/tests/fixtures/controllers/certificate-controller.php
@@ -50,7 +50,7 @@ class CertificateController extends Controller
      */
     public function update(CertificateUpdateRequest $request, Certificate $certificate)
     {
-        $certificate->update([]);
+        $certificate->update($request->validated());
 
         return new CertificateResource($certificate);
     }

--- a/tests/fixtures/controllers/certificate-type-controller.php
+++ b/tests/fixtures/controllers/certificate-type-controller.php
@@ -50,7 +50,7 @@ class CertificateTypeController extends Controller
      */
     public function update(CertificateTypeUpdateRequest $request, CertificateType $certificateType)
     {
-        $certificateType->update([]);
+        $certificateType->update($request->validated());
 
         return new CertificateTypeResource($certificateType);
     }

--- a/tests/fixtures/controllers/custom-models-namespace.php
+++ b/tests/fixtures/controllers/custom-models-namespace.php
@@ -50,7 +50,7 @@ class TagController extends Controller
      */
     public function update(TagUpdateRequest $request, Tag $tag)
     {
-        $tag->update([]);
+        $tag->update($request->validated());
 
         return new TagResource($tag);
     }


### PR DESCRIPTION
This will generate a statement to fill an existing model with the validated request data on _update_. **Note**, this is rather nuanced, only for shorthand references where validation is used.

For example:

```yaml
update:
    validate: post
    update: post
```

But not:

```yaml
update:
    update: post
```

Or:

```yaml
update:
    validate: other, columns
    update: name, title, post
```
---
Fixes #292