### PR TITLE
Toggle foreign key constraints for Migrations

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -37,6 +37,8 @@ class MigrationGenerator implements Generator
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     private $files;
 
+    private $hasForeignKeyConstraints = false;
+
     public function __construct($files)
     {
         $this->files = $files;
@@ -90,6 +92,10 @@ class MigrationGenerator implements Generator
         $stub = str_replace('{{ table }}', $model->tableName(), $stub);
         $stub = str_replace('{{ definition }}', $this->buildDefinition($model), $stub);
 
+        if ($this->hasForeignKeyConstraints) {
+            $stub = $this->disableForeignKeyConstraints($stub);
+        }
+
         return $stub;
     }
 
@@ -98,6 +104,10 @@ class MigrationGenerator implements Generator
         $stub = str_replace('{{ class }}', $this->getPivotClassName($segments), $stub);
         $stub = str_replace('{{ table }}', $this->getPivotTableName($segments), $stub);
         $stub = str_replace('{{ definition }}', $this->buildPivotTableDefinition($segments), $stub);
+
+        if ($this->hasForeignKeyConstraints) {
+            $stub = $this->disableForeignKeyConstraints($stub);
+        }
 
         return $stub;
     }
@@ -149,6 +159,7 @@ class MigrationGenerator implements Generator
             $foreign_modifier = $column->isForeignKey();
 
             if ($this->shouldAddForeignKeyConstraint($column)) {
+                $this->hasForeignKeyConstraints = true;
                 $foreign = $this->buildForeignKey(
                     $column->name(),
                     $foreign_modifier === 'foreign' ? null : $foreign_modifier,
@@ -232,6 +243,7 @@ class MigrationGenerator implements Generator
             }
 
             if (config('blueprint.use_constraints')) {
+                $this->hasForeignKeyConstraints = true;
                 $definition .= $this->buildForeignKey($foreign, $on, 'id').';'.PHP_EOL;
             } elseif ($this->isLaravel7orNewer()) {
                 $definition .= self::INDENT.'$table->foreignId(\''.$foreign.'\');'.PHP_EOL;
@@ -281,6 +293,23 @@ class MigrationGenerator implements Generator
         }
 
         return self::INDENT.'$table->foreign'."('{$column_name}')->references('{$column}')->on('{$table}'){$on_delete_suffix}";
+    }
+
+    protected function disableForeignKeyConstraints($stub): string
+    {
+        $stub = str_replace(
+            'Schema::create(',
+            sprintf("%s\n%s", 'Schema::disableForeignKeyConstraints();', str_pad(' ', 8).'Schema::create('),
+            $stub
+        );
+
+        $stub = str_replace(
+            '});',
+            sprintf("%s\n%s", '});', str_pad(' ', 8).'Schema::enableForeignKeyConstraints();'),
+            $stub
+        );
+
+        return $stub;
     }
 
     protected function getClassName(Model $model)

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -297,17 +297,9 @@ class MigrationGenerator implements Generator
 
     protected function disableForeignKeyConstraints($stub): string
     {
-        $stub = str_replace(
-            'Schema::create(',
-            sprintf("%s\n%s", 'Schema::disableForeignKeyConstraints();', str_pad(' ', 8).'Schema::create('),
-            $stub
-        );
+        $stub = str_replace('Schema::create(', 'Schema::disableForeignKeyConstraints();'.PHP_EOL.str_pad(' ', 8).'Schema::create(', $stub);
 
-        $stub = str_replace(
-            '});',
-            sprintf("%s\n%s", '});', str_pad(' ', 8).'Schema::enableForeignKeyConstraints();'),
-            $stub
-        );
+        $stub = str_replace('});', '});'.PHP_EOL.str_pad(' ', 8).'Schema::enableForeignKeyConstraints();', $stub);
 
         return $stub;
     }

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -297,9 +297,9 @@ class MigrationGenerator implements Generator
 
     protected function disableForeignKeyConstraints($stub): string
     {
-        $stub = str_replace('Schema::create(', 'Schema::disableForeignKeyConstraints();'.PHP_EOL.str_pad(' ', 8).'Schema::create(', $stub);
+        $stub = str_replace('Schema::create(', 'Schema::disableForeignKeyConstraints();'.PHP_EOL.PHP_EOL.str_pad(' ', 8).'Schema::create(', $stub);
 
-        $stub = str_replace('});', '});'.PHP_EOL.str_pad(' ', 8).'Schema::enableForeignKeyConstraints();', $stub);
+        $stub = str_replace('});', '});'.PHP_EOL.PHP_EOL.str_pad(' ', 8).'Schema::enableForeignKeyConstraints();', $stub);
 
         return $stub;
     }

--- a/tests/fixtures/migrations/belongs-to-many-key-constraints-laravel6.php
+++ b/tests/fixtures/migrations/belongs-to-many-key-constraints-laravel6.php
@@ -13,6 +13,7 @@ class CreateJourneysTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('journeys', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
@@ -20,6 +21,7 @@ class CreateJourneysTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/belongs-to-many-key-constraints-laravel6.php
+++ b/tests/fixtures/migrations/belongs-to-many-key-constraints-laravel6.php
@@ -14,6 +14,7 @@ class CreateJourneysTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('journeys', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
@@ -21,6 +22,7 @@ class CreateJourneysTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/belongs-to-many-key-constraints.php
+++ b/tests/fixtures/migrations/belongs-to-many-key-constraints.php
@@ -13,12 +13,14 @@ class CreateJourneysTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('journeys', function (Blueprint $table) {
             $table->id();
             $table->string('name');
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/belongs-to-many-key-constraints.php
+++ b/tests/fixtures/migrations/belongs-to-many-key-constraints.php
@@ -14,12 +14,14 @@ class CreateJourneysTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('journeys', function (Blueprint $table) {
             $table->id();
             $table->string('name');
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/belongs-to-many-pivot-key-constraints-laravel6.php
+++ b/tests/fixtures/migrations/belongs-to-many-pivot-key-constraints-laravel6.php
@@ -13,12 +13,14 @@ class CreateDiaryJourneyTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('diary_journey', function (Blueprint $table) {
             $table->unsignedBigInteger('diary_id');
             $table->foreign('diary_id')->references('id')->on('diaries')->onDelete('cascade');
             $table->unsignedBigInteger('journey_id');
             $table->foreign('journey_id')->references('id')->on('journeys')->onDelete('cascade');
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/belongs-to-many-pivot-key-constraints-laravel6.php
+++ b/tests/fixtures/migrations/belongs-to-many-pivot-key-constraints-laravel6.php
@@ -14,12 +14,14 @@ class CreateDiaryJourneyTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('diary_journey', function (Blueprint $table) {
             $table->unsignedBigInteger('diary_id');
             $table->foreign('diary_id')->references('id')->on('diaries')->onDelete('cascade');
             $table->unsignedBigInteger('journey_id');
             $table->foreign('journey_id')->references('id')->on('journeys')->onDelete('cascade');
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/belongs-to-many-pivot-key-constraints.php
+++ b/tests/fixtures/migrations/belongs-to-many-pivot-key-constraints.php
@@ -13,10 +13,12 @@ class CreateDiaryJourneyTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('diary_journey', function (Blueprint $table) {
             $table->foreignId('diary_id')->constrained()->cascadeOnDelete();
             $table->foreignId('journey_id')->constrained()->cascadeOnDelete();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/belongs-to-many-pivot-key-constraints.php
+++ b/tests/fixtures/migrations/belongs-to-many-pivot-key-constraints.php
@@ -14,10 +14,12 @@ class CreateDiaryJourneyTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('diary_journey', function (Blueprint $table) {
             $table->foreignId('diary_id')->constrained()->cascadeOnDelete();
             $table->foreignId('journey_id')->constrained()->cascadeOnDelete();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/foreign-key-on-delete-laravel6.php
+++ b/tests/fixtures/migrations/foreign-key-on-delete-laravel6.php
@@ -13,6 +13,7 @@ class CreateCommentsTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('site_id');
@@ -25,6 +26,7 @@ class CreateCommentsTable extends Migration
             $table->foreign('approver_id')->references('id')->on('users')->onDelete('no action');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/foreign-key-on-delete-laravel6.php
+++ b/tests/fixtures/migrations/foreign-key-on-delete-laravel6.php
@@ -14,6 +14,7 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('site_id');
@@ -26,6 +27,7 @@ class CreateCommentsTable extends Migration
             $table->foreign('approver_id')->references('id')->on('users')->onDelete('no action');
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/foreign-key-on-delete.php
+++ b/tests/fixtures/migrations/foreign-key-on-delete.php
@@ -13,6 +13,7 @@ class CreateCommentsTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
             $table->foreignId('site_id')->constrained()->cascadeOnDelete();
@@ -21,6 +22,7 @@ class CreateCommentsTable extends Migration
             $table->foreignId('approver_id')->constrained('users')->onDelete('no action');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/foreign-key-on-delete.php
+++ b/tests/fixtures/migrations/foreign-key-on-delete.php
@@ -14,6 +14,7 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
             $table->foreignId('site_id')->constrained()->cascadeOnDelete();
@@ -22,6 +23,7 @@ class CreateCommentsTable extends Migration
             $table->foreignId('approver_id')->constrained('users')->onDelete('no action');
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/foreign-key-shorthand.php
+++ b/tests/fixtures/migrations/foreign-key-shorthand.php
@@ -14,6 +14,7 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
             $table->foreignId('post_id')->constrained()->cascadeOnDelete();
@@ -21,6 +22,7 @@ class CreateCommentsTable extends Migration
             $table->foreignId('ccid')->constrained('countries', 'code')->cascadeOnDelete();
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/foreign-key-shorthand.php
+++ b/tests/fixtures/migrations/foreign-key-shorthand.php
@@ -13,6 +13,7 @@ class CreateCommentsTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
             $table->foreignId('post_id')->constrained()->cascadeOnDelete();
@@ -20,6 +21,7 @@ class CreateCommentsTable extends Migration
             $table->foreignId('ccid')->constrained('countries', 'code')->cascadeOnDelete();
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/model-key-constraints.php
+++ b/tests/fixtures/migrations/model-key-constraints.php
@@ -14,6 +14,7 @@ class CreateOrdersTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('orders', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
@@ -24,6 +25,7 @@ class CreateOrdersTable extends Migration
             $table->json('meta')->default('[]');
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/model-key-constraints.php
+++ b/tests/fixtures/migrations/model-key-constraints.php
@@ -13,6 +13,7 @@ class CreateOrdersTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('orders', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
@@ -23,6 +24,7 @@ class CreateOrdersTable extends Migration
             $table->json('meta')->default('[]');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/nullable-chaining-laravel6.php
+++ b/tests/fixtures/migrations/nullable-chaining-laravel6.php
@@ -13,6 +13,7 @@ class CreateCartsTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('carts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
@@ -20,6 +21,7 @@ class CreateCartsTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/nullable-chaining-laravel6.php
+++ b/tests/fixtures/migrations/nullable-chaining-laravel6.php
@@ -14,6 +14,7 @@ class CreateCartsTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('carts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
@@ -21,6 +22,7 @@ class CreateCartsTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/nullable-chaining.php
+++ b/tests/fixtures/migrations/nullable-chaining.php
@@ -13,12 +13,14 @@ class CreateCartsTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('carts', function (Blueprint $table) {
             $table->id();
             $table->string('name');
             $table->foreignId('user_id')->nullable()->constrained()->onDelete('set null');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/nullable-chaining.php
+++ b/tests/fixtures/migrations/nullable-chaining.php
@@ -14,12 +14,14 @@ class CreateCartsTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('carts', function (Blueprint $table) {
             $table->id();
             $table->string('name');
             $table->foreignId('user_id')->nullable()->constrained()->onDelete('set null');
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/relationships-constraints-laravel6.php
+++ b/tests/fixtures/migrations/relationships-constraints-laravel6.php
@@ -13,6 +13,7 @@ class CreateCommentsTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('post_id');
@@ -21,6 +22,7 @@ class CreateCommentsTable extends Migration
             $table->foreign('author_id')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/relationships-constraints-laravel6.php
+++ b/tests/fixtures/migrations/relationships-constraints-laravel6.php
@@ -14,6 +14,7 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('post_id');
@@ -22,6 +23,7 @@ class CreateCommentsTable extends Migration
             $table->foreign('author_id')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/relationships-constraints.php
+++ b/tests/fixtures/migrations/relationships-constraints.php
@@ -13,12 +13,14 @@ class CreateCommentsTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
             $table->foreignId('post_id')->constrained()->cascadeOnDelete();
             $table->foreignId('author_id')->constrained('users')->cascadeOnDelete();
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/relationships-constraints.php
+++ b/tests/fixtures/migrations/relationships-constraints.php
@@ -14,12 +14,14 @@ class CreateCommentsTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
             $table->foreignId('post_id')->constrained()->cascadeOnDelete();
             $table->foreignId('author_id')->constrained('users')->cascadeOnDelete();
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 

--- a/tests/fixtures/migrations/unconventional-foreign-key.php
+++ b/tests/fixtures/migrations/unconventional-foreign-key.php
@@ -13,6 +13,7 @@ class CreateStatesTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
         Schema::create('states', function (Blueprint $table) {
             $table->id();
             $table->string('name');
@@ -25,6 +26,7 @@ class CreateStatesTable extends Migration
             $table->foreign('c_code')->references('code')->on('countries')->onDelete('cascade');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/tests/fixtures/migrations/unconventional-foreign-key.php
+++ b/tests/fixtures/migrations/unconventional-foreign-key.php
@@ -14,6 +14,7 @@ class CreateStatesTable extends Migration
     public function up()
     {
         Schema::disableForeignKeyConstraints();
+
         Schema::create('states', function (Blueprint $table) {
             $table->id();
             $table->string('name');
@@ -26,6 +27,7 @@ class CreateStatesTable extends Migration
             $table->foreign('c_code')->references('code')->on('countries')->onDelete('cascade');
             $table->timestamps();
         });
+
         Schema::enableForeignKeyConstraints();
     }
 


### PR DESCRIPTION
- generate migrations with the syntax to disable foreign key constraints when referencing another table.
- supports Laravel 6 & 7 foreign key syntax.
- resolve #208 

```php
class CreateStatesTable extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::disableForeignKeyConstraints();
        Schema::create('states', function (Blueprint $table) {
            $table->id();
            $table->string('name');
            $table->foreignId('countries_id')->constrained('countries')->cascadeOnDelete();
            $table->string('country_code');
            $table->foreign('country_code')->references('code')->on('countries')->onDelete('cascade');
        });
        Schema::enableForeignKeyConstraints();
    }
```