### PR TITLE
Generate migration columns with comments

### DIFF
--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -207,7 +207,7 @@ class ModelLexer implements Lexer
         $data_type = null;
         $modifiers = [];
 
-        $tokens = preg_split('#("|\').*?("|\')(*SKIP)(*FAIL)|\s+#', $definition);
+        $tokens = preg_split('#("|\').*?\1(*SKIP)(*FAIL)|\s+#', $definition);
         foreach ($tokens as $token) {
             $parts = explode(':', $token);
             $value = $parts[0];

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -95,6 +95,7 @@ class ModelLexer implements Lexer
         'primary' => 'primary',
         'foreign' => 'foreign',
         'ondelete' => 'onDelete',
+        'comment' => 'comment',
     ];
 
     public function analyze(array $tokens): array
@@ -206,7 +207,7 @@ class ModelLexer implements Lexer
         $data_type = null;
         $modifiers = [];
 
-        $tokens = preg_split('#".*?"(*SKIP)(*FAIL)|\s+#', $definition);
+        $tokens = preg_split('#("|\').*?("|\')(*SKIP)(*FAIL)|\s+#', $definition);
         foreach ($tokens as $token) {
             $parts = explode(':', $token);
             $value = $parts[0];

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -754,6 +754,7 @@ class MigrationGeneratorTest extends TestCase
             ['drafts/unconventional-foreign-key.yaml', 'database/migrations/timestamp_create_states_table.php', 'migrations/unconventional-foreign-key.php'],
             ['drafts/resource-statements.yaml', 'database/migrations/timestamp_create_users_table.php', 'migrations/resource-statements.php'],
             ['drafts/enum-options.yaml', 'database/migrations/timestamp_create_messages_table.php', 'migrations/enum-options.php'],
+            ['drafts/columns-with-comments.yaml', 'database/migrations/timestamp_create_professions_table.php', 'migrations/columns-with-comments.php'],
         ];
     }
 }

--- a/tests/fixtures/drafts/columns-with-comments.yaml
+++ b/tests/fixtures/drafts/columns-with-comments.yaml
@@ -1,0 +1,4 @@
+models:
+  Profession:
+    title: string:400 comment:"Some title for the profession"
+    description: string:400 nullable comment:'Some description for the profession'

--- a/tests/fixtures/migrations/columns-with-comments.php
+++ b/tests/fixtures/migrations/columns-with-comments.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProfessionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('professions', function (Blueprint $table) {
+            $table->id();
+            $table->string('title', 400)->comment("Some title for the profession");
+            $table->string('description', 400)->nullable()->comment('Some description for the profession');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('professions');
+    }
+}


### PR DESCRIPTION
- single-quote and double-quote string accepted.

closes #344 