### PR TITLE
feat: generate composite indexes for migrations

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -37,6 +37,8 @@ class Blueprint
             $content = preg_replace('/^(\s*)-\s*/m', '\1', $content);
         }
 
+        $content = preg_replace('/\s*,\s*/', ',', $content);
+
         $content = preg_replace_callback('/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)$/mi', function ($matches) {
             return $matches[1].strtolower($matches[2]).': '.$matches[2];
         }, $content);

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -11,6 +11,12 @@ use Illuminate\Support\Str;
 
 class MigrationGenerator implements Generator
 {
+    const COMPOSITE_INDEXES = [
+        '_index',
+        '_primary',
+        '_unique',
+    ];
+
     const INDENT = '            ';
 
     const NULLABLE_TYPES = [
@@ -129,11 +135,13 @@ class MigrationGenerator implements Generator
                 $column_definition .= '$table->id(';
             } elseif ($dataType === 'rememberToken') {
                 $column_definition .= '$table->rememberToken(';
+            } elseif (in_array(mb_strtolower($column->name()), self::COMPOSITE_INDEXES)) {
+                $column_definition .= '$table->'.$dataType."(['".implode("', '", $column->attributes())."']";
             } else {
                 $column_definition .= '$table->'.$dataType."('{$column->name()}'";
             }
 
-            if (! empty($column->attributes()) && ! in_array($column->dataType(), ['id', 'uuid'])) {
+            if (! empty($column->attributes()) && ! in_array($column->dataType(), ['id', 'uuid']) && ! in_array($column->name(), self::COMPOSITE_INDEXES)) {
                 $column_definition .= ', ';
                 if (in_array($column->dataType(), ['set', 'enum'])) {
                     $column_definition .= json_encode($column->attributes());

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -136,7 +136,11 @@ class MigrationGenerator implements Generator
             } elseif ($dataType === 'rememberToken') {
                 $column_definition .= '$table->rememberToken(';
             } elseif (in_array(mb_strtolower($column->name()), self::COMPOSITE_INDEXES)) {
-                $column_definition .= '$table->'.$dataType."(['".implode("', '", $column->attributes())."']";
+                $column_definition = [];
+                foreach ($column->attributes() as $attributes) {
+                    $column_definition[] = self::INDENT.'$table->'.$dataType."(['".implode("', '", $attributes)."']);";
+                }
+                $column_definition =  implode(PHP_EOL, $column_definition).PHP_EOL;
             } else {
                 $column_definition .= '$table->'.$dataType."('{$column->name()}'";
             }
@@ -149,7 +153,9 @@ class MigrationGenerator implements Generator
                     $column_definition .= implode(', ', $column->attributes());
                 }
             }
-            $column_definition .= ')';
+            if (!in_array(mb_strtolower($column->name()), self::COMPOSITE_INDEXES)) {
+                $column_definition .= ')';
+            }
 
             $modifiers = $column->modifiers();
 
@@ -191,7 +197,9 @@ class MigrationGenerator implements Generator
                 }
             }
 
-            $column_definition .= ';'.PHP_EOL;
+            if (!in_array(mb_strtolower($column->name()), self::COMPOSITE_INDEXES)) {
+                $column_definition .= ';'.PHP_EOL;
+            }
             if (! empty($foreign)) {
                 $column_definition .= $foreign.';'.PHP_EOL;
             }

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -226,7 +226,10 @@ class ModelLexer implements Lexer
             }
             if (isset(self::$compositeIndexes[strtolower($name)])) {
                 $data_type = self::$compositeIndexes[strtolower($name)];
-                $attributes = explode(',', $value);
+                $attributes = [];
+                foreach (explode(' ', $definition) as $attribute) {
+                    $attributes[] = explode(',', $attribute);
+                }
             }
             if (isset(self::$dataTypes[strtolower($value)])) {
                 $attributes = $parts[1] ?? null;

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -98,6 +98,12 @@ class ModelLexer implements Lexer
         'comment' => 'comment',
     ];
 
+    private static $compositeIndexes = [
+        '_index' => 'index',
+        '_primary' => 'primary',
+        '_unique' => 'unique',
+    ];
+
     public function analyze(array $tokens): array
     {
         $registry = [
@@ -217,7 +223,12 @@ class ModelLexer implements Lexer
                 if (isset($parts[1])) {
                     $attributes = [$parts[1]];
                 }
-            } elseif (isset(self::$dataTypes[strtolower($value)])) {
+            }
+            if (isset(self::$compositeIndexes[strtolower($name)])) {
+                $data_type = self::$compositeIndexes[strtolower($name)];
+                $attributes = explode(',', $value);
+            }
+            if (isset(self::$dataTypes[strtolower($value)])) {
                 $attributes = $parts[1] ?? null;
                 $data_type = self::$dataTypes[strtolower($value)];
                 if (!empty($attributes)) {

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -64,7 +64,7 @@ class BlueprintTest extends TestCase
                     'user_id' => 'id',
                 ],
             ],
-            'seeders' => 'Post, Comment',
+            'seeders' => 'Post,Comment',
         ], $this->subject->parse($blueprint));
     }
 
@@ -219,7 +219,7 @@ class BlueprintTest extends TestCase
                         'render' => 'post.index with:posts',
                     ],
                     'store' => [
-                        'validate' => 'title, content, author_id',
+                        'validate' => 'title,content,author_id',
                         'save' => 'post',
                         'send' => 'ReviewPost to:post.author.email with:post',
                         'dispatch' => 'SyncMedia with:post',
@@ -262,7 +262,7 @@ class BlueprintTest extends TestCase
                         'render' => 'post.index with:posts',
                     ],
                     'store' => [
-                        'validate' => 'title, content, author_id',
+                        'validate' => 'title,content,author_id',
                         'save' => 'post',
                         'send' => 'ReviewPost to:post.author.email with:post',
                         'dispatch' => 'SyncMedia with:post',
@@ -299,7 +299,7 @@ class BlueprintTest extends TestCase
                         'render' => 'post.index with:posts',
                     ],
                     'store' => [
-                        'validate' => 'title, content',
+                        'validate' => 'title,content',
                         'save' => 'post',
                         'redirect' => 'post.index',
                     ],

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -755,6 +755,7 @@ class MigrationGeneratorTest extends TestCase
             ['drafts/resource-statements.yaml', 'database/migrations/timestamp_create_users_table.php', 'migrations/resource-statements.php'],
             ['drafts/enum-options.yaml', 'database/migrations/timestamp_create_messages_table.php', 'migrations/enum-options.php'],
             ['drafts/columns-with-comments.yaml', 'database/migrations/timestamp_create_professions_table.php', 'migrations/columns-with-comments.php'],
+            ['drafts/migration-with-composite-indexes.yaml', 'database/migrations/timestamp_create_participations_table.php', 'migrations/migration-with-composite-indexes.php'],
         ];
     }
 }

--- a/tests/fixtures/drafts/migration-with-composite-indexes.yaml
+++ b/tests/fixtures/drafts/migration-with-composite-indexes.yaml
@@ -3,6 +3,6 @@ models:
     project_id: bigInteger
     user_id: bigInteger
     name: string
-    _unique: project_id,user_id
+    _unique: project_id,user_id team_id,project_id
     _index: project_id,user_id
     _primary: project_id,user_id

--- a/tests/fixtures/drafts/migration-with-composite-indexes.yaml
+++ b/tests/fixtures/drafts/migration-with-composite-indexes.yaml
@@ -3,6 +3,6 @@ models:
     project_id: bigInteger
     user_id: bigInteger
     name: string
-    _unique: project_id,user_id team_id,project_id
-    _index: project_id,user_id
-    _primary: project_id,user_id
+    _unique: project_id, user_id team_id,project_id
+    _index: project_id, user_id
+    _primary: project_id, user_id

--- a/tests/fixtures/drafts/migration-with-composite-indexes.yaml
+++ b/tests/fixtures/drafts/migration-with-composite-indexes.yaml
@@ -1,0 +1,8 @@
+models:
+  Participation:
+    project_id: bigInteger
+    user_id: bigInteger
+    name: string
+    _unique: project_id,user_id
+    _index: project_id,user_id
+    _primary: project_id,user_id

--- a/tests/fixtures/migrations/migration-with-composite-indexes.php
+++ b/tests/fixtures/migrations/migration-with-composite-indexes.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateParticipationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('participations', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('project_id');
+            $table->bigInteger('user_id');
+            $table->string('name');
+            $table->unique(['project_id', 'user_id']);
+            $table->index(['project_id', 'user_id']);
+            $table->primary(['project_id', 'user_id']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('participations');
+    }
+}

--- a/tests/fixtures/migrations/migration-with-composite-indexes.php
+++ b/tests/fixtures/migrations/migration-with-composite-indexes.php
@@ -19,6 +19,7 @@ class CreateParticipationsTable extends Migration
             $table->bigInteger('user_id');
             $table->string('name');
             $table->unique(['project_id', 'user_id']);
+            $table->unique(['team_id', 'project_id']);
             $table->index(['project_id', 'user_id']);
             $table->primary(['project_id', 'user_id']);
             $table->timestamps();


### PR DESCRIPTION
- add composite indexes `_unique`, `_index`, `_primary` (prefixed with `_` to avoid possibly overwriting table names). 
- support multiple definitions of each type with space (` `) between.
- resolves #271 

**draft.yml**
```yaml
models:
  Participation:
    project_id: bigInteger
    team_id: bigInteger
    user_id: bigInteger
    name: string
    _unique: project_id,user_id team_id,project_id
    _index: project_id,user_id
    _primary: project_id,user_id
```
**Output:**
```php
Schema::create('participations', function (Blueprint $table) {
    $table->id();
    $table->bigInteger('project_id');
    $table->bigInteger('team_id');
    $table->bigInteger('user_id');
    $table->string('name');
    $table->unique(['project_id', 'user_id']);
    $table->unique(['team_id', 'project_id']);
    $table->index(['project_id', 'user_id']);
    $table->primary(['project_id', 'user_id']);
    $table->timestamps();
});
```