### PR TITLE
lighter trace command to increase the reusability and testability 

### DIFF
--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -65,7 +65,7 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
         $this->app->bind(
             'command.blueprint.trace',
             function ($app) {
-                return new TraceCommand($app['files']);
+                return new TraceCommand($app['files'], app(Tracer::class));
             }
         );
         $this->app->bind(

--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -3,11 +3,8 @@
 namespace Blueprint\Commands;
 
 use Blueprint\Blueprint;
-use Blueprint\EnumType;
 use Blueprint\Tracer;
-use Doctrine\DBAL\Types\Type;
 use Illuminate\Console\Command;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
@@ -37,7 +34,7 @@ class TraceCommand extends Command
      * @param Filesystem $files
      * @param Tracer $tracer
      */
-    public function __construct(Filesystem $files,Tracer $tracer)
+    public function __construct(Filesystem $files, Tracer $tracer)
     {
         parent::__construct();
 
@@ -53,11 +50,11 @@ class TraceCommand extends Command
     public function handle()
     {
         $blueprint = resolve(Blueprint::class);
-        $definitions = $this->tracer->execute($blueprint,$this->files);
+        $definitions = $this->tracer->execute($blueprint, $this->files);
 
         if (empty($definitions)) {
             $this->error('No models found');
-        }else{
+        } else {
             $this->info('Traced ' . count($definitions) . ' ' . Str::plural('model', count($definitions)));
         }
 

--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -4,6 +4,7 @@ namespace Blueprint\Commands;
 
 use Blueprint\Blueprint;
 use Blueprint\EnumType;
+use Blueprint\Tracer;
 use Doctrine\DBAL\Types\Type;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
@@ -29,15 +30,19 @@ class TraceCommand extends Command
     /** @var Filesystem $files */
     protected $files;
 
+    /** @var Tracer */
+    private $tracer;
+
     /**
      * @param Filesystem $files
-     * @param \Illuminate\Contracts\View\Factory $view
+     * @param Tracer $tracer
      */
-    public function __construct(Filesystem $files)
+    public function __construct(Filesystem $files,Tracer $tracer)
     {
         parent::__construct();
 
         $this->files = $files;
+        $this->tracer = $tracer;
     }
 
     /**
@@ -47,236 +52,15 @@ class TraceCommand extends Command
      */
     public function handle()
     {
-        $definitions = [];
-        foreach ($this->appClasses() as $class) {
-            $model = $this->loadModel($class);
-            if (is_null($model)) {
-                continue;
-            }
-
-            $definitions[$this->relativeClassName($model)] = $this->translateColumns($this->mapColumns($this->extractColumns($model)));
-        }
+        $blueprint = resolve(Blueprint::class);
+        $definitions = $this->tracer->execute($blueprint,$this->files);
 
         if (empty($definitions)) {
             $this->error('No models found');
-
-            return;
+        }else{
+            $this->info('Traced ' . count($definitions) . ' ' . Str::plural('model', count($definitions)));
         }
 
-        $blueprint = new Blueprint();
-
-        $cache = [];
-        if ($this->files->exists('.blueprint')) {
-            $cache = $blueprint->parse($this->files->get('.blueprint'));
-        }
-
-        $cache['models'] = $definitions;
-
-        $this->files->put('.blueprint', $blueprint->dump($cache));
-
-        $this->info('Traced ' . count($definitions) . ' ' . Str::plural('model', count($definitions)));
-    }
-
-    private function appClasses()
-    {
-        $dir = Blueprint::appPath();
-
-        if (config('blueprint.models_namespace')) {
-            $dir .= '/' . str_replace('\\', '/', config('blueprint.models_namespace'));
-        }
-
-        if (!$this->files->exists($dir)) {
-            return [];
-        }
-
-        return array_map(function (\SplFIleInfo $file) {
-            return str_replace(
-                [Blueprint::appPath() . '/', '/'],
-                [config('blueprint.namespace') . '\\', '\\'],
-                $file->getPath() . '/' . $file->getBasename('.php')
-            );
-        }, $this->files->allFiles($dir));
-    }
-
-    private function loadModel(string $class)
-    {
-        if (!class_exists($class)) {
-            return null;
-        }
-
-        $reflectionClass = new \ReflectionClass($class);
-        if (
-            !$reflectionClass->isSubclassOf(\Illuminate\Database\Eloquent\Model::class) ||
-            (class_exists('Jenssegers\Mongodb\Eloquent\Model') &&
-            $reflectionClass->isSubclassOf('Jenssegers\Mongodb\Eloquent\Model'))
-        ) {
-            return null;
-        }
-
-        return $this->laravel->make($class);
-    }
-
-    private function extractColumns(Model $model)
-    {
-        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
-        $schema = $model->getConnection()->getDoctrineSchemaManager();
-
-        if (!Type::hasType('enum')) {
-            Type::addType('enum', EnumType::class);
-            $databasePlatform = $schema->getDatabasePlatform();
-            $databasePlatform->registerDoctrineTypeMapping('enum', 'enum');
-        }
-
-        $database = null;
-        if (strpos($table, '.')) {
-            [$database, $table] = explode('.', $table);
-        }
-
-        $columns = $schema->listTableColumns($table, $database);
-
-        $uses_enums = collect($columns)->contains(function ($column) {
-            return $column->getType() instanceof \Blueprint\EnumType;
-        });
-
-        if ($uses_enums) {
-            $definitions = $model->getConnection()->getDoctrineConnection()->fetchAll($schema->getDatabasePlatform()->getListTableColumnsSQL($table, $database));
-
-            collect($columns)->filter(function ($column) {
-                return $column->getType() instanceof \Blueprint\EnumType;
-            })->each(function (&$column, $key) use ($definitions) {
-                $definition = collect($definitions)->where('Field', $key)->first();
-
-                $column->options = \Blueprint\EnumType::extractOptions($definition['Type']);
-            });
-        }
-
-        return $columns;
-    }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Column[] $columns
-     */
-    private function mapColumns($columns)
-    {
-        return collect($columns)
-            ->map([self::class, 'columns'])
-            ->toArray();
-    }
-
-    public static function columns(\Doctrine\DBAL\Schema\Column $column, string $key)
-    {
-        $attributes = [];
-
-        $type = self::translations($column->getType()->getName());
-
-        if (in_array($type, ['decimal', 'float'])) {
-            if ($column->getPrecision()) {
-                $type .= ':' . $column->getPrecision();
-            }
-            if ($column->getScale()) {
-                $type .= ',' . $column->getScale();
-            }
-        } elseif ($type === 'string' && $column->getLength()) {
-            if ($column->getLength() !== 255) {
-                $type .= ':' . $column->getLength();
-            }
-        } elseif ($type === 'text') {
-            if ($column->getLength() > 65535) {
-                $type = 'longtext';
-            }
-        } elseif ($type === 'enum' && !empty($column->options)) {
-            $type .= ':' . implode(',', $column->options);
-        }
-
-        // TODO: guid/uuid
-
-        $attributes[] = $type;
-
-        if ($column->getUnsigned()) {
-            $attributes[] = 'unsigned';
-        }
-
-        if (!$column->getNotnull()) {
-            $attributes[] = 'nullable';
-        }
-
-        if ($column->getAutoincrement()) {
-            $attributes[] = 'autoincrement';
-        }
-
-        if (!is_null($column->getDefault())) {
-            $attributes[] = 'default:' . $column->getDefault();
-        }
-
-        return implode(' ', $attributes);
-    }
-
-    private static function translations(string $type)
-    {
-        static $mappings = [
-            'array' => 'string',
-            'bigint' => 'biginteger',
-            'binary' => 'binary',
-            'blob' => 'binary',
-            'boolean' => 'boolean',
-            'date' => 'date',
-            'date_immutable' => 'date',
-            'dateinterval' => 'date',
-            'datetime' => 'datetime',
-            'datetime_immutable' => 'datetime',
-            'datetimetz' => 'datetimetz',
-            'datetimetz_immutable' => 'datetimetz',
-            'decimal' => 'decimal',
-            'enum' => 'enum',
-            'float' => 'float',
-            'guid' => 'string',
-            'integer' => 'integer',
-            'json' => 'json',
-            'object' => 'string',
-            'simple_array' => 'string',
-            'smallint' => 'smallinteger',
-            'string' => 'string',
-            'text' => 'text',
-            'time' => 'time',
-            'time_immutable' => 'time',
-        ];
-
-        return $mappings[$type] ?? 'string';
-    }
-
-    private function translateColumns(array $columns)
-    {
-        if (isset($columns['id']) && strpos($columns['id'], 'autoincrement') !== false && strpos($columns['id'], 'integer') !== false) {
-            unset($columns['id']);
-        }
-
-        if (isset($columns[Model::CREATED_AT]) && isset($columns[Model::UPDATED_AT])) {
-            if (strpos($columns[Model::CREATED_AT], 'datetimetz') !== false) {
-                $columns['timestampstz'] = 'timestampsTz';
-            }
-
-            unset($columns[Model::CREATED_AT]);
-            unset($columns[Model::UPDATED_AT]);
-        }
-
-        if (isset($columns['deleted_at'])) {
-            if (strpos($columns['deleted_at'], 'datetimetz') !== false) {
-                $columns['softdeletestz'] = 'softDeletesTz';
-            }
-
-            unset($columns['deleted_at']);
-        }
-
-        return $columns;
-    }
-
-    private function relativeClassName($model)
-    {
-        $name = Blueprint::relativeNamespace(get_class($model));
-        if (config('blueprint.models_namespace')) {
-            return $name;
-        }
-
-        return ltrim(str_replace(config('blueprint.models_namespace'), '', $name), '\\');
+        return 0;
     }
 }

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Blueprint;
+
+use Doctrine\DBAL\Types\Type;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\Filesystem;
+
+class Tracer
+{
+    /** @var Filesystem */
+    private $files;
+
+    public function execute(Blueprint $blueprint, Filesystem $files): array
+    {
+        $this->files = $files;
+
+        $definitions = [];
+        foreach ($this->appClasses() as $class) {
+            $model = $this->loadModel($class);
+            if (is_null($model)) {
+                continue;
+            }
+
+            $definitions[$this->relativeClassName($model)] = $this->translateColumns($this->mapColumns($this->extractColumns($model)));
+        }
+
+        if (empty($definitions)) {
+            return $definitions;
+        }
+
+        $cache = [];
+        if ($files->exists('.blueprint')) {
+            $cache = $blueprint->parse($files->get('.blueprint'));
+        }
+
+        $cache['models'] = $definitions;
+
+        $files->put('.blueprint', $blueprint->dump($cache));
+
+        return $definitions;
+    }
+
+    private function appClasses()
+    {
+        $dir = Blueprint::appPath();
+
+        if (config('blueprint.models_namespace')) {
+            $dir .= '/' . str_replace('\\', '/', config('blueprint.models_namespace'));
+        }
+
+        if (!$this->files->exists($dir)) {
+            return [];
+        }
+
+        return array_map(function (\SplFIleInfo $file) {
+            return str_replace(
+                [Blueprint::appPath() . '/', '/'],
+                [config('blueprint.namespace') . '\\', '\\'],
+                $file->getPath() . '/' . $file->getBasename('.php')
+            );
+        }, $this->files->allFiles($dir));
+    }
+
+    private function loadModel(string $class)
+    {
+        if (!class_exists($class)) {
+            return null;
+        }
+
+        $reflectionClass = new \ReflectionClass($class);
+        if (
+            !$reflectionClass->isSubclassOf(\Illuminate\Database\Eloquent\Model::class) ||
+            (class_exists('Jenssegers\Mongodb\Eloquent\Model') &&
+                $reflectionClass->isSubclassOf('Jenssegers\Mongodb\Eloquent\Model'))
+        ) {
+            return null;
+        }
+
+        return app($class);
+    }
+
+    private function extractColumns(Model $model)
+    {
+        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
+        $schema = $model->getConnection()->getDoctrineSchemaManager();
+
+        if (!Type::hasType('enum')) {
+            Type::addType('enum', EnumType::class);
+            $databasePlatform = $schema->getDatabasePlatform();
+            $databasePlatform->registerDoctrineTypeMapping('enum', 'enum');
+        }
+
+        $database = null;
+        if (strpos($table, '.')) {
+            [$database, $table] = explode('.', $table);
+        }
+
+        $columns = $schema->listTableColumns($table, $database);
+
+        $uses_enums = collect($columns)->contains(function ($column) {
+            return $column->getType() instanceof \Blueprint\EnumType;
+        });
+
+        if ($uses_enums) {
+            $definitions = $model->getConnection()->getDoctrineConnection()->fetchAll($schema->getDatabasePlatform()->getListTableColumnsSQL($table, $database));
+
+            collect($columns)->filter(function ($column) {
+                return $column->getType() instanceof \Blueprint\EnumType;
+            })->each(function (&$column, $key) use ($definitions) {
+                $definition = collect($definitions)->where('Field', $key)->first();
+
+                $column->options = \Blueprint\EnumType::extractOptions($definition['Type']);
+            });
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Column[] $columns
+     */
+    private function mapColumns($columns)
+    {
+        return collect($columns)
+            ->map([self::class, 'columns'])
+            ->toArray();
+    }
+
+    public static function columns(\Doctrine\DBAL\Schema\Column $column, string $key)
+    {
+        $attributes = [];
+
+        $type = self::translations($column->getType()->getName());
+
+        if (in_array($type, ['decimal', 'float'])) {
+            if ($column->getPrecision()) {
+                $type .= ':' . $column->getPrecision();
+            }
+            if ($column->getScale()) {
+                $type .= ',' . $column->getScale();
+            }
+        } elseif ($type === 'string' && $column->getLength()) {
+            if ($column->getLength() !== 255) {
+                $type .= ':' . $column->getLength();
+            }
+        } elseif ($type === 'text') {
+            if ($column->getLength() > 65535) {
+                $type = 'longtext';
+            }
+        } elseif ($type === 'enum' && !empty($column->options)) {
+            $type .= ':' . implode(',', $column->options);
+        }
+
+        // TODO: guid/uuid
+
+        $attributes[] = $type;
+
+        if ($column->getUnsigned()) {
+            $attributes[] = 'unsigned';
+        }
+
+        if (!$column->getNotnull()) {
+            $attributes[] = 'nullable';
+        }
+
+        if ($column->getAutoincrement()) {
+            $attributes[] = 'autoincrement';
+        }
+
+        if (!is_null($column->getDefault())) {
+            $attributes[] = 'default:' . $column->getDefault();
+        }
+
+        return implode(' ', $attributes);
+    }
+
+    private static function translations(string $type)
+    {
+        static $mappings = [
+            'array' => 'string',
+            'bigint' => 'biginteger',
+            'binary' => 'binary',
+            'blob' => 'binary',
+            'boolean' => 'boolean',
+            'date' => 'date',
+            'date_immutable' => 'date',
+            'dateinterval' => 'date',
+            'datetime' => 'datetime',
+            'datetime_immutable' => 'datetime',
+            'datetimetz' => 'datetimetz',
+            'datetimetz_immutable' => 'datetimetz',
+            'decimal' => 'decimal',
+            'enum' => 'enum',
+            'float' => 'float',
+            'guid' => 'string',
+            'integer' => 'integer',
+            'json' => 'json',
+            'object' => 'string',
+            'simple_array' => 'string',
+            'smallint' => 'smallinteger',
+            'string' => 'string',
+            'text' => 'text',
+            'time' => 'time',
+            'time_immutable' => 'time',
+        ];
+
+        return $mappings[$type] ?? 'string';
+    }
+
+    private function translateColumns(array $columns)
+    {
+        if (isset($columns['id']) && strpos($columns['id'], 'autoincrement') !== false && strpos($columns['id'], 'integer') !== false) {
+            unset($columns['id']);
+        }
+
+        if (isset($columns[Model::CREATED_AT]) && isset($columns[Model::UPDATED_AT])) {
+            if (strpos($columns[Model::CREATED_AT], 'datetimetz') !== false) {
+                $columns['timestampstz'] = 'timestampsTz';
+            }
+
+            unset($columns[Model::CREATED_AT]);
+            unset($columns[Model::UPDATED_AT]);
+        }
+
+        if (isset($columns['deleted_at'])) {
+            if (strpos($columns['deleted_at'], 'datetimetz') !== false) {
+                $columns['softdeletestz'] = 'softDeletesTz';
+            }
+
+            unset($columns['deleted_at']);
+        }
+
+        return $columns;
+    }
+
+    private function relativeClassName($model)
+    {
+        $name = Blueprint::relativeNamespace(get_class($model));
+        if (config('blueprint.models_namespace')) {
+            return $name;
+        }
+
+        return ltrim(str_replace(config('blueprint.models_namespace'), '', $name), '\\');
+    }
+}

--- a/tests/Feature/Commands/EraseCommandTest.php
+++ b/tests/Feature/Commands/EraseCommandTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Commands;
 
+use Blueprint\Blueprint;
+use Blueprint\Tracer;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
 
@@ -77,7 +79,12 @@ class EraseCommandTest extends TestCase
         $filesystem->expects('get')->with('.blueprint')->andReturn("other: test.php");
         $filesystem->expects('put')->with('.blueprint', "other: test.php\n");
 
+        $tracer = $this->spy(Tracer::class);
+
         $this->artisan('blueprint:erase')
             ->assertExitCode(0);
+
+        $tracer->shouldHaveReceived('execute')
+            ->with(resolve(Blueprint::class), $filesystem);
     }
 }

--- a/tests/Feature/Commands/TraceCommandTest.php
+++ b/tests/Feature/Commands/TraceCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Blueprint\Blueprint;
+use Blueprint\Builder;
+use Blueprint\Commands\TraceCommand;
+use Blueprint\Tracer;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+/**
+ * @covers \Blueprint\Commands\TraceCommand
+ */
+class TraceCommandTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @test */
+    public function it_shows_error_if_no_model_found()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $tracer = $this->mock(Tracer::class);
+
+        $tracer->shouldReceive('execute')
+            ->with(resolve(Blueprint::class), $filesystem)
+            ->andReturn([]);
+
+        $this->artisan('blueprint:trace')
+            ->assertExitCode(0)
+            ->expectsOutput('No models found');
+    }
+
+    /** @test */
+    public function it_shows_the_number_of_traced_models()
+    {
+        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
+        $this->swap('files', $filesystem);
+
+        $tracer = $this->mock(Tracer::class);
+
+        $tracer->shouldReceive('execute')
+            ->with(resolve(Blueprint::class), $filesystem)
+            ->andReturn([
+                "Model" => [],
+                "OtherModel" => [],
+            ]);
+
+        $this->artisan('blueprint:trace')
+            ->assertExitCode(0)
+            ->expectsOutput('Traced 2 models');
+    }
+}


### PR DESCRIPTION
Sorry for suggesting too many conflicting ideas. 😕 

When I start thinking about the big picture and think how must we test the trace command itself, I realized that the command includes the full implementation in contrast to the build command which depends on `Buillder` class.

The PR is not ready for merging yet, but I want to make sure that you are ok with the approach of separating the command from the logic itself. If yes, this will make it easier to call the `Tracer` in other command and test if it's called or not without calling a command from another command?

I really enjoyed reading and refactoring the code, and I think I'm very close to start contributing new features and community requested enhancements.