### PR TITLE
Stubs helper

### DIFF
--- a/tests/Feature/Generator/ControllerGeneratorTest.php
+++ b/tests/Feature/Generator/ControllerGeneratorTest.php
@@ -40,7 +40,7 @@ class ControllerGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('controller.class.stub')
-            ->andReturn(file_get_contents('stubs/controller.class.stub'));
+            ->andReturn($this->stub('controller.class.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -55,10 +55,10 @@ class ControllerGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('controller.class.stub')
-            ->andReturn(file_get_contents('stubs/controller.class.stub'));
+            ->andReturn($this->stub('controller.class.stub'));
         $this->files->expects('stub')
             ->with('controller.method.stub')
-            ->andReturn(file_get_contents('stubs/controller.method.stub'));
+            ->andReturn($this->stub('controller.method.stub'));
 
         $this->files->expects('exists')
             ->with(dirname($path))
@@ -84,10 +84,10 @@ class ControllerGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('controller.class.stub')
-            ->andReturn(file_get_contents('stubs/controller.class.stub'));
+            ->andReturn($this->stub('controller.class.stub'));
         $this->files->expects('stub')
             ->with('controller.method.stub')
-            ->andReturn(file_get_contents('stubs/controller.method.stub'));
+            ->andReturn($this->stub('controller.method.stub'));
 
         $this->files->expects('exists')
             ->with(dirname($path))
@@ -108,10 +108,10 @@ class ControllerGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('controller.class.stub')
-            ->andReturn(file_get_contents('stubs/controller.class.stub'));
+            ->andReturn($this->stub('controller.class.stub'));
         $this->files->expects('stub')
             ->with('controller.method.stub')
-            ->andReturn(file_get_contents('stubs/controller.method.stub'))
+            ->andReturn($this->stub('controller.method.stub'))
             ->twice();
 
         $certificateController = 'app/Http/Controllers/CertificateController.php';
@@ -145,10 +145,10 @@ class ControllerGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('controller.class.stub')
-            ->andReturn(file_get_contents('stubs/controller.class.stub'));
+            ->andReturn($this->stub('controller.class.stub'));
         $this->files->expects('stub')
             ->with('controller.method.stub')
-            ->andReturn(file_get_contents('stubs/controller.method.stub'));
+            ->andReturn($this->stub('controller.method.stub'));
 
         $this->files->expects('exists')
             ->with('src/path/Other/Http')

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -38,7 +38,7 @@ class FactoryGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('factory.stub')
-            ->andReturn(file_get_contents('stubs/factory.stub'));
+            ->andReturn($this->stub('factory.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -53,7 +53,7 @@ class FactoryGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('factory.stub')
-            ->andReturn(file_get_contents('stubs/factory.stub'));
+            ->andReturn($this->stub('factory.stub'));
 
         $this->files->expects('exists')
             ->with('database/factories')
@@ -77,7 +77,7 @@ class FactoryGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('factory.stub')
-            ->andReturn(file_get_contents('stubs/factory.stub'));
+            ->andReturn($this->stub('factory.stub'));
 
         $this->files->expects('exists')
             ->with('database/factories')
@@ -102,7 +102,7 @@ class FactoryGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('factory.stub')
-            ->andReturn(file_get_contents('stubs/factory.stub'));
+            ->andReturn($this->stub('factory.stub'));
 
         $this->files->expects('exists')
             ->with('database/factories')
@@ -124,7 +124,7 @@ class FactoryGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('factory.stub')
-            ->andReturn(file_get_contents('stubs/factory.stub'));
+            ->andReturn($this->stub('factory.stub'));
 
         $this->files->expects('exists')
             ->with('database/factories/Admin')

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -41,7 +41,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -56,7 +56,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -84,7 +84,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $yday = Carbon::yesterday();
 
@@ -116,7 +116,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -141,7 +141,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -175,7 +175,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -202,7 +202,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -235,7 +235,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -260,7 +260,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -288,7 +288,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $yday = Carbon::yesterday();
 
@@ -330,7 +330,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -361,7 +361,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -398,7 +398,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -426,7 +426,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -463,7 +463,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -494,7 +494,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -528,7 +528,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -558,7 +558,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -592,7 +592,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -618,7 +618,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -650,7 +650,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -676,7 +676,7 @@ class MigrationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);
@@ -713,7 +713,7 @@ class MigrationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('migration.stub')
-            ->andReturn(file_get_contents('stubs/migration.stub'));
+            ->andReturn($this->stub('migration.stub'));
 
         $now = Carbon::now();
         Carbon::setTestNow($now);

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -80,7 +80,6 @@ class ModelGeneratorTest extends TestCase
             ->with('model.method.comment.stub')
             ->andReturn($this->stub('model.method.comment.stub'));
 
-
         $this->files->expects('exists')
             ->with(dirname($path))
             ->andReturnTrue();
@@ -267,7 +266,7 @@ class ModelGeneratorTest extends TestCase
             ->with('model.casts.stub')
             ->andReturn($this->stub('model.casts.stub'));
 
-      $this->files->expects('stub')
+        $this->files->expects('stub')
             ->with('model.method.stub')
             ->andReturn($this->stub('model.method.stub'));
 

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -35,7 +35,7 @@ class ModelGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -50,35 +50,35 @@ class ModelGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
 
         $this->files->expects('stub')
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'));
+            ->andReturn($this->stub('model.fillable.stub'));
 
         if (in_array($definition, ['drafts/nested-components.yaml','drafts/resource-statements.yaml'])) {
             $this->files->expects('stub')
                 ->with('model.hidden.stub')
-                ->andReturn(file_get_contents('stubs/model.hidden.stub'));
+                ->andReturn($this->stub('model.hidden.stub'));
         }
 
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
 
         if ($definition === 'drafts/readme-example.yaml') {
             $this->files->expects('stub')
                 ->with('model.dates.stub')
-                ->andReturn(file_get_contents('stubs/model.dates.stub'));
+                ->andReturn($this->stub('model.dates.stub'));
         }
 
         $this->files->shouldReceive('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
 
         $this->files->shouldReceive('stub')
             ->with('model.method.comment.stub')
-            ->andReturn(file_get_contents('stubs/model.method.comment.stub'));
+            ->andReturn($this->stub('model.method.comment.stub'));
 
 
         $this->files->expects('exists')
@@ -100,18 +100,18 @@ class ModelGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'))
+            ->andReturn($this->stub('model.fillable.stub'))
             ->twice();
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'))
+            ->andReturn($this->stub('model.casts.stub'))
             ->twice();
         $this->files->expects('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'))
+            ->andReturn($this->stub('model.method.stub'))
             ->twice();
 
         $certificateModel = 'app/Certificate.php';
@@ -142,16 +142,16 @@ class ModelGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'));
+            ->andReturn($this->stub('model.fillable.stub'));
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
         $this->files->expects('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
 
         $this->files->expects('exists')
             ->with('app')
@@ -172,19 +172,19 @@ class ModelGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
         $this->files->expects('stub')
             ->times(3)
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'));
+            ->andReturn($this->stub('model.fillable.stub'));
         $this->files->expects('stub')
             ->times(3)
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
         $this->files->expects('stub')
             ->times(3)
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
 
         $this->files->expects('exists')
             ->with('app')
@@ -217,19 +217,19 @@ class ModelGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
         $this->files->expects('stub')
             ->with('model.timestamps.stub')
-            ->andReturn(file_get_contents('stubs/model.timestamps.stub'));
+            ->andReturn($this->stub('model.timestamps.stub'));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'));
+            ->andReturn($this->stub('model.fillable.stub'));
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
         $this->files->expects('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
 
         $this->files->expects('exists')
             ->with('app')
@@ -254,19 +254,19 @@ class ModelGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
 
         $this->files->expects('stub')
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'));
+            ->andReturn($this->stub('model.fillable.stub'));
 
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
 
         $this->files->expects('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
 
         $this->files->expects('exists')
             ->with('src/path/Models')
@@ -292,35 +292,35 @@ class ModelGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
 
         if ($definition === 'drafts/disable-auto-columns.yaml') {
             $this->files->expects('stub')
                 ->with('model.timestamps.stub')
-                ->andReturn(file_get_contents('stubs/model.timestamps.stub'));
+                ->andReturn($this->stub('model.timestamps.stub'));
         }
 
         $this->files->expects('stub')
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'));
+            ->andReturn($this->stub('model.fillable.stub'));
 
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
 
         if ($definition === 'drafts/readme-example.yaml') {
             $this->files->expects('stub')
                 ->with('model.dates.stub')
-                ->andReturn(file_get_contents('stubs/model.dates.stub'));
+                ->andReturn($this->stub('model.dates.stub'));
         }
 
         $this->files->shouldReceive('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
 
         $this->files->shouldReceive('stub')
             ->with('model.method.comment.stub')
-            ->andReturn(file_get_contents('stubs/model.method.comment.stub'));
+            ->andReturn($this->stub('model.method.comment.stub'));
 
         $this->files->expects('exists')
             ->with(dirname($path))
@@ -344,19 +344,19 @@ class ModelGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
 
         $this->files->expects('stub')
             ->with('model.guarded.stub')
-            ->andReturn(file_get_contents('stubs/model.guarded.stub'));
+            ->andReturn($this->stub('model.guarded.stub'));
 
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
 
         $this->files->shouldReceive('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
 
         $this->files->expects('exists')
             ->with(dirname('app/Comment.php'))
@@ -384,16 +384,16 @@ class ModelGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'));
+            ->andReturn($this->stub('model.fillable.stub'));
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
         $this->files->expects('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
 
         $this->files->expects('exists')
             ->with('app/Models')
@@ -414,19 +414,19 @@ class ModelGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('model.class.stub')
-            ->andReturn(file_get_contents('stubs/model.class.stub'));
+            ->andReturn($this->stub('model.class.stub'));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
-            ->andReturn(file_get_contents('stubs/model.fillable.stub'));
+            ->andReturn($this->stub('model.fillable.stub'));
         $this->files->expects('stub')
             ->with('model.casts.stub')
-            ->andReturn(file_get_contents('stubs/model.casts.stub'));
+            ->andReturn($this->stub('model.casts.stub'));
         $this->files->expects('stub')
             ->with('model.method.stub')
-            ->andReturn(file_get_contents('stubs/model.method.stub'));
+            ->andReturn($this->stub('model.method.stub'));
         $this->files->expects('stub')
             ->with('model.hidden.stub')
-            ->andReturn(file_get_contents('stubs/model.hidden.stub'));
+            ->andReturn($this->stub('model.hidden.stub'));
 
         $this->files->expects('exists')
             ->with('app')

--- a/tests/Feature/Generator/SeederGeneratorTest.php
+++ b/tests/Feature/Generator/SeederGeneratorTest.php
@@ -56,7 +56,7 @@ class SeederGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('seeder.stub')
-            ->andReturn(file_get_contents('stubs/seeder.stub'));
+            ->andReturn($this->stub('seeder.stub'));
 
         $this->files->expects('put')
             ->with('database/seeds/PostSeeder.php', $this->fixture('seeders/PostSeeder.php'));
@@ -76,7 +76,7 @@ class SeederGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('seeder.stub')
-            ->andReturn(file_get_contents('stubs/seeder.stub'));
+            ->andReturn($this->stub('seeder.stub'));
 
         $this->files->expects('put')
             ->with('database/seeds/PostSeeder.php', $this->fixture('seeders/PostSeeder.php'));

--- a/tests/Feature/Generator/Statements/EventGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/EventGeneratorTest.php
@@ -39,7 +39,7 @@ class EventGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('event.stub')
-            ->andReturn(file_get_contents('stubs/event.stub'));
+            ->andReturn($this->stub('event.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -53,7 +53,7 @@ class EventGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('event.stub')
-            ->andReturn(file_get_contents('stubs/event.stub'));
+            ->andReturn($this->stub('event.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -70,11 +70,11 @@ class EventGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('event.stub')
-            ->andReturn(file_get_contents('stubs/event.stub'));
+            ->andReturn($this->stub('event.stub'));
 
         $this->files->expects('stub')
             ->with('constructor.stub')
-            ->andReturn(file_get_contents('stubs/constructor.stub'));
+            ->andReturn($this->stub('constructor.stub'));
 
         $this->files->shouldReceive('exists')
             ->twice()
@@ -107,7 +107,7 @@ class EventGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('event.stub')
-            ->andReturn(file_get_contents('stubs/event.stub'));
+            ->andReturn($this->stub('event.stub'));
 
         $this->files->expects('exists')
             ->with('app/Events/UserCreated.php')
@@ -132,7 +132,7 @@ class EventGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('event.stub')
-            ->andReturn(file_get_contents('stubs/event.stub'));
+            ->andReturn($this->stub('event.stub'));
 
         $this->files->expects('exists')
             ->with('src/path/Events')

--- a/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
@@ -40,7 +40,7 @@ class FormRequestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('request.stub')
-            ->andReturn(file_get_contents('stubs/request.stub'));
+            ->andReturn($this->stub('request.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -54,7 +54,7 @@ class FormRequestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('request.stub')
-            ->andReturn(file_get_contents('stubs/request.stub'));
+            ->andReturn($this->stub('request.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -71,7 +71,7 @@ class FormRequestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('request.stub')
-            ->andReturn(file_get_contents('stubs/request.stub'));
+            ->andReturn($this->stub('request.stub'));
 
         $this->files->shouldReceive('exists')
             ->times(3)
@@ -110,7 +110,7 @@ class FormRequestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('request.stub')
-            ->andReturn(file_get_contents('stubs/request.stub'));
+            ->andReturn($this->stub('request.stub'));
 
         $this->files->shouldReceive('exists')
             ->twice()
@@ -147,7 +147,7 @@ class FormRequestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('request.stub')
-            ->andReturn(file_get_contents('stubs/request.stub'));
+            ->andReturn($this->stub('request.stub'));
 
         $this->files->expects('exists')
             ->with('app/Http/Requests/PostIndexRequest.php')
@@ -172,7 +172,7 @@ class FormRequestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('request.stub')
-            ->andReturn(file_get_contents('stubs/request.stub'));
+            ->andReturn($this->stub('request.stub'));
 
         $this->files->expects('exists')
             ->with('app/Http/Requests/Admin')
@@ -201,7 +201,7 @@ class FormRequestGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('request.stub')
-            ->andReturn(file_get_contents('stubs/request.stub'));
+            ->andReturn($this->stub('request.stub'));
 
         $this->files->expects('exists')
             ->with('src/path/Http/Requests')
@@ -227,7 +227,7 @@ class FormRequestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('request.stub')
-            ->andReturn(file_get_contents('stubs/request.stub'));
+            ->andReturn($this->stub('request.stub'));
 
         $this->files->expects('exists')
             ->with('app/Http/Requests')

--- a/tests/Feature/Generator/Statements/JobGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/JobGeneratorTest.php
@@ -39,7 +39,7 @@ class JobGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('job.stub')
-            ->andReturn(file_get_contents('stubs/job.stub'));
+            ->andReturn($this->stub('job.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -53,7 +53,7 @@ class JobGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('job.stub')
-            ->andReturn(file_get_contents('stubs/job.stub'));
+            ->andReturn($this->stub('job.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -70,11 +70,11 @@ class JobGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('job.stub')
-            ->andReturn(file_get_contents('stubs/job.stub'));
+            ->andReturn($this->stub('job.stub'));
 
         $this->files->expects('stub')
             ->with('constructor.stub')
-            ->andReturn(file_get_contents('stubs/constructor.stub'));
+            ->andReturn($this->stub('constructor.stub'));
 
         $this->files->shouldReceive('exists')
             ->twice()
@@ -107,7 +107,7 @@ class JobGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('job.stub')
-            ->andReturn(file_get_contents('stubs/job.stub'));
+            ->andReturn($this->stub('job.stub'));
 
         $this->files->expects('exists')
             ->with('app/Jobs/CreateUser.php')
@@ -132,7 +132,7 @@ class JobGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('job.stub')
-            ->andReturn(file_get_contents('stubs/job.stub'));
+            ->andReturn($this->stub('job.stub'));
 
         $this->files->expects('exists')
             ->with('src/path/Jobs')

--- a/tests/Feature/Generator/Statements/MailGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/MailGeneratorTest.php
@@ -39,7 +39,7 @@ class MailGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('mail.stub')
-            ->andReturn(file_get_contents('stubs/mail.stub'));
+            ->andReturn($this->stub('mail.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -53,7 +53,7 @@ class MailGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('mail.stub')
-            ->andReturn(file_get_contents('stubs/mail.stub'));
+            ->andReturn($this->stub('mail.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -70,11 +70,11 @@ class MailGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('mail.stub')
-            ->andReturn(file_get_contents('stubs/mail.stub'));
+            ->andReturn($this->stub('mail.stub'));
 
         $this->files->expects('stub')
             ->with('constructor.stub')
-            ->andReturn(file_get_contents('stubs/constructor.stub'));
+            ->andReturn($this->stub('constructor.stub'));
 
         $this->files->shouldReceive('exists')
             ->twice()
@@ -107,7 +107,7 @@ class MailGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('mail.stub')
-            ->andReturn(file_get_contents('stubs/mail.stub'));
+            ->andReturn($this->stub('mail.stub'));
 
         $this->files->expects('exists')
             ->with('app/Mail/ReviewPost.php')
@@ -132,7 +132,7 @@ class MailGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('mail.stub')
-            ->andReturn(file_get_contents('stubs/mail.stub'));
+            ->andReturn($this->stub('mail.stub'));
 
         $this->files->expects('exists')
             ->with('src/path/Mail')

--- a/tests/Feature/Generator/Statements/NotificationGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/NotificationGeneratorTest.php
@@ -39,7 +39,7 @@ class NotificationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('notification.stub')
-            ->andReturn(file_get_contents('stubs/notification.stub'));
+            ->andReturn($this->stub('notification.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -53,7 +53,7 @@ class NotificationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('notification.stub')
-            ->andReturn(file_get_contents('stubs/notification.stub'));
+            ->andReturn($this->stub('notification.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -71,12 +71,12 @@ class NotificationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('notification.stub')
-            ->andReturn(file_get_contents('stubs/notification.stub'));
+            ->andReturn($this->stub('notification.stub'));
 
         if ($draft === 'drafts/send-statements-notification-facade.yaml') {
             $this->files->expects('stub')
                 ->with('constructor.stub')
-                ->andReturn(file_get_contents('stubs/constructor.stub'));
+                ->andReturn($this->stub('constructor.stub'));
         }
 
         $this->files->shouldReceive('exists')
@@ -110,7 +110,7 @@ class NotificationGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('notification.stub')
-            ->andReturn(file_get_contents('stubs/notification.stub'));
+            ->andReturn($this->stub('notification.stub'));
 
         $this->files->expects('exists')
             ->with('app/Notification/ReviewPostNotification.php')
@@ -135,7 +135,7 @@ class NotificationGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('notification.stub')
-            ->andReturn(file_get_contents('stubs/notification.stub'));
+            ->andReturn($this->stub('notification.stub'));
 
         $this->files->expects('exists')
             ->with('src/path/Notification')

--- a/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
@@ -40,7 +40,7 @@ class ResourceGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('resource.stub')
-            ->andReturn(file_get_contents('stubs/resource.stub'));
+            ->andReturn($this->stub('resource.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -54,7 +54,7 @@ class ResourceGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('resource.stub')
-            ->andReturn(file_get_contents('stubs/resource.stub'));
+            ->andReturn($this->stub('resource.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -69,7 +69,7 @@ class ResourceGeneratorTest extends TestCase
      */
     public function output_writes_resources_for_render_statements()
     {
-        $template = file_get_contents('stubs/resource.stub');
+        $template = $this->stub('resource.stub');
         $this->files->expects('stub')
             ->with('resource.stub')
             ->andReturn($template);

--- a/tests/Feature/Generator/Statements/ViewGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ViewGeneratorTest.php
@@ -39,7 +39,7 @@ class ViewGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('view.stub')
-            ->andReturn(file_get_contents('stubs/view.stub'));
+            ->andReturn($this->stub('view.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -53,7 +53,7 @@ class ViewGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('view.stub')
-            ->andReturn(file_get_contents('stubs/view.stub'));
+            ->andReturn($this->stub('view.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -68,7 +68,7 @@ class ViewGeneratorTest extends TestCase
      */
     public function output_writes_views_for_render_statements()
     {
-        $template = file_get_contents('stubs/view.stub');
+        $template = $this->stub('view.stub');
         $this->files->expects('stub')
             ->with('view.stub')
             ->andReturn($template);
@@ -113,7 +113,7 @@ class ViewGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('view.stub')
-            ->andReturn(file_get_contents('stubs/view.stub'));
+            ->andReturn($this->stub('view.stub'));
 
         $this->files->expects('exists')
             ->with('resources/views/user/index.blade.php')

--- a/tests/Feature/Generator/TestGeneratorTest.php
+++ b/tests/Feature/Generator/TestGeneratorTest.php
@@ -40,7 +40,7 @@ class TestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('test.class.stub')
-            ->andReturn(file_get_contents('stubs/test.class.stub'));
+            ->andReturn($this->stub('test.class.stub'));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -55,11 +55,11 @@ class TestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('test.class.stub')
-            ->andReturn(file_get_contents('stubs/test.class.stub'));
+            ->andReturn($this->stub('test.class.stub'));
 
         $this->files->expects('stub')
             ->with('test.case.stub')
-            ->andReturn(file_get_contents('stubs/test.case.stub'));
+            ->andReturn($this->stub('test.case.stub'));
         $dirname = dirname($path);
         $this->files->expects('exists')
             ->with($dirname)
@@ -82,11 +82,11 @@ class TestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('test.class.stub')
-            ->andReturn(file_get_contents('stubs/test.class.stub'));
+            ->andReturn($this->stub('test.class.stub'));
 
         $this->files->expects('stub')
             ->with('test.case.stub')
-            ->andReturn(file_get_contents('stubs/test.case.stub'));
+            ->andReturn($this->stub('test.case.stub'));
 
         $certificateControllerTest = 'tests/Feature/Http/Controllers/CertificateControllerTest.php';
         $certificateTypeControllerTest = 'tests/Feature/Http/Controllers/CertificateTypeControllerTest.php';
@@ -115,11 +115,11 @@ class TestGeneratorTest extends TestCase
     {
         $this->files->expects('stub')
             ->with('test.class.stub')
-            ->andReturn(file_get_contents('stubs/test.class.stub'));
+            ->andReturn($this->stub('test.class.stub'));
 
         $this->files->expects('stub')
             ->with('test.case.stub')
-            ->andReturn(file_get_contents('stubs/test.case.stub'));
+            ->andReturn($this->stub('test.case.stub'));
         $this->files->expects('exists')
             ->with('tests/Feature/Http/Controllers')
             ->andReturnFalse();
@@ -153,11 +153,11 @@ class TestGeneratorTest extends TestCase
 
         $this->files->expects('stub')
             ->with('test.class.stub')
-            ->andReturn(file_get_contents('stubs/test.class.stub'));
+            ->andReturn($this->stub('test.class.stub'));
 
         $this->files->expects('stub')
             ->with('test.case.stub')
-            ->andReturn(file_get_contents('stubs/test.case.stub'));
+            ->andReturn($this->stub('test.case.stub'));
         $dirname = dirname($path);
         $this->files->expects('exists')
             ->with($dirname)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
         return file_get_contents(__DIR__ . '/' . 'fixtures' . '/' . ltrim($path, '/'));
     }
 
+    public function stub(string $path)
+    {
+        return file_get_contents(__DIR__ . '/../' . 'stubs' . '/' . ltrim($path, '/'));
+    }
+
     protected function getPackageProviders($app)
     {
         return [


### PR DESCRIPTION
The old stubs reference prevents me from running the test case directly in PHPStorm alone because it references a relative directory.

I add a new helper to `TestCase` to make it easier to reference stubs in test cases and modify the old tests to use it.