### PR TITLE
BuildCommand tests

### DIFF
--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -43,7 +43,7 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
 
         $this->app->bind('command.blueprint.build',
             function ($app) {
-                return new BuildCommand($app['files']);
+                return new BuildCommand($app['files'],app(Builder::class));
             }
         );
         $this->app->bind('command.blueprint.erase',

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -6,7 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class Builder
 {
-    public static function execute(Blueprint $blueprint, Filesystem $files, string $draft, string $only = '', string $skip = '')
+    public function execute(Blueprint $blueprint, Filesystem $files, string $draft, string $only = '', string $skip = '')
     {
         $cache = [];
         if ($files->exists('.blueprint')) {

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -34,7 +34,7 @@ class BuildCommand extends Command
     protected $files;
 
     /** @var Builder */
-    private Builder $builder;
+    private $builder;
 
     /**
      * @param Filesystem $files

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -5,6 +5,7 @@ namespace Blueprint\Commands;
 use Blueprint\Blueprint;
 use Blueprint\Builder;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,35 +33,35 @@ class BuildCommand extends Command
     /** @var Filesystem */
     protected $files;
 
+    /** @var Builder */
+    private Builder $builder;
+
     /**
      * @param Filesystem $files
+     * @param Builder $builder
      */
-    public function __construct(Filesystem $files)
+    public function __construct(Filesystem $files, Builder $builder)
     {
         parent::__construct();
 
         $this->files = $files;
+        $this->builder = $builder;
     }
 
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
     public function handle()
     {
         $file = $this->argument('draft') ?? $this->defaultDraftFile();
 
-        if (! file_exists($file)) {
+        if (!$this->files->exists($file)) {
             $this->error('Draft file could not be found: '.($file ?: 'draft.yaml'));
-            exit(1);
+            return 1;
         }
 
         $only = $this->option('only') ?: '';
         $skip = $this->option('skip') ?: '';
 
         $blueprint = resolve(Blueprint::class);
-        $generated = Builder::execute($blueprint, $this->files, $file, $only, $skip);
+        $generated = $this->builder->execute($blueprint, $this->files, $file, $only, $skip);
 
         collect($generated)->each(function ($files, $action) {
             $this->line(Str::studly($action).':', $this->outputStyle($action));
@@ -97,12 +98,6 @@ class BuildCommand extends Command
 
     private function defaultDraftFile()
     {
-        if (file_exists('draft.yaml')) {
-            return 'draft.yaml';
-        }
-
-        if (file_exists('draft.yml')) {
-            return 'draft.yml';
-        }
+        return file_exists('draft.yml') ? 'draft.yml' : 'draft.yaml';
     }
 }

--- a/tests/Feature/Commands/BuildCommandTest.php
+++ b/tests/Feature/Commands/BuildCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Blueprint\Blueprint;
+use Blueprint\Builder;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+class BuildCommandTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @test */
+    public function it_uses_the_default_draft_file()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $filesystem->shouldReceive('exists')
+            ->with('draft.yaml')
+            ->andReturnTrue();
+
+        $builder = $this->mock(Builder::class);
+
+        $builder->shouldReceive('execute')
+            ->with(resolve(Blueprint::class), $filesystem, 'draft.yaml', '', '')
+            ->andReturn(collect([]));
+
+        $this->artisan('blueprint:build')
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_passes_the_command_args_to_the_builder_in_right_order()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $filesystem->shouldReceive('exists')
+            ->with('test.yml')
+            ->andReturnTrue();
+
+        $builder = $this->mock(Builder::class);
+
+        $builder->shouldReceive('execute')
+            ->with(resolve(Blueprint::class), $filesystem, 'test.yml', 'a,b,c', 'x,y,z')
+            ->andReturn(collect([]));
+
+        $this->artisan('blueprint:build test.yml --only=a,b,c --skip=x,y,z')
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_fails_if_the_draft_file_not_exists()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $filesystem->shouldReceive('exists')
+            ->with('test.yml')
+            ->andReturnFalse();
+
+        $builder = $this->mock(Builder::class);
+
+        $builder->shouldNotReceive('execute');
+
+        $this->artisan('blueprint:build test.yml --only=a,b,c --skip=x,y,z')
+            ->assertExitCode(1);
+    }
+
+    /** @test */
+    public function it_shows_the_generated_files_groupbed_by_actions()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $filesystem->shouldReceive('exists')
+            ->with('draft.yaml')
+            ->andReturnTrue();
+
+        $builder = $this->mock(Builder::class);
+
+        $builder->shouldReceive('execute')
+            ->with(resolve(Blueprint::class), $filesystem, 'draft.yaml', '', '')
+            ->andReturn(collect([
+                "created" => [
+                    "file1",
+                    "file2",
+                ]
+            ]));
+
+        $this->artisan('blueprint:build')
+            ->assertExitCode(0)
+            ->expectsOutput('Created:')
+            ->expectsOutput('- file1')
+            ->expectsOutput('- file2');
+    }
+}

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -46,7 +46,7 @@ class BuilderTest extends TestCase
         $file->expects('put')
             ->with('.blueprint', 'cacheable blueprint content');
 
-        $actual = Builder::execute($blueprint, $file, 'draft.yaml');
+        $actual = (new Builder)->execute($blueprint, $file, 'draft.yaml');
 
         $this->assertSame($generated, $actual);
     }
@@ -104,7 +104,7 @@ class BuilderTest extends TestCase
         $file->expects('put')
             ->with('.blueprint', 'cacheable blueprint content');
 
-        $actual = Builder::execute($blueprint, $file, 'draft.yaml');
+        $actual = (new Builder)->execute($blueprint, $file, 'draft.yaml');
 
         $this->assertSame($generated, $actual);
     }


### PR DESCRIPTION
In order to test the BuildCommand, I changed some code to make the `Builder` and `BuildCommand` more testable

1. Inject `Builder` to `BuildCommand` nested of Static method invocation to unit test the command. We can also provide e Builder facade and return the static method invocation if needed.
1. Replace `file_exists` with `$this->files->exists` to allow tests code to mock it.
1. Replace `exit(1)` with `return 1` so we can use `assertExitCode(1)` and prevent the command from killing the test command.
1. Simplifying `defaultDraftFile` is not related to the test code, and I can revert the change if you like the old style.

Waiting for your feedback, and if everything goes ok, please select the next candidate to be tested.

Have a nice day 👍 