### PR TITLE
Migrations with fixed timestamp

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -70,13 +70,13 @@ class Blueprint
         return new Tree($registry);
     }
 
-    public function generate(Tree $tree, array $only = [], array $skip = []): array
+    public function generate(Tree $tree, array $only = [], array $skip = [], $overwriteMigrations = false): array
     {
         $components = [];
 
         foreach ($this->generators as $generator) {
             if ($this->shouldGenerate($generator->types(), $only, $skip)) {
-                $components = array_merge_recursive($components, $generator->output($tree));
+                $components = array_merge_recursive($components, $generator->output($tree, $overwriteMigrations));
             }
         }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -6,7 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class Builder
 {
-    public function execute(Blueprint $blueprint, Filesystem $files, string $draft, string $only = '', string $skip = '')
+    public function execute(Blueprint $blueprint, Filesystem $files, string $draft, string $only = '', string $skip = '', $overwriteMigrations = false)
     {
         $cache = [];
         if ($files->exists('.blueprint')) {
@@ -20,7 +20,7 @@ class Builder
         $only = array_filter(explode(',', $only));
         $skip = array_filter(explode(',', $skip));
 
-        $generated = $blueprint->generate($registry, $only, $skip);
+        $generated = $blueprint->generate($registry, $only, $skip, $overwriteMigrations);
 
         $models = array_merge($tokens['cache'], $tokens['models'] ?? []);
 

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -21,6 +21,7 @@ class BuildCommand extends Command
                             {draft? : The path to the draft file, default: draft.yaml or draft.yml }
                             {--only= : Comma separated list of file classes to generate, skipping the rest }
                             {--skip= : Comma separated list of file classes to skip, generating the rest }
+                            {--overwrite-migrations : Update existing migration files, if found }
                             ';
 
     /**
@@ -59,9 +60,10 @@ class BuildCommand extends Command
 
         $only = $this->option('only') ?: '';
         $skip = $this->option('skip') ?: '';
+        $overwriteMigrations = $this->option('overwrite-migrations') ?: false;
 
         $blueprint = resolve(Blueprint::class);
-        $generated = $this->builder->execute($blueprint, $this->files, $file, $only, $skip);
+        $generated = $this->builder->execute($blueprint, $this->files, $file, $only, $skip, $overwriteMigrations);
 
         collect($generated)->each(function ($files, $action) {
             $this->line(Str::studly($action).':', $this->outputStyle($action));

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -379,7 +379,7 @@ class BlueprintTest extends TestCase
         $tree = new Tree(['branch' => ['code', 'attributes']]);
 
         $generatorOne->expects('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['one/new.php'],
                 'updated' => ['one/existing.php'],
@@ -394,7 +394,7 @@ class BlueprintTest extends TestCase
 
         $generatorTwo = \Mockery::mock(Generator::class);
         $generatorTwo->expects('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['two/new.php'],
                 'updated' => ['two/existing.php'],
@@ -429,7 +429,7 @@ class BlueprintTest extends TestCase
 
         $generatorSwap = \Mockery::mock(Generator::class);
         $generatorSwap->expects('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['swapped/new.php'],
                 'updated' => ['swapped/existing.php'],
@@ -464,7 +464,7 @@ class BlueprintTest extends TestCase
         $skip = [];
 
         $generatorFoo->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['foo.php'],
             ]);
@@ -474,7 +474,7 @@ class BlueprintTest extends TestCase
 
         $generatorBar = \Mockery::mock(Generator::class);
         $generatorBar->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['bar.php'],
             ]);
@@ -484,7 +484,7 @@ class BlueprintTest extends TestCase
 
         $generatorBaz = \Mockery::mock(Generator::class);
         $generatorBaz->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['baz.php'],
             ]);
@@ -515,7 +515,7 @@ class BlueprintTest extends TestCase
         $skip = [];
 
         $generatorFoo->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['foo.php'],
             ]);
@@ -525,7 +525,7 @@ class BlueprintTest extends TestCase
 
         $generatorBar = \Mockery::mock(Generator::class);
         $generatorBar->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['bar.php'],
             ]);
@@ -535,7 +535,7 @@ class BlueprintTest extends TestCase
 
         $generatorBaz = \Mockery::mock(Generator::class);
         $generatorBaz->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['baz.php'],
             ]);
@@ -566,7 +566,7 @@ class BlueprintTest extends TestCase
         $skip = ['bar'];
 
         $generatorFoo->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['foo.php'],
             ]);
@@ -576,7 +576,7 @@ class BlueprintTest extends TestCase
 
         $generatorBar = \Mockery::mock(Generator::class);
         $generatorBar->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['bar.php'],
             ]);
@@ -586,7 +586,7 @@ class BlueprintTest extends TestCase
 
         $generatorBaz = \Mockery::mock(Generator::class);
         $generatorBaz->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['baz.php'],
             ]);
@@ -617,7 +617,7 @@ class BlueprintTest extends TestCase
         $skip = ['bar', 'baz'];
 
         $generatorFoo->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['foo.php'],
             ]);
@@ -637,7 +637,7 @@ class BlueprintTest extends TestCase
 
         $generatorBaz = \Mockery::mock(Generator::class);
         $generatorBaz->shouldReceive('output')
-            ->with($tree)
+            ->with($tree, false)
             ->andReturn([
                 'created' => ['baz.php'],
             ]);

--- a/tests/Feature/Commands/BuildCommandTest.php
+++ b/tests/Feature/Commands/BuildCommandTest.php
@@ -24,7 +24,7 @@ class BuildCommandTest extends TestCase
         $builder = $this->mock(Builder::class);
 
         $builder->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $filesystem, 'draft.yaml', '', '')
+            ->with(resolve(Blueprint::class), $filesystem, 'draft.yaml', '', '', false)
             ->andReturn(collect([]));
 
         $this->artisan('blueprint:build')
@@ -44,7 +44,7 @@ class BuildCommandTest extends TestCase
         $builder = $this->mock(Builder::class);
 
         $builder->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $filesystem, 'test.yml', 'a,b,c', 'x,y,z')
+            ->with(resolve(Blueprint::class), $filesystem, 'test.yml', 'a,b,c', 'x,y,z', false)
             ->andReturn(collect([]));
 
         $this->artisan('blueprint:build test.yml --only=a,b,c --skip=x,y,z')
@@ -82,7 +82,7 @@ class BuildCommandTest extends TestCase
         $builder = $this->mock(Builder::class);
 
         $builder->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $filesystem, 'draft.yaml', '', '')
+            ->with(resolve(Blueprint::class), $filesystem, 'draft.yaml', '', '', false)
             ->andReturn(collect([
                 "created" => [
                     "file1",

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -7,6 +7,7 @@ use Blueprint\Generators\MigrationGenerator;
 use Blueprint\Tree;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
+use Symfony\Component\Finder\SplFileInfo;
 use Tests\TestCase;
 
 /**
@@ -57,10 +58,6 @@ class MigrationGeneratorTest extends TestCase
             ->with('migration.stub')
             ->andReturn(file_get_contents('stubs/migration.stub'));
 
-        $this->files->expects('files')
-            ->with('database/migrations/')
-            ->andReturn([]);
-
         $now = Carbon::now();
         Carbon::setTestNow($now);
 
@@ -95,7 +92,9 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('files')
             ->with('database/migrations/')
-            ->andReturn([basename($yesterday_path)]);
+            ->andReturn([
+                new SplFileInfo($yesterday_path, '', ''),
+            ]);
 
         $this->files->expects('exists')
             ->with($yesterday_path)
@@ -124,7 +123,6 @@ class MigrationGeneratorTest extends TestCase
 
         $timestamp_path = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comments_table.php');
 
-        $this->files->expects('files')->andReturn([]);
         $this->files->expects('exists')->andReturn(false);
 
         $this->files->expects('put')
@@ -151,7 +149,6 @@ class MigrationGeneratorTest extends TestCase
         $post_path = str_replace('timestamp', $now->copy()->subSecond()->format('Y_m_d_His'), 'database/migrations/timestamp_create_posts_table.php');
         $comment_path = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comments_table.php');
 
-        $this->files->expects('files')->twice()->andReturn([]);
         $this->files->expects('exists')->twice()->andReturn(false);
 
         $this->files->expects('put')
@@ -185,7 +182,6 @@ class MigrationGeneratorTest extends TestCase
 
         $timestamp_path = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_relationships_table.php');
 
-        $this->files->expects('files')->andReturn([]);
         $this->files->expects('exists')->andReturn(false);
 
         $this->files->expects('put')
@@ -213,7 +209,6 @@ class MigrationGeneratorTest extends TestCase
 
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comments_table.php');
 
-        $this->files->expects('files')->andReturn([]);
         $this->files->expects('exists')->andReturn(false);
 
         $this->files->expects('put')
@@ -247,7 +242,6 @@ class MigrationGeneratorTest extends TestCase
 
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comments_table.php');
 
-        $this->files->expects('files')->andReturn([]);
         $this->files->expects('exists')->andReturn(false);
 
         $this->files->expects('put')
@@ -274,7 +268,6 @@ class MigrationGeneratorTest extends TestCase
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_journeys_table.php');
         $pivot_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_diary_journey_table.php');
 
-        $this->files->expects('files')->twice()->andReturn([]);
         $this->files->expects('exists')->twice()->andReturn(false);
 
         $this->files->expects('put')
@@ -306,8 +299,8 @@ class MigrationGeneratorTest extends TestCase
             ->with('database/migrations/')
             ->twice()
             ->andReturn([
-                basename($model_migration),
-                basename($pivot_migration),
+                new SplFileInfo($model_migration, '', ''),
+                new SplFileInfo($pivot_migration, '', ''),
             ]);
 
         $this->files->expects('exists')->with($model_migration)->andReturn(true);
@@ -321,7 +314,7 @@ class MigrationGeneratorTest extends TestCase
         $tokens = $this->blueprint->parse($this->fixture('drafts/belongs-to-many.yaml'));
         $tree = $this->blueprint->analyze($tokens);
 
-        $this->assertEquals(['updated' => [$model_migration, $pivot_migration]], $this->subject->output($tree));
+        $this->assertEquals(['updated' => [$model_migration, $pivot_migration]], $this->subject->output($tree, true));
     }
 
     /**
@@ -345,7 +338,6 @@ class MigrationGeneratorTest extends TestCase
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_journeys_table.php');
         $pivot_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_diary_journey_table.php');
 
-        $this->files->expects('files')->twice()->andReturn([]);
         $this->files->expects('exists')->twice()->andReturn(false);
 
         $this->files->expects('put')
@@ -377,7 +369,6 @@ class MigrationGeneratorTest extends TestCase
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_journeys_table.php');
         $pivot_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_diary_journey_table.php');
 
-        $this->files->expects('files')->twice()->andReturn([]);
         $this->files->expects('exists')->twice()->andReturn(false);
 
         $this->files->expects('put')
@@ -415,7 +406,6 @@ class MigrationGeneratorTest extends TestCase
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_journeys_table.php');
         $pivot_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_diary_journey_table.php');
 
-        $this->files->expects('files')->twice()->andReturn([]);
         $this->files->expects('exists')->twice()->andReturn(false);
 
         $this->files->expects('put')
@@ -445,7 +435,6 @@ class MigrationGeneratorTest extends TestCase
         $people_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_people_table.php');
         $pivot_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_company_person_table.php');
 
-        $this->files->expects('files')->times(3)->andReturn([]);
         $this->files->expects('exists')->times(3)->andReturn(false);
 
         $this->files->expects('put')
@@ -483,7 +472,6 @@ class MigrationGeneratorTest extends TestCase
         $people_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_people_table.php');
         $pivot_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_company_person_table.php');
 
-        $this->files->expects('files')->times(3)->andReturn([]);
         $this->files->expects('exists')->times(3)->andReturn(false);
 
         $this->files->expects('put')
@@ -514,7 +502,6 @@ class MigrationGeneratorTest extends TestCase
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_users_table.php');
         $pivot_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_test_table.php');
 
-        $this->files->expects('files')->twice()->andReturn([]);
         $this->files->expects('exists')->twice()->andReturn(false);
 
         $this->files->expects('put')
@@ -549,7 +536,6 @@ class MigrationGeneratorTest extends TestCase
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_users_table.php');
         $pivot_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_test_table.php');
 
-        $this->files->expects('files')->twice()->andReturn([]);
         $this->files->expects('exists')->twice()->andReturn(false);
 
         $this->files->expects('put')
@@ -579,7 +565,6 @@ class MigrationGeneratorTest extends TestCase
 
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_carts_table.php');
 
-        $this->files->expects('files')->andReturn([]);
         $this->files->expects('exists')->andReturn(false);
 
         $this->files
@@ -614,7 +599,6 @@ class MigrationGeneratorTest extends TestCase
 
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_carts_table.php');
 
-        $this->files->expects('files')->andReturn([]);
         $this->files->expects('exists')->andReturn(false);
 
         $this->files
@@ -641,7 +625,6 @@ class MigrationGeneratorTest extends TestCase
 
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comments_table.php');
 
-        $this->files->expects('files')->andReturn([]);
         $this->files->expects('exists')->andReturn(false);
 
         $this->files
@@ -674,7 +657,6 @@ class MigrationGeneratorTest extends TestCase
 
         $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comments_table.php');
 
-        $this->files->expects('files')->andReturn([]);
         $this->files->expects('exists')->andReturn(false);
 
         $this->files
@@ -703,7 +685,6 @@ class MigrationGeneratorTest extends TestCase
         $user_migration = str_replace('timestamp', $now->copy()->subSecond()->format('Y_m_d_His'), 'database/migrations/timestamp_create_users_table.php');
         $image_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_images_table.php');
 
-        $this->files->expects('files')->times(3)->andReturn([]);
         $this->files->expects('exists')->times(3)->andReturn(false);
 
         $this->files->expects('put')
@@ -741,7 +722,6 @@ class MigrationGeneratorTest extends TestCase
         $user_migration = str_replace('timestamp', $now->copy()->subSecond()->format('Y_m_d_His'), 'database/migrations/timestamp_create_users_table.php');
         $image_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_images_table.php');
 
-        $this->files->expects('files')->times(3)->andReturn([]);
         $this->files->expects('exists')->times(3)->andReturn(false);
 
         $this->files->expects('put')

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -30,7 +30,7 @@ class BuilderTest extends TestCase
             ->with($tokens + ['cache' => []])
             ->andReturn($registry);
         $blueprint->expects('generate')
-            ->with($registry, $only, $skip)
+            ->with($registry, $only, $skip, false)
             ->andReturn($generated);
         $blueprint->expects('dump')
             ->with($generated)
@@ -81,7 +81,7 @@ class BuilderTest extends TestCase
             ->with($tokens + ['cache' => $cache['models']])
             ->andReturn($registry);
         $blueprint->expects('generate')
-            ->with($registry, $only, $skip)
+            ->with($registry, $only, $skip, false)
             ->andReturn($generated);
         $blueprint->expects('dump')
             ->with([


### PR DESCRIPTION
As per #265, supports `blueprint:build --overwrite-migrations`

Was a little awkward passing options down from the command to a generator, would be worth refactoring if other options for generators will be supported in the future.