### PR TITLE
Small fix for handling id/bigIncrements column with custom names when generating migrations

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -127,6 +127,9 @@ class MigrationGenerator implements Generator
             $column_definition = self::INDENT;
             if ($dataType === 'bigIncrements' && $this->isLaravel7orNewer()) {
                 $column_definition .= '$table->id(';
+                if ($column->name() !== 'id') {
+                    $column_definition .= "'{$column->name()}'";
+                }
             } elseif ($dataType === 'rememberToken') {
                 $column_definition .= '$table->rememberToken(';
             } else {

--- a/tests/fixtures/drafts/model-identities.yaml
+++ b/tests/fixtures/drafts/model-identities.yaml
@@ -2,4 +2,5 @@ models:
   Relationship:
     post_id: id
     another: id
+    big_increments_custom_name: bigIncrements
     timestamps: false

--- a/tests/fixtures/migrations/identity-columns-big-increments.php
+++ b/tests/fixtures/migrations/identity-columns-big-increments.php
@@ -17,6 +17,7 @@ class CreateRelationshipsTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('post_id');
             $table->unsignedBigInteger('another');
+            $table->bigIncrements('big_increments_custom_name');
         });
     }
 

--- a/tests/fixtures/migrations/identity-columns.php
+++ b/tests/fixtures/migrations/identity-columns.php
@@ -17,6 +17,7 @@ class CreateRelationshipsTable extends Migration
             $table->id();
             $table->unsignedBigInteger('post_id');
             $table->unsignedBigInteger('another');
+            $table->id('big_increments_custom_name');
         });
     }
 


### PR DESCRIPTION
For a draft file:
```
  Model:
    custom_column_name: bigIncrements
```

Generated Migrations:
 **Before** 
`$table->id();`

 **After** 
`$table->id('custom_column_name');`

Admittedly not something that's often used