### PR TITLE
Introduce Tree class to manage the analyzed tokens

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -67,10 +67,10 @@ class Blueprint
             $registry = array_merge($registry, $lexer->analyze($tokens));
         }
 
-        return $registry;
+        return new Tree($registry);
     }
 
-    public function generate(array $tree, array $only = [], array $skip = []): array
+    public function generate(Tree $tree, array $only = [], array $skip = []): array
     {
         $components = [];
 

--- a/src/Contracts/Generator.php
+++ b/src/Contracts/Generator.php
@@ -2,6 +2,8 @@
 
 namespace Blueprint\Contracts;
 
+use Blueprint\Tree;
+
 interface Generator
 {
     /**
@@ -9,7 +11,7 @@ interface Generator
      */
     public function __construct($files);
 
-    public function output(array $tree): array;
+    public function output(Tree $tree): array;
 
     public function types(): array;
 }

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -28,7 +28,8 @@ class ControllerGenerator implements Generator
 
     private $imports = [];
 
-    private Tree $tree;
+    /** @var Tree */
+    private $tree;
 
     public function __construct($files)
     {

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -5,7 +5,6 @@ namespace Blueprint\Generators;
 use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Controller;
-use Blueprint\Models\Model;
 use Blueprint\Models\Statements\DispatchStatement;
 use Blueprint\Models\Statements\EloquentStatement;
 use Blueprint\Models\Statements\FireStatement;
@@ -17,6 +16,7 @@ use Blueprint\Models\Statements\RespondStatement;
 use Blueprint\Models\Statements\SendStatement;
 use Blueprint\Models\Statements\SessionStatement;
 use Blueprint\Models\Statements\ValidateStatement;
+use Blueprint\Tree;
 use Illuminate\Support\Str;
 
 class ControllerGenerator implements Generator
@@ -28,23 +28,23 @@ class ControllerGenerator implements Generator
 
     private $imports = [];
 
-    private $models = [];
+    private Tree $tree;
 
     public function __construct($files)
     {
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
+        $this->tree = $tree;
+
         $output = [];
 
         $stub = $this->files->stub('controller/class.stub');
 
-        $this->registerModels($tree);
-
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             $this->addImport($controller, 'Illuminate\\Http\\Request');
 
             if ($controller->fullyQualifiedNamespace() !== 'App\\Http\\Controllers') {
@@ -53,7 +53,7 @@ class ControllerGenerator implements Generator
 
             $path = $this->getPath($controller);
 
-            if (! $this->files->exists(dirname($path))) {
+            if (!$this->files->exists(dirname($path))) {
                 $this->files->makeDirectory(dirname($path), 0755, true);
             }
 
@@ -131,7 +131,7 @@ class ControllerGenerator implements Generator
                     $this->addImport($controller, config('blueprint.namespace').'\\Jobs\\'.$statement->job());
                 } elseif ($statement instanceof FireStatement) {
                     $body .= self::INDENT.$statement->output().PHP_EOL;
-                    if (! $statement->isNamedEvent()) {
+                    if (!$statement->isNamedEvent()) {
                         $this->addImport($controller, config('blueprint.namespace').'\\Events\\'.$statement->event());
                     }
                 } elseif ($statement instanceof RenderStatement) {
@@ -142,7 +142,7 @@ class ControllerGenerator implements Generator
                     $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return \\'.$fqcn, $method);
 
                     $import = $fqcn;
-                    if (! $statement->collection()) {
+                    if (!$statement->collection()) {
                         $import .= ' as '.$statement->name().'Resource';
                     }
 
@@ -166,7 +166,7 @@ class ControllerGenerator implements Generator
                 $body .= PHP_EOL;
             }
 
-            if (! empty($body)) {
+            if (!empty($body)) {
                 $method = str_replace('//', trim($body), $method);
             }
 
@@ -218,32 +218,12 @@ class ControllerGenerator implements Generator
         // Use respond-statement.php as test case.
 
         /** @var \Blueprint\Models\Model $model */
-        $model = $this->modelForContext($model_name);
+        $model = $this->tree->modelForContext($model_name);
 
         if (isset($model)) {
             return $model->fullyQualifiedClassName();
         }
 
         return config('blueprint.namespace').'\\'.($sub_namespace ? $sub_namespace.'\\' : '').$model_name;
-    }
-
-    private function modelForContext(string $context)
-    {
-        if (isset($this->models[Str::studly($context)])) {
-            return $this->models[Str::studly($context)];
-        }
-
-        $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/'.Str::studly($context));
-        });
-
-        if (count($matches) === 1) {
-            return $this->models[$matches[0]];
-        }
-    }
-
-    private function registerModels(array $tree)
-    {
-        $this->models = array_merge($tree['cache'] ?? [], $tree['models'] ?? []);
     }
 }

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -5,6 +5,7 @@ namespace Blueprint\Generators;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Column;
 use Blueprint\Models\Model;
+use Blueprint\Tree;
 use Illuminate\Support\Str;
 
 class FactoryGenerator implements Generator
@@ -21,14 +22,14 @@ class FactoryGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
         $stub = $this->files->stub('factory.stub');
 
         /** @var \Blueprint\Models\Model $model */
-        foreach ($tree['models'] as $model) {
+        foreach ($tree->models() as $model) {
             $this->addImport($model, 'Faker\Generator as Faker');
             $this->addImport($model, $model->fullyQualifiedClassName());
 

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -4,6 +4,7 @@ namespace Blueprint\Generators;
 
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Model;
+use Blueprint\Tree;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
@@ -41,7 +42,7 @@ class MigrationGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
@@ -49,10 +50,10 @@ class MigrationGenerator implements Generator
 
         $stub = $this->files->stub('migration.stub');
 
-        $sequential_timestamp = \Carbon\Carbon::now()->subSeconds(count($tree['models']));
+        $sequential_timestamp = \Carbon\Carbon::now()->subSeconds(count($tree->models()));
 
         /** @var \Blueprint\Models\Model $model */
-        foreach ($tree['models'] as $model) {
+        foreach ($tree->models() as $model) {
             $path = $this->getPath($model, $sequential_timestamp->addSecond());
             $this->files->put($path, $this->populateStub($stub, $model));
 

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -6,6 +6,7 @@ use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Column;
 use Blueprint\Models\Model;
+use Blueprint\Tree;
 use Illuminate\Support\Str;
 
 class ModelGenerator implements Generator
@@ -18,14 +19,14 @@ class ModelGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
         $stub = $this->files->stub('model/class.stub');
 
         /** @var \Blueprint\Models\Model $model */
-        foreach ($tree['models'] as $model) {
+        foreach ($tree->models() as $model) {
             $path = $this->getPath($model);
 
             if (! $this->files->exists(dirname($path))) {
@@ -211,8 +212,8 @@ class ModelGenerator implements Generator
             return $stub;
         }
 
-        $stub = str_replace('use Illuminate\\Database\\Eloquent\\Model;', 'use Illuminate\\Database\\Eloquent\\Model;' . PHP_EOL . 'use Illuminate\\Database\\Eloquent\\SoftDeletes;', $stub);
-        $stub = Str::replaceFirst('{', '{' . PHP_EOL . '    use SoftDeletes;' . PHP_EOL, $stub);
+        $stub = str_replace('use Illuminate\\Database\\Eloquent\\Model;', 'use Illuminate\\Database\\Eloquent\\Model;'.PHP_EOL.'use Illuminate\\Database\\Eloquent\\SoftDeletes;', $stub);
+        $stub = Str::replaceFirst('{', '{'.PHP_EOL.'    use SoftDeletes;'.PHP_EOL, $stub);
 
         return $stub;
     }

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -4,6 +4,7 @@ namespace Blueprint\Generators;
 
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Controller;
+use Blueprint\Tree;
 use Illuminate\Support\Str;
 
 class RouteGenerator implements Generator
@@ -16,16 +17,16 @@ class RouteGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
-        if (empty($tree['controllers'])) {
+        if (empty($tree->controllers())) {
             return [];
         }
 
         $routes = ['api' => '', 'web' => ''];
 
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             $type = $controller->isApiResource() ? 'api' : 'web';
             $routes[$type] .= PHP_EOL.PHP_EOL.$this->buildRoutes($controller);
         }

--- a/src/Generators/SeederGenerator.php
+++ b/src/Generators/SeederGenerator.php
@@ -3,16 +3,15 @@
 namespace Blueprint\Generators;
 
 use Blueprint\Contracts\Generator;
-use Blueprint\Models\Model;
 use Blueprint\Tree;
-use Illuminate\Support\Str;
 
 class SeederGenerator implements Generator
 {
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     private $files;
 
-    private Tree $tree;
+    /** @var Tree */
+    private $tree;
 
     public function __construct($files)
     {
@@ -27,7 +26,7 @@ class SeederGenerator implements Generator
             return [];
         }
 
-        $output = [];
+        $output = []; 
 
         $stub = $this->files->stub('seeder.stub');
 

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -5,6 +5,7 @@ namespace Blueprint\Generators\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Statements\FireStatement;
+use Blueprint\Tree;
 
 class EventGenerator implements Generator
 {
@@ -18,14 +19,14 @@ class EventGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
         $stub = $this->files->stub('event.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
                     if (! $statement instanceof FireStatement) {

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -7,6 +7,7 @@ use Blueprint\Contracts\Generator;
 use Blueprint\Models\Controller;
 use Blueprint\Models\Statements\ValidateStatement;
 use Blueprint\Translators\Rules;
+use Blueprint\Tree;
 use Illuminate\Support\Str;
 
 class FormRequestGenerator implements Generator
@@ -18,23 +19,23 @@ class FormRequestGenerator implements Generator
      */
     private $files;
 
-    private $models = [];
+    private Tree $tree;
 
     public function __construct($files)
     {
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
+        $this->tree = $tree;
+
         $output = [];
 
         $stub = $this->files->stub('form-request.stub');
 
-        $this->registerModels($tree);
-
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
                     if (! $statement instanceof ValidateStatement) {
@@ -103,21 +104,6 @@ class FormRequestGenerator implements Generator
         }, ''));
     }
 
-    private function modelForContext(string $context)
-    {
-        if (isset($this->models[Str::studly($context)])) {
-            return $this->models[Str::studly($context)];
-        }
-
-        $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/'.Str::studly($context));
-        });
-
-        if (count($matches) === 1) {
-            return $this->models[$matches[0]];
-        }
-    }
-
     private function getName(string $context, string $method)
     {
         return $context.Str::studly($method).'Request';
@@ -135,7 +121,7 @@ class FormRequestGenerator implements Generator
     private function validationRules(string $qualifier, string $column)
     {
         /** @var \Blueprint\Models\Model $model */
-        $model = $this->modelForContext($qualifier);
+        $model = $this->tree->modelForContext($qualifier);
 
         $rules = [];
 
@@ -163,10 +149,5 @@ class FormRequestGenerator implements Generator
         }
 
         return $rules;
-    }
-
-    private function registerModels(array $tree)
-    {
-        $this->models = array_merge($tree['cache'] ?? [], $tree['models'] ?? []);
     }
 }

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -19,7 +19,8 @@ class FormRequestGenerator implements Generator
      */
     private $files;
 
-    private Tree $tree;
+    /** @var Tree */
+    private $tree;
 
     public function __construct($files)
     {

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -5,6 +5,7 @@ namespace Blueprint\Generators\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Statements\DispatchStatement;
+use Blueprint\Tree;
 
 class JobGenerator implements Generator
 {
@@ -18,14 +19,14 @@ class JobGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
         $stub = $this->files->stub('job.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
                     if (! $statement instanceof DispatchStatement) {

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -5,6 +5,7 @@ namespace Blueprint\Generators\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Statements\SendStatement;
+use Blueprint\Tree;
 
 class MailGenerator implements Generator
 {
@@ -18,14 +19,14 @@ class MailGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
         $stub = $this->files->stub('mail.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
                     if (! $statement instanceof SendStatement) {

--- a/src/Generators/Statements/NotificationGenerator.php
+++ b/src/Generators/Statements/NotificationGenerator.php
@@ -5,6 +5,7 @@ namespace Blueprint\Generators\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Statements\SendStatement;
+use Blueprint\Tree;
 
 class NotificationGenerator implements Generator
 {
@@ -19,14 +20,14 @@ class NotificationGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
         $stub = $this->files->stub('notification.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
                     if (! $statement instanceof SendStatement) {

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -7,6 +7,7 @@ use Blueprint\Contracts\Generator;
 use Blueprint\Models\Controller;
 use Blueprint\Models\Model;
 use Blueprint\Models\Statements\ResourceStatement;
+use Blueprint\Tree;
 use Illuminate\Support\Str;
 
 class ResourceGenerator implements Generator
@@ -17,23 +18,23 @@ class ResourceGenerator implements Generator
      */
     private $files;
 
-    private $models = [];
+    private Tree $tree;
 
     public function __construct($files)
     {
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
+        $this->tree = $tree;
+
         $output = [];
 
         $stub = $this->files->stub('resource.stub');
 
-        $this->registerModels($tree);
-
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
                     if (! $statement instanceof ResourceStatement) {
@@ -88,7 +89,7 @@ class ResourceGenerator implements Generator
         $context = Str::singular($resource->reference());
 
         /** @var \Blueprint\Models\Model $model */
-        $model = $this->modelForContext($context);
+        $model = $this->tree->modelForContext($context);
 
         $data = [];
         if ($resource->collection()) {
@@ -114,25 +115,5 @@ class ResourceGenerator implements Generator
             'password',
             'remember_token',
         ]);
-    }
-
-    private function modelForContext(string $context)
-    {
-        if (isset($this->models[Str::studly($context)])) {
-            return $this->models[Str::studly($context)];
-        }
-
-        $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/'.Str::studly($context));
-        });
-
-        if (count($matches) === 1) {
-            return $this->models[$matches[0]];
-        }
-    }
-
-    private function registerModels(array $tree)
-    {
-        $this->models = array_merge($tree['cache'] ?? [], $tree['models'] ?? []);
     }
 }

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -18,7 +18,8 @@ class ResourceGenerator implements Generator
      */
     private $files;
 
-    private Tree $tree;
+    /** @var Tree */
+    private $tree;
 
     public function __construct($files)
     {

--- a/src/Generators/Statements/ViewGenerator.php
+++ b/src/Generators/Statements/ViewGenerator.php
@@ -4,6 +4,7 @@ namespace Blueprint\Generators\Statements;
 
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Statements\RenderStatement;
+use Blueprint\Tree;
 
 class ViewGenerator implements Generator
 {
@@ -17,14 +18,14 @@ class ViewGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
         $stub = $this->files->stub('view.stub');
 
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
                     if (! $statement instanceof RenderStatement) {

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -31,7 +31,8 @@ class TestGenerator implements Generator
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     private $files;
 
-    private Tree $tree;
+    /** @var Tree */
+    private $tree;
 
     private $imports = [];
     private $stubs = [];

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -17,6 +17,7 @@ use Blueprint\Models\Statements\RespondStatement;
 use Blueprint\Models\Statements\SendStatement;
 use Blueprint\Models\Statements\SessionStatement;
 use Blueprint\Models\Statements\ValidateStatement;
+use Blueprint\Tree;
 use Illuminate\Support\Str;
 
 class TestGenerator implements Generator
@@ -30,7 +31,7 @@ class TestGenerator implements Generator
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     private $files;
 
-    private $models = [];
+    private Tree $tree;
 
     private $imports = [];
     private $stubs = [];
@@ -41,16 +42,16 @@ class TestGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
+        $this->tree = $tree;
+
         $output = [];
 
         $stub = $this->files->get(STUBS_PATH.'/test/class.stub');
 
-        $this->registerModels($tree);
-
         /** @var \Blueprint\Models\Controller $controller */
-        foreach ($tree['controllers'] as $controller) {
+        foreach ($tree->controllers() as $controller) {
             $path = $this->getPath($controller);
 
             if (! $this->files->exists(dirname($path))) {
@@ -224,7 +225,7 @@ class TestGenerator implements Generator
                             $variable_name = $data;
 
                             /** @var \Blueprint\Models\Model $local_model */
-                            $local_model = $this->modelForContext($qualifier);
+                            $local_model = $this->tree->modelForContext($qualifier);
 
                             if (! is_null($local_model) && $local_model->hasColumn($column)) {
                                 $local_column = $local_model->column($column);
@@ -238,7 +239,7 @@ class TestGenerator implements Generator
                                 }
 
                                 $setup['data'][] = $faker;
-                                $request_data[$data] = '$' . $variable_name;
+                                $request_data[$data] = '$'.$variable_name;
                             } else {
                                 foreach ($local_model->columns() as $local_column) {
                                     if ($local_column->name() === 'id') {
@@ -502,7 +503,7 @@ class TestGenerator implements Generator
         sort($imports);
 
         return implode(PHP_EOL, array_map(function ($class) {
-            return 'use ' . $class . ';';
+            return 'use '.$class.';';
         }, $imports));
     }
 
@@ -640,26 +641,6 @@ END;
         return str_pad(' ', 8).implode(PHP_EOL.str_pad(' ', 8), $lines);
     }
 
-    private function modelForContext(string $context)
-    {
-        if (isset($this->models[Str::studly($context)])) {
-            return $this->models[Str::studly($context)];
-        }
-
-        $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
-            return Str::endsWith($key, '/'.Str::studly($context));
-        });
-
-        if (count($matches) === 1) {
-            return $this->models[$matches[0]];
-        }
-    }
-
-    private function registerModels(array $tree)
-    {
-        $this->models = array_merge($tree['cache'] ?? [], $tree['models'] ?? []);
-    }
-
     private function splitField($field)
     {
         if (Str::contains($field, '.')) {
@@ -685,7 +666,7 @@ END;
         }
 
         $reference = Str::beforeLast($local_column->name(), '_id');
-        $variable_name = $reference . '->id';
+        $variable_name = $reference.'->id';
 
         if ($local_column->attributes()) {
             $reference = $local_column->attributes()[0];
@@ -693,7 +674,7 @@ END;
 
         $faker = sprintf('$%s = factory(%s::class)->create();', Str::beforeLast($local_column->name(), '_id'), Str::studly($reference));
 
-        $this->addImport($controller, $modelNamespace . '\\' . Str::studly($reference));
+        $this->addImport($controller, $modelNamespace.'\\'.Str::studly($reference));
 
         return [$faker, $variable_name];
     }

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Blueprint;
+
+use Illuminate\Support\Str;
+
+class Tree
+{
+    private array $tree;
+
+    public function __construct(array $tree)
+    {
+        $this->tree = $tree;
+
+        $this->registerModels();
+    }
+
+    private function registerModels()
+    {
+        $this->models = array_merge($this->tree['cache'] ?? [], $this->tree['models'] ?? []);
+    }
+
+    public function controllers()
+    {
+        return $this->tree['controllers'];
+    }
+
+    public function models()
+    {
+        return $this->tree['models'];
+    }
+
+    public function seeders()
+    {
+        return $this->tree['seeders'];
+    }
+
+    public function modelForContext(string $context)
+    {
+        if (isset($this->models[Str::studly($context)])) {
+            return $this->models[Str::studly($context)];
+        }
+
+        $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
+            return Str::endsWith($key, '/'.Str::studly($context));
+        });
+
+        if (count($matches) === 1) {
+            return $this->models[$matches[0]];
+        }
+    }
+
+    public function fqcnForContext(string $context)
+    {
+        if (isset($this->models[$context])) {
+            return $this->models[$context]->fullyQualifiedClassName();
+        }
+
+        $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
+            return Str::endsWith($key, '\\'.Str::studly($context));
+        });
+
+        if (count($matches) === 1) {
+            return $this->models[current($matches)]->fullyQualifiedClassName();
+        }
+
+        $fqn = config('blueprint.namespace');
+        if (config('blueprint.models_namespace')) {
+            $fqn .= '\\'.config('blueprint.models_namespace');
+        }
+
+        return $fqn.'\\'.$context;
+    }
+
+    public function toArray()
+    {
+        return $this->tree;
+    }
+}

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
 
 class Tree
 {
-    private array $tree;
+    private $tree;
 
     public function __construct(array $tree)
     {

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use Blueprint\Blueprint;
 use Blueprint\Contracts\Generator;
 use Blueprint\Contracts\Lexer;
+use Blueprint\Tree;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Tests\TestCase;
 
@@ -345,7 +346,7 @@ class BlueprintTest extends TestCase
                 'models' => [],
                 'controllers' => [],
             ],
-            $this->subject->analyze($tokens)
+            $this->subject->analyze($tokens)->toArray()
         );
     }
 
@@ -366,7 +367,7 @@ class BlueprintTest extends TestCase
             'models' => [],
             'controllers' => [],
             'mock' => 'lexer',
-        ], $this->subject->analyze($tokens));
+        ], $this->subject->analyze($tokens)->toArray());
     }
 
     /**
@@ -375,7 +376,7 @@ class BlueprintTest extends TestCase
     public function generate_uses_registered_generators_and_returns_generated_files()
     {
         $generatorOne = \Mockery::mock(Generator::class);
-        $tree = ['branch' => ['code', 'attributes']];
+        $tree = new Tree(['branch' => ['code', 'attributes']]);
 
         $generatorOne->expects('output')
             ->with($tree)
@@ -422,7 +423,7 @@ class BlueprintTest extends TestCase
     public function generate_uses_swapped_generator_and_returns_generated_files()
     {
         $generatorOne = \Mockery::mock(Generator::class);
-        $tree = ['branch' => ['code', 'attributes']];
+        $tree = new Tree(['branch' => ['code', 'attributes']]);
 
         $generatorOne->expects('output')->never();
 
@@ -457,7 +458,7 @@ class BlueprintTest extends TestCase
     public function generate_only_one_specific_type()
     {
         $generatorFoo = \Mockery::mock(Generator::class);
-        $tree = ['branch' => ['code', 'attributes']];
+        $tree = new Tree(['branch' => ['code', 'attributes']]);
 
         $only = ['bar'];
         $skip = [];
@@ -508,7 +509,7 @@ class BlueprintTest extends TestCase
     public function generate_only_specific_types()
     {
         $generatorFoo = \Mockery::mock(Generator::class);
-        $tree = ['branch' => ['code', 'attributes']];
+        $tree = new Tree(['branch' => ['code', 'attributes']]);
 
         $only = ['foo', 'bar'];
         $skip = [];
@@ -559,7 +560,7 @@ class BlueprintTest extends TestCase
     public function generate_should_skip_one_specific_type()
     {
         $generatorFoo = \Mockery::mock(Generator::class);
-        $tree = ['branch' => ['code', 'attributes']];
+        $tree = new Tree(['branch' => ['code', 'attributes']]);
 
         $only = [];
         $skip = ['bar'];
@@ -610,7 +611,7 @@ class BlueprintTest extends TestCase
     public function generate_should_skip_specific_types()
     {
         $generatorFoo = \Mockery::mock(Generator::class);
-        $tree = ['branch' => ['code', 'attributes']];
+        $tree = new Tree(['branch' => ['code', 'attributes']]);
 
         $only = [];
         $skip = ['bar', 'baz'];

--- a/tests/Feature/Generator/ControllerGeneratorTest.php
+++ b/tests/Feature/Generator/ControllerGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generators;
 use Blueprint\Blueprint;
 use Blueprint\Generators\ControllerGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -43,7 +44,7 @@ class ControllerGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Generators;
 
+use Blueprint\Tree;
 use Tests\TestCase;
 use Blueprint\Blueprint;
 use Blueprint\Generators\FactoryGenerator;
@@ -41,7 +42,7 @@ class FactoryGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['models' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['models' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Generators;
 
 use Blueprint\Blueprint;
 use Blueprint\Generators\MigrationGenerator;
+use Blueprint\Tree;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Tests\TestCase;
@@ -43,7 +44,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['models' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['models' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Generators;
 
 use Blueprint\Blueprint;
 use Blueprint\Generators\ModelGenerator;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 class ModelGeneratorTest extends TestCase
@@ -38,7 +39,7 @@ class ModelGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['models' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['models' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generators;
 use Blueprint\Blueprint;
 use Blueprint\Generators\RouteGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -38,7 +39,7 @@ class RouteGeneratorTest extends TestCase
     {
         $this->files->shouldNotHaveReceived('append');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/SeederGeneratorTest.php
+++ b/tests/Feature/Generator/SeederGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Generators;
 
 use Blueprint\Blueprint;
 use Blueprint\Generators\SeederGenerator;
+use Blueprint\Tree;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Tests\TestCase;
@@ -45,7 +46,7 @@ class SeederGeneratorTest extends TestCase
     {
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['seeders' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['seeders' => []])));
     }
 
     /**
@@ -83,9 +84,10 @@ class SeederGeneratorTest extends TestCase
             ->with('database/seeds/CommentSeeder.php', $this->fixture('seeders/CommentSeeder.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/seeders.yaml'));
-        $tree = $this->blueprint->analyze($tokens);
+        $tree = $this->blueprint->analyze($tokens)->toArray();
         $tree['cache'] = $tree['models'];
         unset($tree['models']);
+        $tree = new Tree($tree);
 
         $this->assertEquals(['created' => ['database/seeds/PostSeeder.php', 'database/seeds/CommentSeeder.php']], $this->subject->output($tree));
     }

--- a/tests/Feature/Generator/Statements/EventGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/EventGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generator\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Generators\Statements\EventGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -42,7 +43,7 @@ class EventGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generator\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Generators\Statements\FormRequestGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -43,7 +44,7 @@ class FormRequestGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/Statements/JobGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/JobGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generator\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Generators\Statements\JobGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -42,7 +43,7 @@ class JobGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/Statements/MailGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/MailGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generator\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Generators\Statements\MailGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -42,7 +43,7 @@ class MailGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/Statements/NotificationGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/NotificationGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generator\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Generators\Statements\NotificationGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -42,7 +43,7 @@ class NotificationGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generator\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Generators\Statements\ResourceGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -43,7 +44,7 @@ class ResourceGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/Statements/ViewGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ViewGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generator\Statements;
 use Blueprint\Blueprint;
 use Blueprint\Generators\Statements\ViewGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -42,7 +43,7 @@ class ViewGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Feature/Generator/TestGeneratorTest.php
+++ b/tests/Feature/Generator/TestGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generators;
 use Blueprint\Blueprint;
 use Blueprint\Generators\TestGenerator;
 use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
 use Tests\TestCase;
 
 /**
@@ -43,7 +44,7 @@ class TestGeneratorTest extends TestCase
 
         $this->files->shouldNotHaveReceived('put');
 
-        $this->assertEquals([], $this->subject->output(['controllers' => []]));
+        $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
     /**

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Blueprint\Blueprint;
 use Blueprint\Builder;
+use Blueprint\Tree;
 use Illuminate\Filesystem\Filesystem;
 use Tests\TestCase;
 
@@ -16,7 +17,7 @@ class BuilderTest extends TestCase
     {
         $draft = 'draft blueprint content';
         $tokens = ['some', 'blueprint', 'tokens'];
-        $registry = ['controllers' => [1, 2, 3]];
+        $registry = new Tree(['controllers' => [1, 2, 3]]);
         $only = [];
         $skip = [];
         $generated = ['created' => [1, 2], 'updated' => [3]];
@@ -64,7 +65,7 @@ class BuilderTest extends TestCase
         $tokens = [
             'models' => [1, 2, 3]
         ];
-        $registry = ['registry'];
+        $registry = new Tree(['registry']);
         $only = [];
         $skip = [];
         $generated = ['created' => [1, 2], 'updated' => [3]];


### PR DESCRIPTION
As an initial refactor, I create a new Tree class, and encapsulated the tree management on it.

The class currently provide a central place to provide `modelForContext` and `fqcnForContext` in addition to the simpler getters for `models` `controllers` and `seeders`.

I don't feel comfortable inject the `Tree` object in the method and share it with other methods, and I would suggest having singleton binding or any other pattern to access the Tree from any place in the code.

```php
// nested of 
public function output(Tree $tree): array
{
        $this->tree = $tree;
}
// then
$this->tree->modelForContext($model_name);

we can use
public function output(): array
{
        Tree::controller()
}

Tree::modelForContext($model_name);
```

The PR is already big, so I will wait for your feedback before we can move to the next step.