### PR TITLE
Test erase command

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -5,7 +5,6 @@ namespace Blueprint\Commands;
 use Blueprint\Blueprint;
 use Blueprint\Builder;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Commands/EraseCommand.php
+++ b/src/Commands/EraseCommand.php
@@ -5,6 +5,7 @@ namespace Blueprint\Commands;
 use Blueprint\Blueprint;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Artisan;
 
 class EraseCommand extends Command
 {
@@ -71,7 +72,7 @@ class EraseCommand extends Command
 
         $this->files->put('.blueprint', $blueprint->dump($generated));
 
-        $this->call('blueprint:trace');
+        Artisan::call('blueprint:trace');
     }
 
     private function outputStyle($action)

--- a/src/Commands/EraseCommand.php
+++ b/src/Commands/EraseCommand.php
@@ -5,7 +5,6 @@ namespace Blueprint\Commands;
 use Blueprint\Blueprint;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Input\InputArgument;
 
 class EraseCommand extends Command
 {
@@ -46,7 +45,8 @@ class EraseCommand extends Command
     {
         $contents = $this->files->get('.blueprint');
 
-        $blueprint = new Blueprint();
+        $blueprint = resolve(Blueprint::class);
+
         $generated = $blueprint->parse($contents, false);
 
         collect($generated)->each(function ($files, $action) {
@@ -60,7 +60,7 @@ class EraseCommand extends Command
             }
 
             collect($files)->each(function ($file) {
-                $this->line('- ' . $file);
+                $this->line('- '.$file);
             });
 
             $this->line('');

--- a/tests/ArtisanFake.php
+++ b/tests/ArtisanFake.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel as KernelContract;
+use Illuminate\Foundation\Console\Kernel;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class ArtisanFake implements KernelContract
+{
+    /**
+     * The original kernel implementation.
+     *
+     * @var \Illuminate\Foundation\Console\Kernel
+     */
+    protected $kernel;
+
+    /**
+     * The commands that should be intercepted instead of dispatched.
+     *
+     * @var array
+     */
+    protected $commandsToFake;
+
+    /**
+     * The commands that have been dispatched.
+     *
+     * @var array
+     */
+    protected $commands = [];
+
+    /**
+     * Create a new artisan fake instance.
+     * @param  \Illuminate\Foundation\Console\Kernel  $kernel
+     * @param  array|string  $commandsToFake
+     * @return void
+     */
+    public function __construct(Kernel $kernel, $commandsToFake = [])
+    {
+        $this->kernel = $kernel;
+
+        $this->commandsToFake = Arr::wrap($commandsToFake);
+    }
+
+    /**
+     * Assert if a command was called based on a truth-test callback.
+     *
+     * @param  string  $command
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public function assertCalled($command, $callback = null)
+    {
+        if (is_numeric($callback)) {
+            return $this->assertCalledTimes($command, $callback);
+        }
+
+        PHPUnit::assertTrue(
+            $this->called($command, $callback)->count() > 0,
+            "The expected [{$command}] command was not called."
+        );
+    }
+
+    /**
+     * Assert if a command was called a number of times.
+     *
+     * @param  string  $command
+     * @param  int  $times
+     * @return void
+     */
+    public function assertCalledTimes($command, $times = 1)
+    {
+        $count = $this->called($command)->count();
+
+        PHPUnit::assertSame(
+            $times,
+            $count,
+            "The expected [{$command}] command was called {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
+     * Get all of the jobs matching a truth-test callback.
+     *
+     * @param  string  $command
+     * @param  callable|null  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function called($command, $callback = null)
+    {
+        if (! $this->hasCalled($command)) {
+            return collect();
+        }
+
+        $callback = $callback ?: function () {
+            return true;
+        };
+
+        return collect($this->commands[$command])->filter(function ($command) use ($callback) {
+            return $callback($command);
+        });
+    }
+
+    /**
+     * Determine if there are any stored commands for a given class.
+     *
+     * @param  string  $command
+     * @return bool
+     */
+    public function hasCalled($command)
+    {
+        return isset($this->commands[$command]) && ! empty($this->commands[$command]);
+    }
+
+    /**
+     * Call a command to its appropriate handler.
+     *
+     * @param  mixed  $command
+     * @return mixed
+     */
+    public function call($command, array $parameters = [], $outputBuffer = null)
+    {
+        if ($this->shouldFakeCommand($command)) {
+            $this->commands[$command][] = $command;
+        } else {
+            return $this->kernel->call($command);
+        }
+    }
+
+    /**
+     * Determine if an command should be faked or actually called.
+     *
+     * @param  mixed  $command
+     * @return bool
+     */
+    protected function shouldFakeCommand($command)
+    {
+        if (empty($this->commandsToFake)) {
+            return true;
+        }
+
+        return collect($this->commandsToFake)
+            ->filter(function ($item) use ($command) {
+                return $item === $command;
+            })->isNotEmpty();
+    }
+
+    public function handle($input, $output = null)
+    {
+        // TODO: Implement handle() method.
+    }
+
+    public function queue($command, array $parameters = [])
+    {
+        // TODO: Implement queue() method.
+    }
+
+    public function all()
+    {
+        // TODO: Implement all() method.
+    }
+
+    public function output()
+    {
+        // TODO: Implement output() method.
+    }
+
+    public function terminate($input, $status)
+    {
+        // TODO: Implement terminate() method.
+    }
+}

--- a/tests/Feature/Commands/BuildCommandTest.php
+++ b/tests/Feature/Commands/BuildCommandTest.php
@@ -7,6 +7,9 @@ use Blueprint\Builder;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
 
+/**
+ * @covers \Blueprint\Commands\BuildCommand
+ */
 class BuildCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;

--- a/tests/Feature/Commands/EraseCommandTest.php
+++ b/tests/Feature/Commands/EraseCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Commands;
 
+use Illuminate\Support\Facades\Bus;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
 
@@ -71,15 +72,16 @@ class EraseCommandTest extends TestCase
     /** @test */
     public function it_calls_the_trace_command()
     {
+        Bus::fake();
         $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
         $this->swap('files', $filesystem);
 
         $filesystem->expects('get')->with('.blueprint')->andReturn("other: test.php");
-        $filesystem->expects('put')->with('.blueprint',"other: test.php\n");
+        $filesystem->expects('put')->with('.blueprint', "other: test.php\n");
 
         $this->artisan('blueprint:erase')
             ->expectsOutput('No models found');
-        
+
         $this->markTestIncomplete('how to test if a command called another command?');
     }
 }

--- a/tests/Feature/Commands/EraseCommandTest.php
+++ b/tests/Feature/Commands/EraseCommandTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Feature\Commands;
 
-use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Artisan;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\ArtisanFake;
 use Tests\TestCase;
 
 /**
@@ -72,7 +73,8 @@ class EraseCommandTest extends TestCase
     /** @test */
     public function it_calls_the_trace_command()
     {
-        Bus::fake();
+        Artisan::swap(new ArtisanFake(Artisan::getFacadeRoot(), ['blueprint:trace']));
+
         $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
         $this->swap('files', $filesystem);
 
@@ -80,8 +82,8 @@ class EraseCommandTest extends TestCase
         $filesystem->expects('put')->with('.blueprint', "other: test.php\n");
 
         $this->artisan('blueprint:erase')
-            ->expectsOutput('No models found');
+            ->assertExitCode(0);
 
-        $this->markTestIncomplete('how to test if a command called another command?');
+        Artisan::assertCalled('blueprint:trace', 1);
     }
 }

--- a/tests/Feature/Commands/EraseCommandTest.php
+++ b/tests/Feature/Commands/EraseCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+/**
+ * @covers \Blueprint\Commands\EraseCommand
+ */
+class EraseCommandTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @test */
+    public function it_parses_and_update_the_trace_file()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $filesystem->expects('get')
+            ->with('.blueprint')
+            ->andReturn("created: created_file.php \nupdated: updated_file.php \nother: test.php");
+
+        $filesystem->expects('put')
+            ->with('.blueprint', "other: test.php\n");
+
+        $this->artisan('blueprint:erase')
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_deletes_the_created_files()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $filesystem->expects('get')
+            ->with('.blueprint')
+            ->andReturn("created:\n  -  created_file1.php\n  -  created_file2.php");
+
+        $filesystem->expects('delete')->with([
+            "created_file1.php",
+            "created_file2.php",
+        ]);
+
+        $this->artisan('blueprint:erase')
+            ->assertExitCode(0)
+            ->expectsOutput("Deleted:")
+            ->expectsOutput("- created_file1.php")
+            ->expectsOutput("- created_file2.php");
+    }
+
+    /** @test */
+    public function it_notify_about_the_updated_files()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $filesystem->expects('get')
+            ->with('.blueprint')
+            ->andReturn("updated:\n  -  updated_file1.php\n  -  updated_file2.php");
+
+        $this->artisan('blueprint:erase')
+            ->assertExitCode(0)
+            ->expectsOutput("The updates to the following files can not be erased automatically.")
+            ->expectsOutput("- updated_file1.php")
+            ->expectsOutput("- updated_file2.php");
+    }
+
+    /** @test */
+    public function it_calls_the_trace_command()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $filesystem->expects('get')->with('.blueprint')->andReturn("other: test.php");
+        $filesystem->expects('put')->with('.blueprint',"other: test.php\n");
+
+        $this->artisan('blueprint:erase')
+            ->expectsOutput('No models found');
+        
+        $this->markTestIncomplete('how to test if a command called another command?');
+    }
+}

--- a/tests/Feature/Commands/NewCommandTest.php
+++ b/tests/Feature/Commands/NewCommandTest.php
@@ -6,15 +6,13 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
 
 /**
- * @covers \Blueprint\Commands\NewCommand;
+ * @covers \Blueprint\Commands\NewCommand
  */
 class NewCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_creates_a_draft_file_from_stub_if_none_exists()
     {
         $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
@@ -33,9 +31,7 @@ class NewCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_does_not_create_a_draft_file_if_one_exists_already()
     {
         $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();


### PR DESCRIPTION
Changes:

1. Removing `;` from the `@covers` so code coverage not fails
1. Test the `EraseCommand`

Todo:

- [x] Better way to test if `EraseCommand` calls `TraceCommand`

I tried to use `mock` or `spy` to detect if `TraceCommand` handle method invoked but Laravel neglect the mocked version. Currently I take a very simpler approach to test if `'No models found'` output to the console but it's not a good way to do that.

I also review if Laravel has a similar approach to `Bus::fake($jobsToFake = [])` for commands with no success. If you have any idea, please let me know to I can try to implement it.