### PR TITLE
test: Aliasing method names for an Eloquent relationship

### DIFF
--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -453,6 +453,7 @@ class ModelGeneratorTest extends TestCase
             ['drafts/nested-components.yaml', 'app/Admin/User.php', 'models/nested-components.php'],
             ['drafts/resource-statements.yaml', 'app/User.php', 'models/resource-statements.php'],
             ['drafts/all-column-types.yaml', 'app/AllType.php', 'models/all-column-types.php'],
+            ['drafts/alias-relationships.yaml', 'app/Salesman.php', 'models/alias-relationships.php'],
         ];
     }
 

--- a/tests/fixtures/drafts/alias-relationships.yaml
+++ b/tests/fixtures/drafts/alias-relationships.yaml
@@ -1,0 +1,7 @@
+models:
+  Salesman:
+    name: string
+    relationships:
+      hasOne: User:Lead
+      hasMany: class_name:method_name
+      belongsTo: class_name:method_name

--- a/tests/fixtures/models/alias-relationships.php
+++ b/tests/fixtures/models/alias-relationships.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Salesman extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+
+
+    public function lead()
+    {
+        return $this->hasOne(\App\User::class);
+    }
+
+    public function methodNames()
+    {
+        return $this->hasMany(\App\ClassName::class);
+    }
+
+    public function methodName()
+    {
+        return $this->belongsTo(\App\ClassName::class);
+    }
+}


### PR DESCRIPTION
- Testing the syntax `{belongsTo|hasOne|hasMany}: {class_name}:{method_name}` is supported, to "alias" relationships .
- Resolve #294 

**draft.yaml:**
```yaml
models:
  Salesman:
    name: string
    relationships:
      hasOne: User:Lead
      hasMany: class_name:method_name
      belongsTo: class_name:method_name
```
**Output:**
```php
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;

class Salesman extends Model
{
    /**
     * The attributes that are mass assignable.
     *
     * @var array
     */
    protected $fillable = [
        'name',
    ];

    /**
     * The attributes that should be cast to native types.
     *
     * @var array
     */
    protected $casts = [
        'id' => 'integer',
    ];


    public function lead()
    {
        return $this->hasOne(\App\User::class);
    }

    public function methodNames()
    {
        return $this->hasMany(\App\ClassName::class);
    }

    public function methodName()
    {
        return $this->belongsTo(\App\ClassName::class);
    }
}
```