### PR TITLE
Support namespaced Resources + suffix name

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -139,20 +139,8 @@ class ControllerGenerator implements Generator
                     $body .= self::INDENT.$statement->output().PHP_EOL;
                 } elseif ($statement instanceof ResourceStatement) {
                     $fqcn = config('blueprint.namespace').'\\Http\\Resources\\'.($controller->namespace() ? $controller->namespace().'\\' : '').$statement->name();
-
-                    $import = $fqcn;
-
-                    if (!$statement->collection()) {
-                        $fqcn = $statement->name().'Resource';
-                        $import .= ' as '.$fqcn;
-                    } else {
-                        $fqcn = "\\{$fqcn}";
-                    }
-
-                    $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return '.$fqcn, $method);
-
-                    $this->addImport($controller, $import);
-
+                    $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return \\'.$fqcn, $method);
+                    $this->addImport($controller, $fqcn);
                     $body .= self::INDENT.$statement->output().PHP_EOL;
                 } elseif ($statement instanceof RedirectStatement) {
                     $body .= self::INDENT.$statement->output().PHP_EOL;

--- a/src/Models/Statements/ResourceStatement.php
+++ b/src/Models/Statements/ResourceStatement.php
@@ -31,10 +31,10 @@ class ResourceStatement
     public function name(): string
     {
         if ($this->collection()) {
-            return  Str::studly(Str::singular($this->reference)) . 'Collection';
+            return Str::studly(Str::singular($this->reference)) . 'Collection';
         }
 
-        return  Str::studly(Str::singular($this->reference));
+        return Str::studly(Str::singular($this->reference)) . 'Resource';
     }
 
     public function reference(): string
@@ -55,11 +55,6 @@ class ResourceStatement
     public function output(): string
     {
         $code = 'return new ' . $this->name();
-
-        if (!$this->collection()) {
-            $code .= 'Resource';
-        }
-
         $code .= '($' . $this->reference();
 
         if ($this->paginate()) {

--- a/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
@@ -83,10 +83,10 @@ class ResourceGeneratorTest extends TestCase
 
         $this->files->expects('exists')
             ->twice()
-            ->with('app/Http/Resources/User.php')
+            ->with('app/Http/Resources/UserResource.php')
             ->andReturns(false, true);
         $this->files->expects('put')
-            ->with('app/Http/Resources/User.php', $this->fixture('resources/user.php'));
+            ->with('app/Http/Resources/UserResource.php', $this->fixture('resources/user.php'));
 
         $this->files->expects('exists')
             ->twice()
@@ -98,7 +98,7 @@ class ResourceGeneratorTest extends TestCase
         $tokens = $this->blueprint->parse($this->fixture('drafts/resource-statements.yaml'));
         $tree = $this->blueprint->analyze($tokens);
 
-        $this->assertEquals(['created' => ['app/Http/Resources/UserCollection.php', 'app/Http/Resources/User.php']], $this->subject->output($tree));
+        $this->assertEquals(['created' => ['app/Http/Resources/UserCollection.php', 'app/Http/Resources/UserResource.php']], $this->subject->output($tree));
     }
 
     /**
@@ -118,10 +118,10 @@ class ResourceGeneratorTest extends TestCase
 
         $this->files->expects('exists')
             ->times(3)
-            ->with('app/Http/Resources/Api/Certificate.php')
+            ->with('app/Http/Resources/Api/CertificateResource.php')
             ->andReturns(false, true, true);
         $this->files->expects('put')
-            ->with('app/Http/Resources/Api/Certificate.php', $this->fixture('resources/certificate.php'));
+            ->with('app/Http/Resources/Api/CertificateResource.php', $this->fixture('resources/certificate.php'));
 
         $this->files->expects('exists')
             ->with('app/Http/Resources/Api/CertificateCollection.php')
@@ -133,7 +133,7 @@ class ResourceGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals([
-            'created' => ['app/Http/Resources/Api/CertificateCollection.php', 'app/Http/Resources/Api/Certificate.php'],
+            'created' => ['app/Http/Resources/Api/CertificateCollection.php', 'app/Http/Resources/Api/CertificateResource.php'],
         ], $this->subject->output($tree));
     }
 }

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -663,7 +663,7 @@ class StatementLexerTest extends TestCase
         $this->assertCount(1, $actual);
         $this->assertInstanceOf(ResourceStatement::class, $actual[0]);
 
-        $this->assertEquals('User', $actual[0]->name());
+        $this->assertEquals('UserResource', $actual[0]->name());
         $this->assertEquals('user', $actual[0]->reference());
         $this->assertFalse($actual[0]->collection());
         $this->assertFalse($actual[0]->paginate());

--- a/tests/fixtures/controllers/api-routes-example.php
+++ b/tests/fixtures/controllers/api-routes-example.php
@@ -6,8 +6,8 @@ use App\Certificate;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\CertificateStoreRequest;
 use App\Http\Requests\Api\CertificateUpdateRequest;
-use App\Http\Resources\Api\Certificate as CertificateResource;
 use App\Http\Resources\Api\CertificateCollection;
+use App\Http\Resources\Api\CertificateResource;
 use Illuminate\Http\Request;
 
 class CertificateController extends Controller
@@ -25,7 +25,7 @@ class CertificateController extends Controller
 
     /**
      * @param \App\Http\Requests\Api\CertificateStoreRequest $request
-     * @return \App\Http\Resources\Api\Certificate
+     * @return \App\Http\Resources\Api\CertificateResource
      */
     public function store(CertificateStoreRequest $request)
     {
@@ -37,7 +37,7 @@ class CertificateController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Api\Certificate
+     * @return \App\Http\Resources\Api\CertificateResource
      */
     public function show(Request $request, Certificate $certificate)
     {
@@ -47,7 +47,7 @@ class CertificateController extends Controller
     /**
      * @param \App\Http\Requests\Api\CertificateUpdateRequest $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Api\Certificate
+     * @return \App\Http\Resources\Api\CertificateResource
      */
     public function update(CertificateUpdateRequest $request, Certificate $certificate)
     {

--- a/tests/fixtures/controllers/certificate-controller.php
+++ b/tests/fixtures/controllers/certificate-controller.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers;
 use App\Certificate;
 use App\Http\Requests\CertificateStoreRequest;
 use App\Http\Requests\CertificateUpdateRequest;
-use App\Http\Resources\Certificate as CertificateResource;
 use App\Http\Resources\CertificateCollection;
+use App\Http\Resources\CertificateResource;
 use Illuminate\Http\Request;
 
 class CertificateController extends Controller
@@ -24,7 +24,7 @@ class CertificateController extends Controller
 
     /**
      * @param \App\Http\Requests\CertificateStoreRequest $request
-     * @return CertificateResource
+     * @return \App\Http\Resources\CertificateResource
      */
     public function store(CertificateStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class CertificateController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Certificate $certificate
-     * @return CertificateResource
+     * @return \App\Http\Resources\CertificateResource
      */
     public function show(Request $request, Certificate $certificate)
     {
@@ -46,7 +46,7 @@ class CertificateController extends Controller
     /**
      * @param \App\Http\Requests\CertificateUpdateRequest $request
      * @param \App\Certificate $certificate
-     * @return CertificateResource
+     * @return \App\Http\Resources\CertificateResource
      */
     public function update(CertificateUpdateRequest $request, Certificate $certificate)
     {

--- a/tests/fixtures/controllers/certificate-type-controller.php
+++ b/tests/fixtures/controllers/certificate-type-controller.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers;
 use App\CertificateType;
 use App\Http\Requests\CertificateTypeStoreRequest;
 use App\Http\Requests\CertificateTypeUpdateRequest;
-use App\Http\Resources\CertificateType as CertificateTypeResource;
 use App\Http\Resources\CertificateTypeCollection;
+use App\Http\Resources\CertificateTypeResource;
 use Illuminate\Http\Request;
 
 class CertificateTypeController extends Controller
@@ -24,7 +24,7 @@ class CertificateTypeController extends Controller
 
     /**
      * @param \App\Http\Requests\CertificateTypeStoreRequest $request
-     * @return CertificateTypeResource
+     * @return \App\Http\Resources\CertificateTypeResource
      */
     public function store(CertificateTypeStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class CertificateTypeController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\CertificateType $certificateType
-     * @return CertificateTypeResource
+     * @return \App\Http\Resources\CertificateTypeResource
      */
     public function show(Request $request, CertificateType $certificateType)
     {
@@ -46,7 +46,7 @@ class CertificateTypeController extends Controller
     /**
      * @param \App\Http\Requests\CertificateTypeUpdateRequest $request
      * @param \App\CertificateType $certificateType
-     * @return CertificateTypeResource
+     * @return \App\Http\Resources\CertificateTypeResource
      */
     public function update(CertificateTypeUpdateRequest $request, CertificateType $certificateType)
     {

--- a/tests/fixtures/controllers/custom-models-namespace.php
+++ b/tests/fixtures/controllers/custom-models-namespace.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\TagStoreRequest;
 use App\Http\Requests\TagUpdateRequest;
-use App\Http\Resources\Tag as TagResource;
 use App\Http\Resources\TagCollection;
+use App\Http\Resources\TagResource;
 use App\Models\Tag;
 use Illuminate\Http\Request;
 
@@ -24,7 +24,7 @@ class TagController extends Controller
 
     /**
      * @param \App\Http\Requests\TagStoreRequest $request
-     * @return TagResource
+     * @return \App\Http\Resources\TagResource
      */
     public function store(TagStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class TagController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Models\Tag $tag
-     * @return TagResource
+     * @return \App\Http\Resources\TagResource
      */
     public function show(Request $request, Tag $tag)
     {
@@ -46,7 +46,7 @@ class TagController extends Controller
     /**
      * @param \App\Http\Requests\TagUpdateRequest $request
      * @param \App\Models\Tag $tag
-     * @return TagResource
+     * @return \App\Http\Resources\TagResource
      */
     public function update(TagUpdateRequest $request, Tag $tag)
     {

--- a/tests/fixtures/controllers/resource-statements.php
+++ b/tests/fixtures/controllers/resource-statements.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Resources\User as UserResource;
 use App\Http\Resources\UserCollection;
+use App\Http\Resources\UserResource;
 use App\User;
 use Illuminate\Http\Request;
 
@@ -20,7 +20,7 @@ class UserController extends Controller
 
     /**
      * @param \Illuminate\Http\Request $request
-     * @return UserResource
+     * @return \App\Http\Resources\UserResource
      */
     public function store(Request $request)
     {
@@ -30,7 +30,7 @@ class UserController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\User $user
-     * @return UserResource
+     * @return \App\Http\Resources\UserResource
      */
     public function show(Request $request, User $user)
     {

--- a/tests/fixtures/resources/certificate.php
+++ b/tests/fixtures/resources/certificate.php
@@ -4,7 +4,7 @@ namespace App\Http\Resources\Api;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class Certificate extends JsonResource
+class CertificateResource extends JsonResource
 {
     /**
      * Transform the resource into an array.

--- a/tests/fixtures/resources/user.php
+++ b/tests/fixtures/resources/user.php
@@ -4,7 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class User extends JsonResource
+class UserResource extends JsonResource
 {
     /**
      * Transform the resource into an array.


### PR DESCRIPTION
This fixes an issue when using namespaced resources. In addition, to avoid aliasing imports and being consistent with other naming conventions within Laravel, Blueprint now suffixes the singular resource as well.

For example, `Http\Resources\User` is now `Http\Resources\UserResource`.

---
Supersedes #332 