### PR TITLE
Add support for tuple route generation

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -102,4 +102,17 @@ return [
 
     'use_guarded' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Use Route Tuples
+    |--------------------------------------------------------------------------
+    |
+    | By default, Laravel configures a root controller namespace within the
+    | RouteServiceProvider. In case you have removed that value to use a
+    | "tuple-based" approach in the routes file(s) to improve typing
+    | in your project, you may set this to true instead.
+    |
+    */
+    'use_route_tuples' => false,
+
 ];

--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -107,10 +107,11 @@ return [
     | Use Route Tuples
     |--------------------------------------------------------------------------
     |
-    | By default, Laravel configures a root controller namespace within the
-    | RouteServiceProvider. In case you have removed that value to use a
-    | "tuple-based" approach in the routes file(s) to improve typing
-    | in your project, you may set this to true instead.
+    | By default, Blueprint follows the Laravel convention of the controller
+    | namespace matches the namespace set within the RouteServiceProvider.
+    | However, you may configure Blueprint to generate routes using a
+    | "tuple syntax" in cases where you may not use this property
+    | or wish to improve static analysis.
     |
     */
     'use_route_tuples' => false,

--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -114,6 +114,6 @@ return [
     | or wish to improve static analysis.
     |
     */
-    'use_route_tuples' => false,
+    'generate_fqcn_route' => false,
 
 ];

--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -104,7 +104,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Use Route Tuples
+    | Generate FQCN Routes
     |--------------------------------------------------------------------------
     |
     | By default, Blueprint follows the Laravel convention of the controller

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -6,15 +6,21 @@ use Blueprint\Contracts\Generator;
 use Blueprint\Models\Controller;
 use Blueprint\Tree;
 use Illuminate\Support\Str;
+use Illuminate\Contracts\Routing\UrlGenerator;
 
 class RouteGenerator implements Generator
 {
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     private $files;
 
+    /** @var string */
+    private $rootNamespace;
+
     public function __construct($files)
     {
         $this->files = $files;
+
+        $this->rootNamespace = $this->determineRootNamespace(app(UrlGenerator::class));
     }
 
     public function output(Tree $tree): array
@@ -52,14 +58,19 @@ class RouteGenerator implements Generator
         $routes = '';
         $methods = array_keys($controller->methods());
 
-        $className = str_replace('App\Http\Controllers\\', '', $controller->fullyQualifiedClassName());
+        $useTuples = $this->rootNamespace === null || $this->rootNamespace === '';
+
+        $className = $useTuples
+            ? $controller->fullyQualifiedClassName() . '::class'
+            : '\'' . str_replace($this->rootNamespace . '\\', '', $controller->fullyQualifiedClassName()) . '\'';
+
         $slug = Str::kebab($controller->prefix());
 
         $resource_methods = array_intersect($methods, Controller::$resourceMethods);
         if (count($resource_methods)) {
             $routes .= $controller->isApiResource()
-                ? sprintf("Route::apiResource('%s', '%s')", $slug, $className)
-                : sprintf("Route::resource('%s', '%s')", $slug, $className);
+                ? sprintf("Route::apiResource('%s', %s)", $slug, $className)
+                : sprintf("Route::resource('%s', %s)", $slug, $className);
 
             $missing_methods = $controller->isApiResource()
                 ? array_diff(Controller::$apiResourceMethods, $resource_methods)
@@ -78,10 +89,26 @@ class RouteGenerator implements Generator
 
         $methods = array_diff($methods, Controller::$resourceMethods);
         foreach ($methods as $method) {
-            $routes .= sprintf("Route::get('%s/%s', '%s@%s');", $slug, Str::kebab($method), $className, $method);
+            if ($useTuples) {
+                $action = "[{$className}, '{$method}']";
+            } else {
+                $classNameNoQuotes = trim($className, '\'');
+                $action = "'{$classNameNoQuotes}@{$method}'";
+            }
+
+            $routes .= sprintf("Route::get('%s/%s', %s);", $slug, Str::kebab($method), $action);
             $routes .= PHP_EOL;
         }
 
         return trim($routes);
+    }
+
+    protected function determineRootNamespace(UrlGenerator $urlGenerator): ?string
+    {
+        return (function () {
+            // While there is a setter, there is no getter for the root namespace
+            // This closure acts like a subclass so the value can be retrieved
+            return $this->rootNamespace;
+        })->call($urlGenerator);
     }
 }

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -6,21 +6,15 @@ use Blueprint\Contracts\Generator;
 use Blueprint\Models\Controller;
 use Blueprint\Tree;
 use Illuminate\Support\Str;
-use Illuminate\Contracts\Routing\UrlGenerator;
 
 class RouteGenerator implements Generator
 {
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     private $files;
 
-    /** @var string */
-    private $rootNamespace;
-
     public function __construct($files)
     {
         $this->files = $files;
-
-        $this->rootNamespace = $this->determineRootNamespace(app(UrlGenerator::class));
     }
 
     public function output(Tree $tree): array
@@ -58,11 +52,11 @@ class RouteGenerator implements Generator
         $routes = '';
         $methods = array_keys($controller->methods());
 
-        $useTuples = $this->rootNamespace === null || $this->rootNamespace === '';
+        $useTuples = config('blueprint.use_route_tuples');
 
         $className = $useTuples
             ? $controller->fullyQualifiedClassName() . '::class'
-            : '\'' . str_replace($this->rootNamespace . '\\', '', $controller->fullyQualifiedClassName()) . '\'';
+            : '\'' . str_replace('App\Http\Controllers\\', '', $controller->fullyQualifiedClassName()) . '\'';
 
         $slug = Str::kebab($controller->prefix());
 
@@ -101,14 +95,5 @@ class RouteGenerator implements Generator
         }
 
         return trim($routes);
-    }
-
-    protected function determineRootNamespace(UrlGenerator $urlGenerator): ?string
-    {
-        return (function () {
-            // While there is a setter, there is no getter for the root namespace
-            // This closure acts like a subclass so the value can be retrieved
-            return $this->rootNamespace;
-        })->call($urlGenerator);
     }
 }

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -52,7 +52,7 @@ class RouteGenerator implements Generator
         $routes = '';
         $methods = array_keys($controller->methods());
 
-        $useTuples = config('blueprint.use_route_tuples');
+        $useTuples = config('blueprint.generate_fqcn_route');
 
         $className = $useTuples
             ? $controller->fullyQualifiedClassName() . '::class'

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -93,7 +93,7 @@ class RouteGeneratorTest extends TestCase
      */
     public function output_generates_routes_using_tuples()
     {
-        config(['blueprint.use_route_tuples' => true]);
+        config(['blueprint.generate_fqcn_route' => true]);
 
         $this->files->expects('append')
             ->with('routes/web.php', $this->fixture('routes/routes-tuples.php'));

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -6,6 +6,7 @@ use Blueprint\Blueprint;
 use Blueprint\Generators\RouteGenerator;
 use Blueprint\Lexers\StatementLexer;
 use Blueprint\Tree;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Tests\TestCase;
 
 /**
@@ -23,6 +24,9 @@ class RouteGeneratorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Default laravel installations provide a namespace, while the framework itself does not
+        $this->app[UrlGenerator::class]->setRootControllerNamespace('App\Http\Controllers');
 
         $this->files = \Mockery::mock();
         $this->subject = new RouteGenerator($this->files);
@@ -86,6 +90,22 @@ class RouteGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals(['updated' => ['routes/api.php', 'routes/web.php']], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     */
+    public function output_generates_routes_using_tuples()
+    {
+        $this->app[UrlGenerator::class]->setRootControllerNamespace(null);
+
+        $this->files->expects('append')
+            ->with('routes/web.php', $this->fixture('routes/routes-tuples.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/routes-tuples.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        (new RouteGenerator($this->files))->output($tree);
     }
 
     public function controllerTreeDataProvider()

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -6,7 +6,6 @@ use Blueprint\Blueprint;
 use Blueprint\Generators\RouteGenerator;
 use Blueprint\Lexers\StatementLexer;
 use Blueprint\Tree;
-use Illuminate\Contracts\Routing\UrlGenerator;
 use Tests\TestCase;
 
 /**
@@ -24,9 +23,6 @@ class RouteGeneratorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        // Default laravel installations provide a namespace, while the framework itself does not
-        $this->app[UrlGenerator::class]->setRootControllerNamespace('App\Http\Controllers');
 
         $this->files = \Mockery::mock();
         $this->subject = new RouteGenerator($this->files);
@@ -97,7 +93,7 @@ class RouteGeneratorTest extends TestCase
      */
     public function output_generates_routes_using_tuples()
     {
-        $this->app[UrlGenerator::class]->setRootControllerNamespace(null);
+        config(['blueprint.use_route_tuples' => true]);
 
         $this->files->expects('append')
             ->with('routes/web.php', $this->fixture('routes/routes-tuples.php'));
@@ -105,7 +101,7 @@ class RouteGeneratorTest extends TestCase
         $tokens = $this->blueprint->parse($this->fixture('drafts/routes-tuples.yaml'));
         $tree = $this->blueprint->analyze($tokens);
 
-        (new RouteGenerator($this->files))->output($tree);
+        $this->subject->output($tree);
     }
 
     public function controllerTreeDataProvider()

--- a/tests/fixtures/drafts/routes-tuples.yaml
+++ b/tests/fixtures/drafts/routes-tuples.yaml
@@ -1,0 +1,10 @@
+models:
+  Foo:
+    name: string
+
+controllers:
+  Foo:
+    resource
+  Some:
+    whatever:
+      redirect: some.index

--- a/tests/fixtures/routes/routes-tuples.php
+++ b/tests/fixtures/routes/routes-tuples.php
@@ -1,0 +1,5 @@
+
+
+Route::resource('foo', App\Http\Controllers\FooController::class);
+
+Route::get('some/whatever', [App\Http\Controllers\SomeController::class, 'whatever']);


### PR DESCRIPTION
I was unsure which approach to take, but I ended up with reading out the actual value from the UrlGenerator class itself, rather than trying to analyze the RouteServiceProvider. Seemed like the most stable solution to me.

Fixes #321
