### PR TITLE
Stub file match Laravel

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -73,10 +73,10 @@ class ControllerGenerator implements Generator
 
     protected function populateStub(string $stub, Controller $controller)
     {
-        $stub = str_replace('DummyNamespace', $controller->fullyQualifiedNamespace(), $stub);
-        $stub = str_replace('DummyClass', $controller->className(), $stub);
-        $stub = str_replace('// methods...', $this->buildMethods($controller), $stub);
-        $stub = str_replace('// imports...', $this->buildImports($controller), $stub);
+        $stub = str_replace('{{ namespace }}', $controller->fullyQualifiedNamespace(), $stub);
+        $stub = str_replace('{{ class }}', $controller->className(), $stub);
+        $stub = str_replace('{{ methods }}', $this->buildMethods($controller), $stub);
+        $stub = str_replace('{{ imports }}', $this->buildImports($controller), $stub);
 
         return $stub;
     }
@@ -88,7 +88,7 @@ class ControllerGenerator implements Generator
         $methods = '';
 
         foreach ($controller->methods() as $name => $statements) {
-            $method = str_replace('DummyMethod', $name, $template);
+            $method = str_replace('{{ method }}', $name, $template);
 
             if (in_array($name, ['edit', 'update', 'show', 'destroy'])) {
                 $context = Str::singular($controller->prefix());
@@ -168,7 +168,7 @@ class ControllerGenerator implements Generator
             }
 
             if (!empty($body)) {
-                $method = str_replace('//', trim($body), $method);
+                $method = str_replace('{{ body }}', trim($body), $method);
             }
 
             $methods .= PHP_EOL.$method;

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -65,9 +65,9 @@ class FactoryGenerator implements Generator
 
     protected function populateStub(string $stub, Model $model)
     {
-        $stub = str_replace('DummyClass', $model->name(), $stub);
-        $stub = str_replace('// definition...', $this->buildDefinition($model), $stub);
-        $stub = str_replace('// imports...', $this->buildImports($model), $stub);
+        $stub = str_replace('{{ class }}', $model->name(), $stub);
+        $stub = str_replace('{{ definition }}', $this->buildDefinition($model), $stub);
+        $stub = str_replace('{{ imports }}', $this->buildImports($model), $stub);
 
         return $stub;
     }

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -84,18 +84,18 @@ class MigrationGenerator implements Generator
 
     protected function populateStub(string $stub, Model $model)
     {
-        $stub = str_replace('DummyClass', $this->getClassName($model), $stub);
-        $stub = str_replace('DummyTable', $model->tableName(), $stub);
-        $stub = str_replace('// definition...', $this->buildDefinition($model), $stub);
+        $stub = str_replace('{{ class }}', $this->getClassName($model), $stub);
+        $stub = str_replace('{{ table }}', $model->tableName(), $stub);
+        $stub = str_replace('{{ definition }}', $this->buildDefinition($model), $stub);
 
         return $stub;
     }
 
     protected function populatePivotStub(string $stub, array $segments)
     {
-        $stub = str_replace('DummyClass', $this->getPivotClassName($segments), $stub);
-        $stub = str_replace('DummyTable', $this->getPivotTableName($segments), $stub);
-        $stub = str_replace('// definition...', $this->buildPivotTableDefinition($segments), $stub);
+        $stub = str_replace('{{ class }}', $this->getPivotClassName($segments), $stub);
+        $stub = str_replace('{{ table }}', $this->getPivotTableName($segments), $stub);
+        $stub = str_replace('{{ definition }}', $this->buildPivotTableDefinition($segments), $stub);
 
         return $stub;
     }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -48,15 +48,15 @@ class ModelGenerator implements Generator
 
     protected function populateStub(string $stub, Model $model)
     {
-        $stub = str_replace('DummyNamespace', $model->fullyQualifiedNamespace(), $stub);
-        $stub = str_replace('DummyClass', $model->name(), $stub);
-        $stub = str_replace('/** DummyPHPDocClass **/', $this->buildClassPhpDoc($model), $stub);
+        $stub = str_replace('{{ namespace }}', $model->fullyQualifiedNamespace(), $stub);
+        $stub = str_replace('{{ class }}', $model->name(), $stub);
+        $stub = str_replace('{{ PHPDoc }}', $this->buildClassPhpDoc($model), $stub);
 
         $body = $this->buildProperties($model);
         $body .= PHP_EOL.PHP_EOL;
         $body .= $this->buildRelationships($model);
 
-        $stub = str_replace('// ...', trim($body), $stub);
+        $stub = str_replace('{{ body }}', trim($body), $stub);
         $stub = $this->addTraits($model, $stub);
 
         return $stub;
@@ -187,10 +187,10 @@ class ModelGenerator implements Generator
                 } elseif (in_array($type, ['hasMany', 'belongsToMany', 'morphMany'])) {
                     $method_name = Str::plural($column_name);
                 }
-                $method = str_replace('DummyName', Str::camel($method_name), $template);
+                $method = str_replace('{{ method }}', Str::camel($method_name), $template);
                 $method = str_replace('null', $relationship, $method);
 
-                $phpDoc = str_replace('DummyReturn', '\Illuminate\Database\Eloquent\Relations\\'.Str::ucfirst($type), $commentTemplate);
+                $phpDoc = str_replace('{{ namespacedReturnClass }}', '\Illuminate\Database\Eloquent\Relations\\'.Str::ucfirst($type), $commentTemplate);
 
                 $methods .= PHP_EOL.$phpDoc.$method;
             }

--- a/src/Generators/SeederGenerator.php
+++ b/src/Generators/SeederGenerator.php
@@ -47,8 +47,8 @@ class SeederGenerator implements Generator
 
     protected function populateStub(string $stub, string $model)
     {
-        $stub = str_replace('DummyClass', $this->getClassName($model), $stub);
-        $stub = str_replace('//', $this->build($model), $stub);
+        $stub = str_replace('{{ class }}', $this->getClassName($model), $stub);
+        $stub = str_replace('{{ body }}', $this->build($model), $stub);
 
         return $stub;
     }

--- a/src/Generators/StatementGenerator.php
+++ b/src/Generators/StatementGenerator.php
@@ -30,14 +30,14 @@ abstract class StatementGenerator implements Generator
         }
 
         if (empty($statement->data())) {
-            return trim($constructor);
+            $stub = (str_replace('{{ body }}', '//', $constructor));
+        } else {
+            $stub = $this->buildProperties($statement->data()) . PHP_EOL . PHP_EOL;
+            $stub .= str_replace('__construct()', '__construct(' . $this->buildParameters($statement->data()) . ')', $constructor);
+            $stub = str_replace('{{ body }}', $this->buildAssignments($statement->data()), $stub);
         }
 
-        $stub = $this->buildProperties($statement->data()) . PHP_EOL . PHP_EOL;
-        $stub .= str_replace('__construct()', '__construct(' . $this->buildParameters($statement->data()) . ')', $constructor);
-        $stub = trim(str_replace('//', $this->buildAssignments($statement->data()), $stub));
-
-        return $stub;
+        return trim($stub);
     }
 
     protected function buildProperties(array $data)

--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -61,9 +61,9 @@ class EventGenerator extends StatementGenerator
 
     protected function populateStub(string $stub, FireStatement $fireStatement)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Events', $stub);
-        $stub = str_replace('DummyClass', $fireStatement->event(), $stub);
-        $stub = str_replace('// properties...', $this->buildConstructor($fireStatement), $stub);
+        $stub = str_replace('{{ namespace }}', config('blueprint.namespace').'\\Events', $stub);
+        $stub = str_replace('{{ class }}', $fireStatement->event(), $stub);
+        $stub = str_replace('{{ properties }}', $this->buildConstructor($fireStatement), $stub);
 
         return $stub;
     }

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -77,9 +77,9 @@ class FormRequestGenerator implements Generator
 
     protected function populateStub(string $stub, string $name, $context, ValidateStatement $validateStatement, Controller $controller)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Http\\Requests'.($controller->namespace() ? '\\'.$controller->namespace() : ''), $stub);
-        $stub = str_replace('DummyClass', $name, $stub);
-        $stub = str_replace('// rules...', $this->buildRules($context, $validateStatement), $stub);
+        $stub = str_replace('{{ namespace }}', config('blueprint.namespace').'\\Http\\Requests'.($controller->namespace() ? '\\'.$controller->namespace() : ''), $stub);
+        $stub = str_replace('{{ class }}', $name, $stub);
+        $stub = str_replace('{{ rules }}', $this->buildRules($context, $validateStatement), $stub);
 
         return $stub;
     }

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -57,9 +57,9 @@ class JobGenerator extends StatementGenerator
 
     protected function populateStub(string $stub, DispatchStatement $dispatchStatement)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Jobs', $stub);
-        $stub = str_replace('DummyClass', $dispatchStatement->job(), $stub);
-        $stub = str_replace('// properties...', $this->buildConstructor($dispatchStatement), $stub);
+        $stub = str_replace('{{ namespace }}', config('blueprint.namespace').'\\Jobs', $stub);
+        $stub = str_replace('{{ class }}', $dispatchStatement->job(), $stub);
+        $stub = str_replace('{{ properties }}', $this->buildConstructor($dispatchStatement), $stub);
 
         return $stub;
     }

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -61,9 +61,9 @@ class MailGenerator extends StatementGenerator
 
     protected function populateStub(string $stub, SendStatement $sendStatement)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Mail', $stub);
-        $stub = str_replace('DummyClass', $sendStatement->mail(), $stub);
-        $stub = str_replace('// properties...', $this->buildConstructor($sendStatement), $stub);
+        $stub = str_replace('{{ namespace }}', config('blueprint.namespace').'\\Mail', $stub);
+        $stub = str_replace('{{ class }}', $sendStatement->mail(), $stub);
+        $stub = str_replace('{{ properties }}', $this->buildConstructor($sendStatement), $stub);
 
         return $stub;
     }

--- a/src/Generators/Statements/NotificationGenerator.php
+++ b/src/Generators/Statements/NotificationGenerator.php
@@ -61,9 +61,9 @@ class NotificationGenerator extends StatementGenerator
 
     protected function populateStub(string $stub, SendStatement $sendStatement)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace') . '\\Notification', $stub);
-        $stub = str_replace('DummyClass', $sendStatement->mail(), $stub);
-        $stub = str_replace('// properties...', $this->buildConstructor($sendStatement), $stub);
+        $stub = str_replace('{{ namespace }}', config('blueprint.namespace') . '\\Notification', $stub);
+        $stub = str_replace('{{ class }}', $sendStatement->mail(), $stub);
+        $stub = str_replace('{{ properties }}', $this->buildConstructor($sendStatement), $stub);
 
         return $stub;
     }

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -74,13 +74,13 @@ class ResourceGenerator implements Generator
 
     protected function populateStub(string $stub, ResourceStatement $resource)
     {
-        $stub = str_replace('DummyNamespace', config('blueprint.namespace').'\\Http\\Resources', $stub);
-        $stub = str_replace('DummyImport', $resource->collection() ? 'Illuminate\\Http\\Resources\\Json\\ResourceCollection' : 'Illuminate\\Http\\Resources\\Json\\JsonResource', $stub);
-        $stub = str_replace('DummyParent', $resource->collection() ? 'ResourceCollection' : 'JsonResource', $stub);
-        $stub = str_replace('DummyClass', $resource->name(), $stub);
-        $stub = str_replace('DummyParent', $resource->collection() ? 'ResourceCollection' : 'JsonResource', $stub);
-        $stub = str_replace('DummyItem', $resource->collection() ? 'resource collection' : 'resource', $stub);
-        $stub = str_replace('// data...', $this->buildData($resource), $stub);
+        $stub = str_replace('{{ namespace }}', config('blueprint.namespace').'\\Http\\Resources', $stub);
+        $stub = str_replace('{{ import }}', $resource->collection() ? 'Illuminate\\Http\\Resources\\Json\\ResourceCollection' : 'Illuminate\\Http\\Resources\\Json\\JsonResource', $stub);
+        $stub = str_replace('{{ parentClass }}', $resource->collection() ? 'ResourceCollection' : 'JsonResource', $stub);
+        $stub = str_replace('{{ class }}', $resource->name(), $stub);
+        $stub = str_replace('{{ parentClass }}', $resource->collection() ? 'ResourceCollection' : 'JsonResource', $stub);
+        $stub = str_replace('{{ resource }}', $resource->collection() ? 'resource collection' : 'resource', $stub);
+        $stub = str_replace('{{ body }}', $this->buildData($resource), $stub);
 
         return $stub;
     }

--- a/src/Generators/Statements/ViewGenerator.php
+++ b/src/Generators/Statements/ViewGenerator.php
@@ -65,6 +65,6 @@ class ViewGenerator implements Generator
 
     protected function populateStub(string $stub, RenderStatement $renderStatement)
     {
-        return str_replace('DummyView', $renderStatement->view(), $stub);
+        return str_replace('{{ view }}', $renderStatement->view(), $stub);
     }
 }

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -82,11 +82,11 @@ class TestGenerator implements Generator
 
     protected function populateStub(string $stub, Controller $controller)
     {
-        $stub = str_replace('DummyNamespace', 'Tests\\Feature\\'.Blueprint::relativeNamespace($controller->fullyQualifiedNamespace()), $stub);
-        $stub = str_replace('DummyController', '\\'.$controller->fullyQualifiedClassName(), $stub);
-        $stub = str_replace('DummyClass', $controller->className().'Test', $stub);
-        $stub = str_replace('// test cases...', $this->buildTestCases($controller), $stub);
-        $stub = str_replace('// imports...', $this->buildImports($controller), $stub);
+        $stub = str_replace('{{ namespace }}', 'Tests\\Feature\\'.Blueprint::relativeNamespace($controller->fullyQualifiedNamespace()), $stub);
+        $stub = str_replace('{{ namespacedClass }}', '\\'.$controller->fullyQualifiedClassName(), $stub);
+        $stub = str_replace('{{ class }}', $controller->className().'Test', $stub);
+        $stub = str_replace('{{ body }}', $this->buildTestCases($controller), $stub);
+        $stub = str_replace('{{ imports }}', $this->buildImports($controller), $stub);
 
         return $stub;
     }
@@ -478,8 +478,8 @@ class TestGenerator implements Generator
             $body .= PHP_EOL.PHP_EOL;
             $body .= implode(PHP_EOL.PHP_EOL, array_map([$this, 'buildLines'], array_filter($assertions)));
 
-            $test_case = str_replace('dummy_test_case', $this->buildTestCaseName($name, $tested_bits), $test_case);
-            $test_case = str_replace('// ...', trim($body), $test_case);
+            $test_case = str_replace('{{ method }}', $this->buildTestCaseName($name, $tested_bits), $test_case);
+            $test_case = str_replace('{{ body }}', trim($body), $test_case);
 
             $test_cases .= PHP_EOL.$test_case.PHP_EOL;
         }

--- a/stubs/controller/class.stub
+++ b/stubs/controller/class.stub
@@ -1,10 +1,10 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
-// imports...
+{{ imports }}
 
-class DummyClass extends Controller
+class {{ class }} extends Controller
 {
-    // methods...
+    {{ methods }}
 }

--- a/stubs/controller/method.stub
+++ b/stubs/controller/method.stub
@@ -2,7 +2,7 @@
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
-    public function DummyMethod(Request $request)
+    public function {{ method }}(Request $request)
     {
-        //
+        {{ body }}
     }

--- a/stubs/event.stub
+++ b/stubs/event.stub
@@ -1,12 +1,12 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Queue\SerializesModels;
 
-class DummyClass
+class {{ class }}
 {
     use SerializesModels;
 
-    // properties...
+    {{ properties }}
 }

--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -2,10 +2,10 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-// imports...
+{{ imports }}
 
-$factory->define(DummyClass::class, function (Faker $faker) {
+$factory->define({{ class }}::class, function (Faker $faker) {
     return [
-        // definition...
+        {{ definition }}
     ];
 });

--- a/stubs/form-request.stub
+++ b/stubs/form-request.stub
@@ -1,10 +1,10 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class DummyClass extends FormRequest
+class {{ class }} extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -24,7 +24,7 @@ class DummyClass extends FormRequest
     public function rules()
     {
         return [
-            // rules...
+            {{ rules }}
         ];
     }
 }

--- a/stubs/job.stub
+++ b/stubs/job.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -8,11 +8,11 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
-class DummyClass implements ShouldQueue
+class {{ class }} implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    // properties...
+    {{ properties }}
 
     /**
      * Execute the job.

--- a/stubs/mail.stub
+++ b/stubs/mail.stub
@@ -1,17 +1,17 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 
-class DummyClass extends Mailable
+class {{ class }} extends Mailable
 {
     use Queueable, SerializesModels;
 
-    // properties...
+    {{ properties }}
 
     /**
      * Build the message.

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class DummyClass extends Migration
+class {{ class }} extends Migration
 {
     /**
      * Run the migrations.
@@ -13,8 +13,8 @@ class DummyClass extends Migration
      */
     public function up()
     {
-        Schema::create('DummyTable', function (Blueprint $table) {
-            // definition...
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            {{ definition }}
         });
     }
 
@@ -25,6 +25,6 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('DummyTable');
+        Schema::dropIfExists('{{ table }}');
     }
 }

--- a/stubs/model/class.stub
+++ b/stubs/model/class.stub
@@ -1,10 +1,10 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Database\Eloquent\Model;
-/** DummyPHPDocClass **/
-class DummyClass extends Model
+{{ PHPDoc }}
+class {{ class }} extends Model
 {
-    // ...
+    {{ body }}
 }

--- a/stubs/model/method-comment.stub
+++ b/stubs/model/method-comment.stub
@@ -1,3 +1,3 @@
     /**
-     * @return DummyReturn
+     * @return {{ namespacedReturnClass }}
      */

--- a/stubs/model/method.stub
+++ b/stubs/model/method.stub
@@ -1,4 +1,4 @@
-    public function DummyName()
+    public function {{ method }}()
     {
         return null;
     }

--- a/stubs/notification.stub
+++ b/stubs/notification.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
@@ -8,11 +8,11 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Queue\SerializesModels;
 
-class DummyClass extends Notification
+class {{ class }} extends Notification
 {
     use Queueable, SerializesModels;
 
-    // properties...
+    {{ properties }}
 
     /**
      * Get the notification's delivery channels.

--- a/stubs/partials/constructor.stub
+++ b/stubs/partials/constructor.stub
@@ -5,5 +5,5 @@
      */
     public function __construct()
     {
-        //
+        {{ body }}
     }

--- a/stubs/resource.stub
+++ b/stubs/resource.stub
@@ -1,19 +1,19 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
-use DummyImport;
+use {{ import }};
 
-class DummyClass extends DummyParent
+class {{ class }} extends {{ parentClass }}
 {
     /**
-     * Transform the DummyItem into an array.
+     * Transform the {{ resource }} into an array.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return array
      */
     public function toArray($request)
     {
-        // data...
+        {{ body }}
     }
 }

--- a/stubs/seeder.stub
+++ b/stubs/seeder.stub
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Seeder;
 
-class DummyClass extends Seeder
+class {{ class }} extends Seeder
 {
     /**
      * Run the database seeds.
@@ -11,6 +11,6 @@ class DummyClass extends Seeder
      */
     public function run()
     {
-        //
+        {{ body }}
     }
 }

--- a/stubs/test/case.stub
+++ b/stubs/test/case.stub
@@ -1,7 +1,7 @@
     /**
      * @test
      */
-    public function dummy_test_case()
+    public function {{ method }}()
     {
-        // ...
+        {{ body }}
     }

--- a/stubs/test/class.stub
+++ b/stubs/test/class.stub
@@ -1,13 +1,13 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
-// imports...
+{{ imports }}
 
 /**
- * @see DummyController
+ * @see {{ namespacedClass }}
  */
-class DummyClass extends TestCase
+class {{ class }} extends TestCase
 {
-    // test cases...
+    {{ body }}
 }

--- a/stubs/view.stub
+++ b/stubs/view.stub
@@ -1,5 +1,5 @@
 @extends('layouts.app')
 
 @section('content')
-    DummyView template
+    {{ view }} template
 @endsection

--- a/tests/Feature/Generator/Statements/ViewGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ViewGeneratorTest.php
@@ -81,13 +81,13 @@ class ViewGeneratorTest extends TestCase
             ->with('resources/views/user/index.blade.php')
             ->andReturnFalse();
         $this->files->expects('put')
-            ->with('resources/views/user/index.blade.php', str_replace('DummyView', 'user.index', $template));
+            ->with('resources/views/user/index.blade.php', str_replace('{{ view }}', 'user.index', $template));
 
         $this->files->expects('exists')
             ->with('resources/views/user/create.blade.php')
             ->andReturnFalse();
         $this->files->expects('put')
-            ->with('resources/views/user/create.blade.php', str_replace('DummyView', 'user.create', $template));
+            ->with('resources/views/user/create.blade.php', str_replace('{{ view }}', 'user.create', $template));
 
         $this->files->expects('exists')
             ->with('resources/views/post')
@@ -98,7 +98,7 @@ class ViewGeneratorTest extends TestCase
         $this->files->expects('makeDirectory')
             ->with('resources/views/post', 0755, true);
         $this->files->expects('put')
-            ->with('resources/views/post/show.blade.php', str_replace('DummyView', 'post.show', $template));
+            ->with('resources/views/post/show.blade.php', str_replace('{{ view }}', 'post.show', $template));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/render-statements.yaml'));
         $tree = $this->blueprint->analyze($tokens);


### PR DESCRIPTION
I have replaced all placeholders to `{{ xxx }}` format.
- Changed `Dummyxxx`, `// xxx` to `{{ xxx }}`
- **Renamed** `//`, `//...` to semantic placeholder name. I'm not an English expert, so I'm not sure if they are proper name, maybe need double check.


Some further change discussion:
Do we match stub file structure to [laravel-stubs](https://github.com/jasonmccreary/laravel-stubs), like moving `model/casts.stub` to `model.casts.stub`.