### PR TITLE
extract common logic to abstract generator

### DIFF
--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Blueprint\Generators;
+
+use Blueprint\Contracts\Generator as GeneratorContracts;
+
+abstract class Generator implements GeneratorContracts
+{
+    /**
+     * @var \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * @var string
+     */
+    protected $new_instance = 'new instance';
+
+    public function __construct($files)
+    {
+        $this->files = $files;
+    }
+
+    protected function buildConstructor($statement)
+    {
+        static $constructor = null;
+
+        if (is_null($constructor)) {
+            $constructor = str_replace('new instance', $this->new_instance, $this->files->stub('partials/constructor.stub'));
+        }
+
+        if (empty($statement->data())) {
+            return trim($constructor);
+        }
+
+        $stub = $this->buildProperties($statement->data()) . PHP_EOL . PHP_EOL;
+        $stub .= str_replace('__construct()', '__construct(' . $this->buildParameters($statement->data()) . ')', $constructor);
+        $stub = str_replace('//', $this->buildAssignments($statement->data()), $stub);
+
+        return $stub;
+    }
+
+    protected function buildProperties(array $data)
+    {
+        return trim(array_reduce($data, function ($output, $property) {
+            $output .= '    public $' . $property . ';' . PHP_EOL . PHP_EOL;
+
+            return $output;
+        }, ''));
+    }
+
+    private function buildAssignments(array $data)
+    {
+        return trim(array_reduce($data, function ($output, $property) {
+            $output .= '        $this->' . $property . ' = $' . $property . ';' . PHP_EOL;
+
+            return $output;
+        }, ''));
+    }
+
+    private function buildParameters(array $data)
+    {
+        $parameters = array_map(function ($parameter) {
+            return '$' . $parameter;
+        }, $data);
+
+        return implode(', ', $parameters);
+    }
+}

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -49,7 +49,7 @@ abstract class Generator implements GeneratorContracts
         }, ''));
     }
 
-    private function buildAssignments(array $data)
+    protected function buildAssignments(array $data)
     {
         return trim(array_reduce($data, function ($output, $property) {
             $output .= '        $this->' . $property . ' = $' . $property . ';' . PHP_EOL;
@@ -58,7 +58,7 @@ abstract class Generator implements GeneratorContracts
         }, ''));
     }
 
-    private function buildParameters(array $data)
+    protected function buildParameters(array $data)
     {
         $parameters = array_map(function ($parameter) {
             return '$' . $parameter;

--- a/src/Generators/StatementGenerator.php
+++ b/src/Generators/StatementGenerator.php
@@ -2,9 +2,9 @@
 
 namespace Blueprint\Generators;
 
-use Blueprint\Contracts\Generator as GeneratorContracts;
+use Blueprint\Contracts\Generator;
 
-abstract class Generator implements GeneratorContracts
+abstract class StatementGenerator implements Generator
 {
     /**
      * @var \Illuminate\Contracts\Filesystem\Filesystem

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -3,20 +3,12 @@
 namespace Blueprint\Generators\Statements;
 
 use Blueprint\Blueprint;
-use Blueprint\Contracts\Generator;
+use Blueprint\Generators\Generator;
 use Blueprint\Models\Statements\FireStatement;
 
-class EventGenerator implements Generator
+class EventGenerator extends Generator
 {
-    /**
-     * @var \Illuminate\Contracts\Filesystem\Filesystem
-     */
-    private $files;
-
-    public function __construct($files)
-    {
-        $this->files = $files;
-    }
+    protected $new_instance = 'new event instance';
 
     public function output(array $tree): array
     {
@@ -73,51 +65,5 @@ class EventGenerator implements Generator
         $stub = str_replace('// properties...', $this->buildConstructor($fireStatement), $stub);
 
         return $stub;
-    }
-
-    protected function buildConstructor(FireStatement $fireStatement)
-    {
-        static $constructor = null;
-
-        if (is_null($constructor)) {
-            $constructor = str_replace('new instance', 'new event instance', $this->files->stub('partials/constructor.stub'));
-        }
-
-        if (empty($fireStatement->data())) {
-            return trim($constructor);
-        }
-
-        $stub = $this->buildProperties($fireStatement->data()).PHP_EOL.PHP_EOL;
-        $stub .= str_replace('__construct()', '__construct('.$this->buildParameters($fireStatement->data()).')', $constructor);
-        $stub = str_replace('//', $this->buildAssignments($fireStatement->data()), $stub);
-
-        return $stub;
-    }
-
-    private function buildProperties(array $data)
-    {
-        return trim(array_reduce($data, function ($output, $property) {
-            $output .= '    public $'.$property.';'.PHP_EOL.PHP_EOL;
-
-            return $output;
-        }, ''));
-    }
-
-    private function buildParameters(array $data)
-    {
-        $parameters = array_map(function ($parameter) {
-            return '$'.$parameter;
-        }, $data);
-
-        return implode(', ', $parameters);
-    }
-
-    private function buildAssignments(array $data)
-    {
-        return trim(array_reduce($data, function ($output, $property) {
-            $output .= '        $this->'.$property.' = $'.$property.';'.PHP_EOL;
-
-            return $output;
-        }, ''));
     }
 }

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -3,10 +3,10 @@
 namespace Blueprint\Generators\Statements;
 
 use Blueprint\Blueprint;
-use Blueprint\Generators\Generator;
+use Blueprint\Generators\StatementGenerator;
 use Blueprint\Models\Statements\FireStatement;
 
-class EventGenerator extends Generator
+class EventGenerator extends StatementGenerator
 {
     protected $new_instance = 'new event instance';
 

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -3,20 +3,12 @@
 namespace Blueprint\Generators\Statements;
 
 use Blueprint\Blueprint;
-use Blueprint\Contracts\Generator;
+use Blueprint\Generators\Generator;
 use Blueprint\Models\Statements\SendStatement;
 
-class MailGenerator implements Generator
+class MailGenerator extends Generator
 {
-    /**
-     * @var \Illuminate\Contracts\Filesystem\Filesystem
-     */
-    private $files;
-
-    public function __construct($files)
-    {
-        $this->files = $files;
-    }
+    protected $new_instance = 'new message instance';
 
     public function output(array $tree): array
     {
@@ -73,51 +65,5 @@ class MailGenerator implements Generator
         $stub = str_replace('// properties...', $this->buildConstructor($sendStatement), $stub);
 
         return $stub;
-    }
-
-    protected function buildConstructor(SendStatement $sendStatement)
-    {
-        static $constructor = null;
-
-        if (is_null($constructor)) {
-            $constructor = str_replace('new instance', 'new message instance', $this->files->stub('partials/constructor.stub'));
-        }
-
-        if (empty($sendStatement->data())) {
-            return trim($constructor);
-        }
-
-        $stub = $this->buildProperties($sendStatement->data()).PHP_EOL.PHP_EOL;
-        $stub .= str_replace('__construct()', '__construct('.$this->buildParameters($sendStatement->data()).')', $constructor);
-        $stub = str_replace('//', $this->buildAssignments($sendStatement->data()), $stub);
-
-        return $stub;
-    }
-
-    private function buildProperties(array $data)
-    {
-        return trim(array_reduce($data, function ($output, $property) {
-            $output .= '    public $'.$property.';'.PHP_EOL.PHP_EOL;
-
-            return $output;
-        }, ''));
-    }
-
-    private function buildParameters(array $data)
-    {
-        $parameters = array_map(function ($parameter) {
-            return '$'.$parameter;
-        }, $data);
-
-        return implode(', ', $parameters);
-    }
-
-    private function buildAssignments(array $data)
-    {
-        return trim(array_reduce($data, function ($output, $property) {
-            $output .= '        $this->'.$property.' = $'.$property.';'.PHP_EOL;
-
-            return $output;
-        }, ''));
     }
 }

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -3,10 +3,10 @@
 namespace Blueprint\Generators\Statements;
 
 use Blueprint\Blueprint;
-use Blueprint\Generators\Generator;
+use Blueprint\Generators\StatementGenerator;
 use Blueprint\Models\Statements\SendStatement;
 
-class MailGenerator extends Generator
+class MailGenerator extends StatementGenerator
 {
     protected $new_instance = 'new message instance';
 

--- a/src/Generators/Statements/NotificationGenerator.php
+++ b/src/Generators/Statements/NotificationGenerator.php
@@ -3,21 +3,12 @@
 namespace Blueprint\Generators\Statements;
 
 use Blueprint\Blueprint;
-use Blueprint\Contracts\Generator;
+use Blueprint\Generators\Generator;
 use Blueprint\Models\Statements\SendStatement;
 
-class NotificationGenerator implements Generator
+class NotificationGenerator extends Generator
 {
-    /**
-     * @
- \Illuminate\Contracts\Filesystem\Filesystem
-     */
-    private $files;
-
-    public function __construct($files)
-    {
-        $this->files = $files;
-    }
+    protected $new_instance = 'new message instance';
 
     public function output(array $tree): array
     {
@@ -29,11 +20,11 @@ class NotificationGenerator implements Generator
         foreach ($tree['controllers'] as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
-                    if (! $statement instanceof SendStatement) {
+                    if (!$statement instanceof SendStatement) {
                         continue;
                     }
 
-                    if (! $statement->isNotification()) {
+                    if (!$statement->isNotification()) {
                         continue;
                     }
 
@@ -43,7 +34,7 @@ class NotificationGenerator implements Generator
                         continue;
                     }
 
-                    if (! $this->files->exists(dirname($path))) {
+                    if (!$this->files->exists(dirname($path))) {
                         $this->files->makeDirectory(dirname($path), 0755, true);
                     }
 
@@ -64,61 +55,15 @@ class NotificationGenerator implements Generator
 
     protected function getPath(string $name)
     {
-        return Blueprint::appPath().'/Notification/'.$name.'.php';
+        return Blueprint::appPath() . '/Notification/' . $name . '.php';
     }
 
     protected function populateStub(string $stub, SendStatement $sendStatement)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Notification', $stub);
+        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Notification', $stub);
         $stub = str_replace('DummyClass', $sendStatement->mail(), $stub);
         $stub = str_replace('// properties...', $this->buildConstructor($sendStatement), $stub);
 
         return $stub;
-    }
-
-    private function buildConstructor(SendStatement $sendStatement)
-    {
-        static $constructor = null;
-
-        if (is_null($constructor)) {
-            $constructor = str_replace('new instance', 'new message instance', $this->files->stub('partials/constructor.stub'));
-        }
-
-        if (empty($sendStatement->data())) {
-            return trim($constructor);
-        }
-
-        $stub = $this->buildProperties($sendStatement->data()).PHP_EOL.PHP_EOL;
-        $stub .= str_replace('__construct()', '__construct('.$this->buildParameters($sendStatement->data()).')', $constructor);
-        $stub = str_replace('//', $this->buildAssignments($sendStatement->data()), $stub);
-
-        return $stub;
-    }
-
-    private function buildProperties(array $data)
-    {
-        return trim(array_reduce($data, function ($output, $property) {
-            $output .= '    public $'.$property.';'.PHP_EOL.PHP_EOL;
-
-            return $output;
-        }, ''));
-    }
-
-    private function buildParameters(array $data)
-    {
-        $parameters = array_map(function ($parameter) {
-            return '$'.$parameter;
-        }, $data);
-
-        return implode(', ', $parameters);
-    }
-
-    private function buildAssignments(array $data)
-    {
-        return trim(array_reduce($data, function ($output, $property) {
-            $output .= '        $this->'.$property.' = $'.$property.';'.PHP_EOL;
-
-            return $output;
-        }, ''));
     }
 }

--- a/src/Generators/Statements/NotificationGenerator.php
+++ b/src/Generators/Statements/NotificationGenerator.php
@@ -3,10 +3,10 @@
 namespace Blueprint\Generators\Statements;
 
 use Blueprint\Blueprint;
-use Blueprint\Generators\Generator;
+use Blueprint\Generators\StatementGenerator;
 use Blueprint\Models\Statements\SendStatement;
 
-class NotificationGenerator extends Generator
+class NotificationGenerator extends StatementGenerator
 {
     protected $new_instance = 'new message instance';
 

--- a/src/Models/Statements/FireStatement.php
+++ b/src/Models/Statements/FireStatement.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Blueprint\Models\Statements;
 
 class FireStatement


### PR DESCRIPTION
By introducing a property for `$new_instance`, we can easily extract the duplicated code between generators and pull them up to an abstract generator class.

Even If we need to customize any of the extracted methods in the future, we can override them so I change the visibility of these methods to protected.

Hope you will find this useful.

I will start working on the `Tree` class as we discussed before, and submit a PR tonight 👍 