### PR TITLE
Use aliased resource imports in controllers

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -140,12 +140,16 @@ class ControllerGenerator implements Generator
                 } elseif ($statement instanceof ResourceStatement) {
                     $fqcn = config('blueprint.namespace').'\\Http\\Resources\\'.($controller->namespace() ? $controller->namespace().'\\' : '').$statement->name();
 
-                    $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return \\'.$fqcn, $method);
-
                     $import = $fqcn;
+
                     if (!$statement->collection()) {
-                        $import .= ' as '.$statement->name().'Resource';
+                        $fqcn = $statement->name().'Resource';
+                        $import .= ' as '.$fqcn;
+                    } else {
+                        $fqcn = "\\{$fqcn}";
                     }
+
+                    $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return '.$fqcn, $method);
 
                     $this->addImport($controller, $import);
 

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -42,7 +42,7 @@ class ResourceGenerator implements Generator
                         continue;
                     }
 
-                    $path = $this->getPath($statement->name());
+                    $path = $this->getPath(($controller->namespace() ? $controller->namespace().'/' : '').$statement->name());
 
                     if ($this->files->exists($path)) {
                         continue;
@@ -52,7 +52,7 @@ class ResourceGenerator implements Generator
                         $this->files->makeDirectory(dirname($path), 0755, true);
                     }
 
-                    $this->files->put($path, $this->populateStub($stub, $statement));
+                    $this->files->put($path, $this->populateStub($stub, $controller, $statement));
 
                     $output['created'][] = $path;
                 }
@@ -72,9 +72,13 @@ class ResourceGenerator implements Generator
         return Blueprint::appPath().'/Http/Resources/'.$name.'.php';
     }
 
-    protected function populateStub(string $stub, ResourceStatement $resource)
+    protected function populateStub(string $stub, Controller $controller, ResourceStatement $resource)
     {
-        $stub = str_replace('{{ namespace }}', config('blueprint.namespace').'\\Http\\Resources', $stub);
+        $namespace = config('blueprint.namespace')
+            .'\\Http\\Resources'
+            .($controller->namespace() ? '\\'.$controller->namespace() : '');
+
+        $stub = str_replace('{{ namespace }}', $namespace, $stub);
         $stub = str_replace('{{ import }}', $resource->collection() ? 'Illuminate\\Http\\Resources\\Json\\ResourceCollection' : 'Illuminate\\Http\\Resources\\Json\\JsonResource', $stub);
         $stub = str_replace('{{ parentClass }}', $resource->collection() ? 'ResourceCollection' : 'JsonResource', $stub);
         $stub = str_replace('{{ class }}', $resource->name(), $stub);

--- a/tests/Feature/Generator/ControllerGeneratorTest.php
+++ b/tests/Feature/Generator/ControllerGeneratorTest.php
@@ -175,6 +175,7 @@ class ControllerGeneratorTest extends TestCase
             ['drafts/respond-statements.yaml', 'app/Http/Controllers/Api/PostController.php', 'controllers/respond-statements.php'],
             ['drafts/resource-statements.yaml', 'app/Http/Controllers/UserController.php', 'controllers/resource-statements.php'],
             ['drafts/save-without-validation.yaml', 'app/Http/Controllers/PostController.php', 'controllers/save-without-validation.php'],
+            ['drafts/api-routes-example.yaml', 'app/Http/Controllers/Api/CertificateController.php', 'controllers/api-routes-example.php'],
         ];
     }
 }

--- a/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
@@ -100,4 +100,40 @@ class ResourceGeneratorTest extends TestCase
 
         $this->assertEquals(['created' => ['app/Http/Resources/UserCollection.php', 'app/Http/Resources/User.php']], $this->subject->output($tree));
     }
+
+    /**
+     * @test
+     */
+    public function output_writes_namespaced_classes()
+    {
+        $this->files->expects('stub')
+            ->with('resource.stub')
+            ->andReturn(file_get_contents('stubs/resource.stub'));
+
+        $this->files->shouldReceive('exists')
+            ->with('app/Http/Resources/Api')
+            ->andReturns(false, true);
+        $this->files->expects('makeDirectory')
+            ->with('app/Http/Resources/Api', 0755, true);
+
+        $this->files->expects('exists')
+            ->times(3)
+            ->with('app/Http/Resources/Api/Certificate.php')
+            ->andReturns(false, true, true);
+        $this->files->expects('put')
+            ->with('app/Http/Resources/Api/Certificate.php', $this->fixture('resources/certificate.php'));
+
+        $this->files->expects('exists')
+            ->with('app/Http/Resources/Api/CertificateCollection.php')
+            ->andReturns(false);
+        $this->files->expects('put')
+            ->with('app/Http/Resources/Api/CertificateCollection.php', $this->fixture('resources/certificate-collection.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals([
+            'created' => ['app/Http/Resources/Api/CertificateCollection.php', 'app/Http/Resources/Api/Certificate.php'],
+        ], $this->subject->output($tree));
+    }
 }

--- a/tests/fixtures/controllers/api-routes-example.php
+++ b/tests/fixtures/controllers/api-routes-example.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Certificate;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\CertificateStoreRequest;
+use App\Http\Requests\Api\CertificateUpdateRequest;
+use App\Http\Resources\Api\Certificate as CertificateResource;
+use App\Http\Resources\Api\CertificateCollection;
+use Illuminate\Http\Request;
+
+class CertificateController extends Controller
+{
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \App\Http\Resources\Api\CertificateCollection
+     */
+    public function index(Request $request)
+    {
+        $certificates = Certificate::all();
+
+        return new CertificateCollection($certificates);
+    }
+
+    /**
+     * @param \App\Http\Requests\Api\CertificateStoreRequest $request
+     * @return \App\Http\Resources\Api\Certificate
+     */
+    public function store(CertificateStoreRequest $request)
+    {
+        $certificate = Certificate::create($request->validated());
+
+        return new CertificateResource($certificate);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Certificate $certificate
+     * @return \App\Http\Resources\Api\Certificate
+     */
+    public function show(Request $request, Certificate $certificate)
+    {
+        return new CertificateResource($certificate);
+    }
+
+    /**
+     * @param \App\Http\Requests\Api\CertificateUpdateRequest $request
+     * @param \App\Certificate $certificate
+     * @return \App\Http\Resources\Api\Certificate
+     */
+    public function update(CertificateUpdateRequest $request, Certificate $certificate)
+    {
+        $certificate->update($request->validated());
+
+        return new CertificateResource($certificate);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Certificate $certificate
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Request $request, Certificate $certificate)
+    {
+        $certificate->delete();
+
+        return response()->noContent(200);
+    }
+}

--- a/tests/fixtures/controllers/api-routes-example.php
+++ b/tests/fixtures/controllers/api-routes-example.php
@@ -25,7 +25,7 @@ class CertificateController extends Controller
 
     /**
      * @param \App\Http\Requests\Api\CertificateStoreRequest $request
-     * @return \App\Http\Resources\Api\Certificate
+     * @return CertificateResource
      */
     public function store(CertificateStoreRequest $request)
     {
@@ -37,7 +37,7 @@ class CertificateController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Api\Certificate
+     * @return CertificateResource
      */
     public function show(Request $request, Certificate $certificate)
     {
@@ -47,7 +47,7 @@ class CertificateController extends Controller
     /**
      * @param \App\Http\Requests\Api\CertificateUpdateRequest $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Api\Certificate
+     * @return CertificateResource
      */
     public function update(CertificateUpdateRequest $request, Certificate $certificate)
     {

--- a/tests/fixtures/controllers/certificate-controller.php
+++ b/tests/fixtures/controllers/certificate-controller.php
@@ -24,7 +24,7 @@ class CertificateController extends Controller
 
     /**
      * @param \App\Http\Requests\CertificateStoreRequest $request
-     * @return \App\Http\Resources\Certificate
+     * @return CertificateResource
      */
     public function store(CertificateStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class CertificateController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Certificate
+     * @return CertificateResource
      */
     public function show(Request $request, Certificate $certificate)
     {
@@ -46,7 +46,7 @@ class CertificateController extends Controller
     /**
      * @param \App\Http\Requests\CertificateUpdateRequest $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Certificate
+     * @return CertificateResource
      */
     public function update(CertificateUpdateRequest $request, Certificate $certificate)
     {

--- a/tests/fixtures/controllers/certificate-type-controller.php
+++ b/tests/fixtures/controllers/certificate-type-controller.php
@@ -24,7 +24,7 @@ class CertificateTypeController extends Controller
 
     /**
      * @param \App\Http\Requests\CertificateTypeStoreRequest $request
-     * @return \App\Http\Resources\CertificateType
+     * @return CertificateTypeResource
      */
     public function store(CertificateTypeStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class CertificateTypeController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\CertificateType $certificateType
-     * @return \App\Http\Resources\CertificateType
+     * @return CertificateTypeResource
      */
     public function show(Request $request, CertificateType $certificateType)
     {
@@ -46,7 +46,7 @@ class CertificateTypeController extends Controller
     /**
      * @param \App\Http\Requests\CertificateTypeUpdateRequest $request
      * @param \App\CertificateType $certificateType
-     * @return \App\Http\Resources\CertificateType
+     * @return CertificateTypeResource
      */
     public function update(CertificateTypeUpdateRequest $request, CertificateType $certificateType)
     {

--- a/tests/fixtures/controllers/custom-models-namespace.php
+++ b/tests/fixtures/controllers/custom-models-namespace.php
@@ -24,7 +24,7 @@ class TagController extends Controller
 
     /**
      * @param \App\Http\Requests\TagStoreRequest $request
-     * @return \App\Http\Resources\Tag
+     * @return TagResource
      */
     public function store(TagStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class TagController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Models\Tag $tag
-     * @return \App\Http\Resources\Tag
+     * @return TagResource
      */
     public function show(Request $request, Tag $tag)
     {
@@ -46,7 +46,7 @@ class TagController extends Controller
     /**
      * @param \App\Http\Requests\TagUpdateRequest $request
      * @param \App\Models\Tag $tag
-     * @return \App\Http\Resources\Tag
+     * @return TagResource
      */
     public function update(TagUpdateRequest $request, Tag $tag)
     {

--- a/tests/fixtures/controllers/resource-statements.php
+++ b/tests/fixtures/controllers/resource-statements.php
@@ -20,7 +20,7 @@ class UserController extends Controller
 
     /**
      * @param \Illuminate\Http\Request $request
-     * @return \App\Http\Resources\User
+     * @return UserResource
      */
     public function store(Request $request)
     {
@@ -30,7 +30,7 @@ class UserController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\User $user
-     * @return \App\Http\Resources\User
+     * @return UserResource
      */
     public function show(Request $request, User $user)
     {

--- a/tests/fixtures/drafts/api-routes-example.yaml
+++ b/tests/fixtures/drafts/api-routes-example.yaml
@@ -8,5 +8,5 @@ models:
     remarks: text nullable
 
 controllers:
-  Certificate:
+  Api/Certificate:
     resource: api

--- a/tests/fixtures/resources/certificate-collection.php
+++ b/tests/fixtures/resources/certificate-collection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class CertificateCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'data' => $this->collection,
+        ];
+    }
+}

--- a/tests/fixtures/resources/certificate.php
+++ b/tests/fixtures/resources/certificate.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Certificate extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'certificate_type_id' => $this->certificate_type_id,
+            'reference' => $this->reference,
+            'document' => $this->document,
+            'expiry_date' => $this->expiry_date,
+            'remarks' => $this->remarks,
+        ];
+    }
+}

--- a/tests/fixtures/routes/api-routes.php
+++ b/tests/fixtures/routes/api-routes.php
@@ -1,3 +1,3 @@
 
 
-Route::apiResource('certificate', 'CertificateController');
+Route::apiResource('certificate', 'Api\CertificateController');


### PR DESCRIPTION
That way resources do not need to be imported twice: via FQCN and inline import.

(Github will rebase automatically once #330 gets merged)