### PR TITLE
Add whitelist section to enable code coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,11 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
     <php>
         <const name="STUBS_PATH" value="stubs"/>
     </php>


### PR DESCRIPTION
Hi again!

I enjoyed refactoring the codebase so I can understand the current features before helping introduce a new one or pick a community requested enhancements.

Before going further with extra enhancements, I would like to take care of the `tests` suite, so I enabled the code coverage by adding the whitelisting section to the `phpunit.xml` config file.

The current code coverage reports below show that classes especially the commands and the top-level classes are not well-tested. I just want to double-check if you are interested to cover them?

<img width="434" alt="Screen Shot 2020-07-25 at 16 26 29" src="https://user-images.githubusercontent.com/9499808/88458023-998eac00-ce93-11ea-87cf-b306c56cb069.png">

In addition to that, I think the `TraceCommand` encapsulate too many concerns and the private method's logic need to be moved to another class to make the command lighter? if yes, what would you name the new class?

<img width="553" alt="Screen Shot 2020-07-25 at 16 33 58" src="https://user-images.githubusercontent.com/9499808/88458156-a65fcf80-ce94-11ea-9c27-840d192f6387.png">

I asked about the `TraceCommand` specifically because it seems to me as the top candidate to be tested and refactored.