### PR TITLE
Add support for generating indexes (including composite indexes) in migrations

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -29,8 +29,8 @@ class Blueprint
         return str_replace('\\', '/', config('blueprint.app_path'));
     }
 
-    public function parse($content, $strip_dashes = true)
-    {
+    public function parse($content, $strip_dashes = false)
+    {   
         $content = str_replace(["\r\n", "\r"], "\n", $content);
 
         if ($strip_dashes) {

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -200,6 +200,17 @@ class MigrationGenerator implements Generator
             $definition .= self::INDENT.sprintf('$table->string(\'%s\');', Str::lower($model->morphTo().'_type')).PHP_EOL;
         }
 
+        foreach ($model->indexes() as $index) {
+            $index_definition = self::INDENT;
+            $index_definition .= '$table->'.$index->type();
+            if (count($index->columnNames()) > 1 ) {
+                $index_definition .= "(['".implode("', '", $index->columnNames())."']);".PHP_EOL;
+            }
+            else {
+                $index_definition .= "('{$index->columnNames()[0]}');".PHP_EOL;
+            }
+            $definition .= $index_definition; 
+        }
         if ($model->usesTimestamps()) {
             $definition .= self::INDENT.'$table->'.$model->timestampsDataType().'();'.PHP_EOL;
         }

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -4,6 +4,7 @@ namespace Blueprint\Lexers;
 
 use Blueprint\Contracts\Lexer;
 use Blueprint\Models\Column;
+use Blueprint\Models\Index;
 use Blueprint\Models\Model;
 use Illuminate\Support\Str;
 
@@ -163,6 +164,13 @@ class ModelLexer implements Lexer
             }
 
             unset($columns['relationships']);
+        }
+
+        if (isset($columns['indexes'])) {
+            foreach ($columns['indexes'] as $index) {
+                $model->addIndex(new Index(key($index), array_map('trim', explode(',', current($index)))));
+            }
+            unset($columns['indexes']);
         }
 
         if (!isset($columns['id']) && $model->usesPrimaryKey()) {

--- a/src/Models/Index.php
+++ b/src/Models/Index.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Blueprint\Models;
+
+class Index
+{
+    private $type;
+    private $columnNames;
+
+    public function __construct(string $type, array $columnNames = [])
+    {
+        $this->type = $type;
+        $this->columnNames = $columnNames;
+    }
+
+    public function type()
+    {
+        return $this->type;
+    }
+
+    public function columnNames()
+    {
+        return $this->columnNames;
+    }
+}

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -15,6 +15,7 @@ class Model
     private $columns = [];
     private $relationships = [];
     private $pivotTables = [];
+    private $indexes = [];
 
     /**
      * @param $name
@@ -157,6 +158,16 @@ class Model
         $segments = [$this->name(), $reference];
         sort($segments);
         $this->pivotTables[] = $segments;
+    }
+
+    public function indexes(): array
+    {
+        return $this->indexes;
+    }
+    
+    public function addIndex(Index $index)
+    {
+        $this->indexes[] = $index;
     }
 
     public function pivotTables(): array

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -281,38 +281,6 @@ class BlueprintTest extends TestCase
     /**
      * @test
      */
-    public function it_parses_yaml_with_dashed_syntax()
-    {
-        $definition = $this->fixture('drafts/readme-example-dashes.yaml');
-
-        $expected = [
-            'models' => [
-                'Post' => [
-                    'title' => 'string:400',
-                    'content' => 'longtext',
-                ],
-            ],
-            'controllers' => [
-                'Post' => [
-                    'index' => [
-                        'query' => 'all:posts',
-                        'render' => 'post.index with:posts',
-                    ],
-                    'store' => [
-                        'validate' => 'title, content',
-                        'save' => 'post',
-                        'redirect' => 'post.index',
-                    ],
-                ],
-            ],
-        ];
-
-        $this->assertEquals($expected, $this->subject->parse($definition));
-    }
-
-    /**
-     * @test
-     */
     public function it_allows_parsing_without_stripping_dashes()
     {
         $sequence = [

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -746,6 +746,7 @@ class MigrationGeneratorTest extends TestCase
             ['drafts/soft-deletes.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/soft-deletes.php'],
             ['drafts/with-timezones.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/with-timezones.php'],
             ['drafts/relationships.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/relationships.php'],
+            ['drafts/indexes.yaml', 'database/migrations/timestamp_create_posts_table.php', 'migrations/indexes.php'],
             ['drafts/unconventional.yaml', 'database/migrations/timestamp_create_teams_table.php', 'migrations/unconventional.php'],
             ['drafts/optimize.yaml', 'database/migrations/timestamp_create_optimizes_table.php', 'migrations/optimize.php'],
             ['drafts/model-key-constraints.yaml', 'database/migrations/timestamp_create_orders_table.php', 'migrations/model-key-constraints.php'],

--- a/tests/fixtures/drafts/indexes.yaml
+++ b/tests/fixtures/drafts/indexes.yaml
@@ -1,0 +1,16 @@
+models:
+  Post:
+    id: unsignedInteger
+    title: string
+    parent_post_id: id
+    author_id: id
+    published_at: timestamp nullable
+    word_count: integer unsigned
+    location: geometry
+    indexes:
+      - primary: id
+      - index: author_id
+      - index: author_id, published_at
+      - unique: title
+      - unique: title, parent_post_id
+      - spatialIndex: location

--- a/tests/fixtures/migrations/indexes.php
+++ b/tests/fixtures/migrations/indexes.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->unsignedInteger('id');
+            $table->string('title');
+            $table->unsignedBigInteger('parent_post_id');
+            $table->unsignedBigInteger('author_id');
+            $table->timestamp('published_at')->nullable();
+            $table->unsignedInteger('word_count');
+            $table->geometry('location');
+            $table->primary('id');
+            $table->index('author_id');
+            $table->index(['author_id', 'published_at']);
+            $table->unique('title');
+            $table->unique(['title', 'parent_post_id']);
+            $table->spatialIndex('location');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}


### PR DESCRIPTION
For: https://github.com/laravel-shift/blueprint/issues/271

Unfortunately, the syntax proposed here will require using array within the YAML draft file, which would be incompatible with: https://github.com/laravel-shift/blueprint/pull/260 

Opening this for a discussion, not sure what would be the best way forward to be honest