### PR TITLE
refactor: cleanup tests

### DIFF
--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -26,9 +26,7 @@ class BlueprintTest extends TestCase
         $this->subject = new Blueprint();
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_models()
     {
         $blueprint = $this->fixture('drafts/models-only.yaml');
@@ -68,9 +66,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->parse($blueprint));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_controllers()
     {
         $blueprint = $this->fixture('drafts/controllers-only.yaml');
@@ -95,9 +91,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->parse($blueprint));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_shorthands()
     {
         $blueprint = $this->fixture('drafts/shorthands.yaml');
@@ -118,9 +112,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->parse($blueprint));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_uuid_shorthand()
     {
         $blueprint = $this->fixture('drafts/uuid-shorthand.yaml');
@@ -135,9 +127,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->parse($blueprint));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_shorthands_with_timezones()
     {
         $blueprint = $this->fixture('drafts/with-timezones.yaml');
@@ -152,9 +142,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->parse($blueprint));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_longhands()
     {
         $blueprint = $this->fixture('drafts/longhands.yaml');
@@ -179,9 +167,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->parse($blueprint));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_resource_shorthands()
     {
         $blueprint = $this->fixture('drafts/with-timezones.yaml');
@@ -196,9 +182,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->parse($blueprint));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_the_readme_example()
     {
         $blueprint = $this->fixture('drafts/readme-example.yaml');
@@ -232,9 +216,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->parse($blueprint));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_the_readme_example_with_different_platform_eols()
     {
         $definition = $this->fixture('drafts/readme-example.yaml');
@@ -278,9 +260,7 @@ class BlueprintTest extends TestCase
         $this->assertEquals($expected, $this->subject->parse($definition_windows_eol));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_parses_yaml_with_dashed_syntax()
     {
         $definition = $this->fixture('drafts/readme-example-dashes.yaml');
@@ -310,9 +290,7 @@ class BlueprintTest extends TestCase
         $this->assertEquals($expected, $this->subject->parse($definition));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_allows_parsing_without_stripping_dashes()
     {
         $sequence = [
@@ -322,9 +300,7 @@ class BlueprintTest extends TestCase
         $this->assertEquals($sequence, $this->subject->parse($this->subject->dump($sequence), false));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_throws_a_custom_error_when_parsing_fails()
     {
         $this->expectException(ParseException::class);
@@ -334,9 +310,7 @@ class BlueprintTest extends TestCase
         $this->subject->parse($blueprint);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function analyze_return_default_tree_for_empty_tokens()
     {
         $tokens = [];
@@ -350,9 +324,7 @@ class BlueprintTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function analyze_uses_register_lexers_to_analyze_tokens()
     {
         $lexer = \Mockery::mock(Lexer::class);
@@ -370,9 +342,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->analyze($tokens)->toArray());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function generate_uses_registered_generators_and_returns_generated_files()
     {
         $generatorOne = \Mockery::mock(Generator::class);
@@ -417,9 +387,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->generate($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function generate_uses_swapped_generator_and_returns_generated_files()
     {
         $generatorOne = \Mockery::mock(Generator::class);
@@ -452,9 +420,7 @@ class BlueprintTest extends TestCase
         ], $this->subject->generate($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function generate_only_one_specific_type()
     {
         $generatorFoo = \Mockery::mock(Generator::class);
@@ -503,9 +469,7 @@ class BlueprintTest extends TestCase
         ], $actual);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function generate_only_specific_types()
     {
         $generatorFoo = \Mockery::mock(Generator::class);
@@ -554,9 +518,7 @@ class BlueprintTest extends TestCase
         ], $actual);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function generate_should_skip_one_specific_type()
     {
         $generatorFoo = \Mockery::mock(Generator::class);
@@ -605,9 +567,7 @@ class BlueprintTest extends TestCase
         ], $actual);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function generate_should_skip_specific_types()
     {
         $generatorFoo = \Mockery::mock(Generator::class);

--- a/tests/Feature/Commands/EraseCommandTest.php
+++ b/tests/Feature/Commands/EraseCommandTest.php
@@ -6,26 +6,28 @@ use Blueprint\Blueprint;
 use Blueprint\Tracer;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
+use Tests\Traits\MocksFilesystem;
 
 /**
  * @covers \Blueprint\Commands\EraseCommand
  */
 class EraseCommandTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
+    use MockeryPHPUnitIntegration, MocksFilesystem;
 
     /** @test */
     public function it_parses_and_update_the_trace_file()
     {
-        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
-        $this->swap('files', $filesystem);
-
-        $filesystem->expects('get')
+        $this->files->expects('get')
             ->with('.blueprint')
             ->andReturn("created: created_file.php \nupdated: updated_file.php \nother: test.php");
 
-        $filesystem->expects('put')
+        $this->files->expects('delete')->with("created_file.php");
+
+        $this->files->expects('put')
             ->with('.blueprint', "other: test.php\n");
+
+        $this->files->expects('exists')->with('app');
 
         $this->artisan('blueprint:erase')
             ->assertExitCode(0);
@@ -34,17 +36,17 @@ class EraseCommandTest extends TestCase
     /** @test */
     public function it_deletes_the_created_files()
     {
-        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
-        $this->swap('files', $filesystem);
-
-        $filesystem->expects('get')
+        $this->files->expects('get')
             ->with('.blueprint')
             ->andReturn("created:\n  -  created_file1.php\n  -  created_file2.php");
 
-        $filesystem->expects('delete')->with([
+        $this->files->expects('delete')->with([
             "created_file1.php",
             "created_file2.php",
         ]);
+
+        $this->files->expects('put')->with('.blueprint', '{  }');
+        $this->files->expects('exists')->with('app');
 
         $this->artisan('blueprint:erase')
             ->assertExitCode(0)
@@ -56,12 +58,12 @@ class EraseCommandTest extends TestCase
     /** @test */
     public function it_notify_about_the_updated_files()
     {
-        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
-        $this->swap('files', $filesystem);
-
-        $filesystem->expects('get')
+        $this->files->expects('get')
             ->with('.blueprint')
             ->andReturn("updated:\n  -  updated_file1.php\n  -  updated_file2.php");
+
+        $this->files->expects('put')->with('.blueprint', '{  }');
+        $this->files->expects('exists')->with('app');
 
         $this->artisan('blueprint:erase')
             ->assertExitCode(0)
@@ -73,11 +75,8 @@ class EraseCommandTest extends TestCase
     /** @test */
     public function it_calls_the_trace_command()
     {
-        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
-        $this->swap('files', $filesystem);
-
-        $filesystem->expects('get')->with('.blueprint')->andReturn("other: test.php");
-        $filesystem->expects('put')->with('.blueprint', "other: test.php\n");
+        $this->files->expects('get')->with('.blueprint')->andReturn("other: test.php");
+        $this->files->expects('put')->with('.blueprint', "other: test.php\n");
 
         $tracer = $this->spy(Tracer::class);
 
@@ -85,6 +84,6 @@ class EraseCommandTest extends TestCase
             ->assertExitCode(0);
 
         $tracer->shouldHaveReceived('execute')
-            ->with(resolve(Blueprint::class), $filesystem);
+            ->with(resolve(Blueprint::class), $this->files);
     }
 }

--- a/tests/Feature/Commands/NewCommandTest.php
+++ b/tests/Feature/Commands/NewCommandTest.php
@@ -4,28 +4,30 @@ namespace Tests\Feature\Commands;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
+use Tests\Traits\MocksFilesystem;
 
 /**
  * @covers \Blueprint\Commands\NewCommand
  */
 class NewCommandTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
+    use MockeryPHPUnitIntegration, MocksFilesystem;
 
-    /** @test */
+    /**
+     * @test
+     */
     public function it_creates_a_draft_file_from_stub_if_none_exists()
     {
-        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
-        $this->swap('files', $filesystem);
-
-        $filesystem->shouldReceive('exists')
+        $this->files->shouldReceive('exists')
             ->with('draft.yaml')
             ->andReturnFalse();
-        $filesystem->shouldReceive('stub')
+        $this->files->shouldReceive('stub')
             ->with('draft.stub')
             ->andReturn('stub');
-        $filesystem->shouldReceive('put')
+        $this->files->shouldReceive('put')
             ->with('draft.yaml', 'stub');
+
+        $this->files->shouldReceive('exists')->with('app');
 
         $this->artisan('blueprint:new')
             ->assertExitCode(0);
@@ -34,13 +36,12 @@ class NewCommandTest extends TestCase
     /** @test */
     public function it_does_not_create_a_draft_file_if_one_exists_already()
     {
-        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
-        $this->swap('files', $filesystem);
-
-        $filesystem->shouldReceive('exists')
+        $this->files->shouldReceive('exists')
             ->with('draft.yaml')
             ->andReturnTrue();
-        $filesystem->shouldNotReceive('put');
+        $this->files->shouldNotReceive('put');
+        $this->files->shouldReceive('exists')
+            ->with('app');
 
         $this->artisan('blueprint:new')
             ->assertExitCode(0);

--- a/tests/Feature/Commands/NewCommandTest.php
+++ b/tests/Feature/Commands/NewCommandTest.php
@@ -13,9 +13,7 @@ class NewCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration, MocksFilesystem;
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_creates_a_draft_file_from_stub_if_none_exists()
     {
         $this->files->shouldReceive('exists')

--- a/tests/Feature/Commands/TraceCommandTest.php
+++ b/tests/Feature/Commands/TraceCommandTest.php
@@ -8,24 +8,22 @@ use Blueprint\Commands\TraceCommand;
 use Blueprint\Tracer;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
+use Tests\Traits\MocksFilesystem;
 
 /**
  * @covers \Blueprint\Commands\TraceCommand
  */
 class TraceCommandTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
+    use MockeryPHPUnitIntegration, MocksFilesystem;
 
     /** @test */
     public function it_shows_error_if_no_model_found()
     {
-        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
-        $this->swap('files', $filesystem);
-
         $tracer = $this->mock(Tracer::class);
 
         $tracer->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $filesystem)
+            ->with(resolve(Blueprint::class), $this->files)
             ->andReturn([]);
 
         $this->artisan('blueprint:trace')
@@ -36,13 +34,10 @@ class TraceCommandTest extends TestCase
     /** @test */
     public function it_shows_the_number_of_traced_models()
     {
-        $filesystem = \Mockery::mock(\Illuminate\Filesystem\Filesystem::class)->makePartial();
-        $this->swap('files', $filesystem);
-
         $tracer = $this->mock(Tracer::class);
 
         $tracer->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $filesystem)
+            ->with(resolve(Blueprint::class), $this->files)
             ->andReturn([
                 "Model" => [],
                 "OtherModel" => [],

--- a/tests/Feature/Generator/ControllerGeneratorTest.php
+++ b/tests/Feature/Generator/ControllerGeneratorTest.php
@@ -33,9 +33,7 @@ class ControllerGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -71,9 +69,7 @@ class ControllerGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_controllers_with_models_with_custom_namespace_correctly()
     {
         $definition = 'drafts/custom-models-namespace.yaml';
@@ -101,9 +97,7 @@ class ControllerGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_works_for_pascal_case_definition()
     {
         $this->files->expects('stub')
@@ -134,9 +128,7 @@ class ControllerGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$certificateController, $certificateTypeController]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_respects_configuration()
     {
         $this->app['config']->set('blueprint.app_path', 'src/path');

--- a/tests/Feature/Generator/FactoryGeneratorTest.php
+++ b/tests/Feature/Generator/FactoryGeneratorTest.php
@@ -31,9 +31,7 @@ class FactoryGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -68,9 +66,7 @@ class FactoryGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_ignores_nullables_if_fake_nullables_configuration_is_set_to_false()
     {
         $this->app['config']->set('blueprint.fake_nullables', false);
@@ -92,9 +88,7 @@ class FactoryGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['database/factories/PostFactory.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_respects_configuration()
     {
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
@@ -117,9 +111,7 @@ class FactoryGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['database/factories/PostFactory.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_creates_directory_for_nested_components()
     {
         $this->files->expects('stub')

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -164,15 +164,10 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_uses_proper_data_type_for_id_columns_in_laravel6()
     {
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
-
         $this->files->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));
@@ -222,16 +217,11 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_creates_constraints_for_unconventional_foreign_reference_migration_laravel6()
     {
         $this->app->config->set('blueprint.use_constraints', true);
-
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
 
         $this->files->expects('stub')
             ->with('migration.stub')
@@ -319,15 +309,10 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_also_creates_pivot_table_migration_laravel6()
     {
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
-
         $this->files->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));
@@ -385,16 +370,11 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_also_creates_constraints_for_pivot_table_migration_laravel6()
     {
         $this->app->config->set('blueprint.use_constraints', true);
-
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
 
         $this->files->expects('stub')
             ->with('migration.stub')
@@ -452,15 +432,10 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_does_not_duplicate_pivot_table_migration_laravel6()
     {
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
-
         $this->files->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));
@@ -517,15 +492,10 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_also_creates_pivot_table_migration_with_custom_name_laravel6()
     {
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
-
         $this->files->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));
@@ -579,16 +549,11 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_creates_foreign_keys_with_nullable_chained_correctly_laravel6()
     {
         $this->app->config->set('blueprint.on_delete', 'null');
-
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
 
         $this->files->expects('stub')
             ->with('migration.stub')
@@ -639,15 +604,10 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_creates_foreign_keys_with_on_delete_laravel6()
     {
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
-
         $this->files->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));
@@ -702,15 +662,10 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
      */
     public function output_works_with_polymorphic_relationships_laravel6()
     {
-        $app = \Mockery::mock();
-        $app->shouldReceive('version')
-            ->withNoArgs()
-            ->andReturn('6.0.0');
-        App::swap($app);
-
         $this->files->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));

--- a/tests/Feature/Generator/MigrationGeneratorTest.php
+++ b/tests/Feature/Generator/MigrationGeneratorTest.php
@@ -34,9 +34,7 @@ class MigrationGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -109,9 +107,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['updated' => [$yesterday_path]], $this->subject->output($tree, true));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_migration_for_foreign_shorthand()
     {
         $this->files->expects('stub')
@@ -134,9 +130,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$timestamp_path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_uses_past_timestamp_for_multiple_migrations()
     {
         $this->files->expects('stub')
@@ -188,9 +182,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$timestamp_path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_creates_constraints_for_unconventional_foreign_reference_migration()
     {
         $this->app->config->set('blueprint.use_constraints', true);
@@ -243,9 +235,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$model_migration]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_also_creates_pivot_table_migration()
     {
         $this->files->expects('stub')
@@ -271,9 +261,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$model_migration, $pivot_migration]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_also_updates_pivot_table_migration()
     {
         $this->files->expects('stub')
@@ -337,9 +325,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$model_migration, $pivot_migration]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_also_creates_constraints_for_pivot_table_migration()
     {
         $this->app->config->set('blueprint.use_constraints', true);
@@ -399,9 +385,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$model_migration, $pivot_migration]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_does_not_duplicate_pivot_table_migration()
     {
         $this->files->expects('stub')
@@ -462,9 +446,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$company_migration, $people_migration, $pivot_migration]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_also_creates_pivot_table_migration_with_custom_name()
     {
         $this->files->expects('stub')
@@ -519,9 +501,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$model_migration, $pivot_migration]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_creates_foreign_keys_with_nullable_chained_correctly()
     {
         $this->app->config->set('blueprint.on_delete', 'null');
@@ -576,9 +556,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$model_migration]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_creates_foreign_keys_with_on_delete()
     {
         $this->files->expects('stub')
@@ -629,9 +607,7 @@ class MigrationGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$model_migration]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_works_with_polymorphic_relationships()
     {
         $this->files->expects('stub')

--- a/tests/Feature/Generator/ModelGeneratorTest.php
+++ b/tests/Feature/Generator/ModelGeneratorTest.php
@@ -28,9 +28,7 @@ class ModelGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -92,9 +90,7 @@ class ModelGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_works_for_pascal_case_definition()
     {
         $this->files->expects('stub')
@@ -137,9 +133,7 @@ class ModelGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$certificateModel, $certificateTypeModel]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_relationships()
     {
         $this->files->expects('stub')
@@ -167,9 +161,7 @@ class ModelGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Subscription.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_polymorphic_relationships()
     {
         $this->files->expects('stub')
@@ -212,9 +204,7 @@ class ModelGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Post.php', 'app/User.php', 'app/Image.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_disabled_auto_columns()
     {
         $this->files->expects('stub')
@@ -245,9 +235,7 @@ class ModelGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/State.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_respects_configuration()
     {
         $this->app['config']->set('blueprint.app_path', 'src/path');
@@ -337,9 +325,7 @@ class ModelGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_models_with_guarded_property_when_config_option_is_set()
     {
         $this->app['config']->set('blueprint.use_guarded', true);
@@ -373,9 +359,7 @@ class ModelGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Comment.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_models_with_custom_namespace_correctly()
     {
         $definition = 'drafts/custom-models-namespace.yaml';
@@ -409,9 +393,7 @@ class ModelGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_models_with_custom_pivot_columns()
     {
         $this->files->expects('stub')

--- a/tests/Feature/Generator/RouteGeneratorTest.php
+++ b/tests/Feature/Generator/RouteGeneratorTest.php
@@ -32,9 +32,7 @@ class RouteGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_nothing_for_empty_tree()
     {
         $this->files->shouldNotHaveReceived('append');
@@ -58,9 +56,7 @@ class RouteGeneratorTest extends TestCase
         $this->assertEquals(['updated' => [$path]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_api_routes()
     {
         $this->files->expects('append')
@@ -72,9 +68,7 @@ class RouteGeneratorTest extends TestCase
         $this->assertEquals(['updated' => ['routes/api.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_routes_for_mixed_resources()
     {
         $this->files->expects('append')
@@ -88,9 +82,7 @@ class RouteGeneratorTest extends TestCase
         $this->assertEquals(['updated' => ['routes/api.php', 'routes/web.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_routes_using_tuples()
     {
         config(['blueprint.generate_fqcn_route' => true]);

--- a/tests/Feature/Generator/SeederGeneratorTest.php
+++ b/tests/Feature/Generator/SeederGeneratorTest.php
@@ -39,9 +39,7 @@ class SeederGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_nothing_for_empty_tree()
     {
         $this->files->shouldNotHaveReceived('put');
@@ -49,9 +47,7 @@ class SeederGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output(new Tree(['seeders' => []])));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_seeders()
     {
         $this->files->expects('stub')
@@ -69,9 +65,7 @@ class SeederGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['database/seeds/PostSeeder.php', 'database/seeds/CommentSeeder.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_seeders_from_traced_models()
     {
         $this->files->expects('stub')

--- a/tests/Feature/Generator/Statements/EventGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/EventGeneratorTest.php
@@ -32,9 +32,7 @@ class EventGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -46,9 +44,7 @@ class EventGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_tree_without_validate_statements()
     {
         $this->files->expects('stub')
@@ -63,9 +59,7 @@ class EventGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_events()
     {
         $this->files->expects('stub')
@@ -100,9 +94,7 @@ class EventGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Events/UserCreated.php', 'app/Events/UserDeleted.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_only_outputs_new_events()
     {
         $this->files->expects('stub')
@@ -122,9 +114,7 @@ class EventGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_respects_configuration()
     {
         $this->app['config']->set('blueprint.namespace', 'Some\\App');

--- a/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/FormRequestGeneratorTest.php
@@ -33,9 +33,7 @@ class FormRequestGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -47,9 +45,7 @@ class FormRequestGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_without_validate_statements()
     {
         $this->files->expects('stub')
@@ -64,9 +60,7 @@ class FormRequestGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_form_requests()
     {
         $this->files->expects('stub')
@@ -103,9 +97,7 @@ class FormRequestGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Http/Requests/PostIndexRequest.php', 'app/Http/Requests/PostStoreRequest.php', 'app/Http/Requests/OtherStoreRequest.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_form_requests_with_support_for_model_reference_in_validate_statement()
     {
         $this->files->expects('stub')
@@ -140,9 +132,7 @@ class FormRequestGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Http/Requests/CertificateStoreRequest.php', 'app/Http/Requests/CertificateUpdateRequest.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_only_outputs_new_form_requests()
     {
         $this->files->expects('stub')
@@ -165,9 +155,7 @@ class FormRequestGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_supports_nested_form_requests()
     {
         $this->files->expects('stub')
@@ -191,9 +179,7 @@ class FormRequestGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Http/Requests/Admin/UserStoreRequest.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_respects_configuration()
     {
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
@@ -220,9 +206,7 @@ class FormRequestGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['src/path/Http/Requests/PostStoreRequest.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_test_for_controller_tree_using_cached_model()
     {
         $this->files->expects('stub')

--- a/tests/Feature/Generator/Statements/JobGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/JobGeneratorTest.php
@@ -32,9 +32,7 @@ class JobGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -46,9 +44,7 @@ class JobGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_tree_without_validate_statements()
     {
         $this->files->expects('stub')
@@ -63,9 +59,7 @@ class JobGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_jobs()
     {
         $this->files->expects('stub')
@@ -100,9 +94,7 @@ class JobGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Jobs/CreateUser.php', 'app/Jobs/DeleteRole.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_only_outputs_new_jobs()
     {
         $this->files->expects('stub')
@@ -122,9 +114,7 @@ class JobGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_respects_configuration()
     {
         $this->app['config']->set('blueprint.namespace', 'Some\\App');

--- a/tests/Feature/Generator/Statements/MailGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/MailGeneratorTest.php
@@ -32,9 +32,7 @@ class MailGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -46,9 +44,7 @@ class MailGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_tree_without_validate_statements()
     {
         $this->files->expects('stub')
@@ -63,9 +59,7 @@ class MailGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_mails()
     {
         $this->files->expects('stub')
@@ -100,9 +94,7 @@ class MailGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Mail/ReviewPost.php', 'app/Mail/PublishedPost.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_only_outputs_new_mails()
     {
         $this->files->expects('stub')
@@ -122,9 +114,7 @@ class MailGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_respects_configuration()
     {
         $this->app['config']->set('blueprint.namespace', 'Some\\App');

--- a/tests/Feature/Generator/Statements/NotificationGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/NotificationGeneratorTest.php
@@ -32,9 +32,7 @@ class NotificationGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -46,9 +44,7 @@ class NotificationGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_tree_without_validate_statements()
     {
         $this->files->expects('stub')
@@ -103,9 +99,7 @@ class NotificationGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Notification/ReviewPostNotification.php', 'app/Notification/PublishedPostNotification.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_only_outputs_new_notifications()
     {
         $this->files->expects('stub')
@@ -125,9 +119,7 @@ class NotificationGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_respects_configuration()
     {
         $this->app['config']->set('blueprint.namespace', 'Some\\App');

--- a/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ResourceGeneratorTest.php
@@ -33,9 +33,7 @@ class ResourceGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -47,9 +45,7 @@ class ResourceGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_without_resource_statements()
     {
         $this->files->expects('stub')
@@ -64,9 +60,7 @@ class ResourceGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_resources_for_render_statements()
     {
         $template = $this->stub('resource.stub');
@@ -101,9 +95,7 @@ class ResourceGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Http/Resources/UserCollection.php', 'app/Http/Resources/UserResource.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_namespaced_classes()
     {
         $this->files->expects('stub')

--- a/tests/Feature/Generator/Statements/ViewGeneratorTest.php
+++ b/tests/Feature/Generator/Statements/ViewGeneratorTest.php
@@ -32,9 +32,7 @@ class ViewGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -46,9 +44,7 @@ class ViewGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output(new Tree(['controllers' => []])));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_without_render_statements()
     {
         $this->files->expects('stub')
@@ -63,9 +59,7 @@ class ViewGeneratorTest extends TestCase
         $this->assertEquals([], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_views_for_render_statements()
     {
         $template = $this->stub('view.stub');
@@ -106,9 +100,7 @@ class ViewGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['resources/views/user/index.blade.php', 'resources/views/user/create.blade.php', 'resources/views/post/show.blade.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_only_outputs_new_views()
     {
         $this->files->expects('stub')

--- a/tests/Feature/Generator/TestGeneratorTest.php
+++ b/tests/Feature/Generator/TestGeneratorTest.php
@@ -33,9 +33,7 @@ class TestGeneratorTest extends TestCase
         $this->blueprint->registerGenerator($this->subject);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
@@ -108,9 +106,7 @@ class TestGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$certificateControllerTest, $certificateTypeControllerTest]], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_test_for_controller_tree_using_cached_model()
     {
         $this->files->expects('stub')
@@ -140,9 +136,7 @@ class TestGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['tests/Feature/Http/Controllers/UserControllerTest.php']], $this->subject->output($tree));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_tests_with_models_with_custom_namespace_correctly()
     {
         $definition = 'drafts/models-with-custom-namespace.yaml';

--- a/tests/Feature/Lexers/ControllerLexerTest.php
+++ b/tests/Feature/Lexers/ControllerLexerTest.php
@@ -27,17 +27,13 @@ class ControllerLexerTest extends TestCase
         $this->subject = new ControllerLexer($this->statementLexer);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_nothing_without_controllers_token()
     {
         $this->assertEquals(['controllers' => []], $this->subject->analyze([]));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_controllers()
     {
         $tokens = [
@@ -105,9 +101,7 @@ class ControllerLexerTest extends TestCase
         $this->assertEquals('index-statement-1', $methods['index'][0]);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_web_resource_controller()
     {
         $tokens = [
@@ -194,9 +188,7 @@ class ControllerLexerTest extends TestCase
         $this->assertEquals('destroy-statements', $methods['destroy'][0]);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_an_api_resource_controller()
     {
         $tokens = [
@@ -254,9 +246,7 @@ class ControllerLexerTest extends TestCase
         $this->assertEquals('api-update-statements', $methods['update'][0]);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_specific_resource_controller()
     {
         $tokens = [
@@ -316,9 +306,7 @@ class ControllerLexerTest extends TestCase
         $this->assertEquals('destroy-statements', $methods['destroy'][0]);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_resource_controller_with_overrides()
     {
         $tokens = [
@@ -373,9 +361,7 @@ class ControllerLexerTest extends TestCase
         $this->assertEquals('custom-statements', $methods['custom'][0]);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_resource_controllers_with_api_flag_set()
     {
         $tokens = [

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -19,9 +19,7 @@ class ModelLexerTest extends TestCase
         $this->subject = new ModelLexer();
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_nothing_without_models_token()
     {
         $this->assertEquals([
@@ -30,9 +28,7 @@ class ModelLexerTest extends TestCase
         ], $this->subject->analyze([]));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_models()
     {
         $tokens = [
@@ -96,9 +92,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals([], $columns['id']->modifiers());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_defaults_the_id_column()
     {
         $tokens = [
@@ -131,9 +125,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals(['nullable'], $columns['title']->modifiers());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_disables_the_id_column()
     {
         $tokens = [
@@ -156,9 +148,7 @@ class ModelLexerTest extends TestCase
         $this->assertFalse($model->usesPrimaryKey());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_disables_timestamps()
     {
         $tokens = [
@@ -180,9 +170,7 @@ class ModelLexerTest extends TestCase
         $this->assertFalse($model->usesSoftDeletes());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_defaults_to_string_datatype()
     {
         $tokens = [
@@ -215,9 +203,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals(['nullable'], $columns['title']->modifiers());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_accepts_lowercase_keywords()
     {
         $tokens = [
@@ -330,9 +316,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals([[$modifier => $attributes], 'nullable'], $columns['column']->modifiers());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_handles_attributes_and_modifiers_with_attributes()
     {
         $tokens = [
@@ -351,9 +335,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals(['100'], $actual->attributes());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_enables_soft_deletes()
     {
         $tokens = [
@@ -381,9 +363,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals([], $columns['id']->modifiers());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_converts_foreign_shorthand_to_id()
     {
         $tokens = [
@@ -418,9 +398,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals([['foreign' => 'user']], $columns['author_id']->modifiers());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_sets_belongs_to_with_foreign_attributes()
     {
         $tokens = [
@@ -488,9 +466,7 @@ class ModelLexerTest extends TestCase
         ], $relationships['belongsTo']);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_traced_models()
     {
         $tokens = [
@@ -563,9 +539,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals(['nullable'], $columns['name']->modifiers());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_stores_relationships()
     {
         $tokens = [
@@ -606,9 +580,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals(['Duration', 'Transaction:tid'], $relationships['hasOne']);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_enables_morphable_and_set_its_reference()
     {
         $tokens = [

--- a/tests/Feature/Lexers/SeederLexerTest.php
+++ b/tests/Feature/Lexers/SeederLexerTest.php
@@ -33,9 +33,7 @@ class SeederLexerTest extends TestCase
         $this->subject = new SeederLexer();
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_nothing_without_seeders_token()
     {
         $this->assertEquals([
@@ -43,9 +41,7 @@ class SeederLexerTest extends TestCase
         ], $this->subject->analyze([]));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_seeders()
     {
         $tokens = [
@@ -60,9 +56,7 @@ class SeederLexerTest extends TestCase
         $this->assertSame(['Post'], $actual['seeders']);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_multiple_seeders()
     {
         $tokens = [

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -33,17 +33,13 @@ class StatementLexerTest extends TestCase
         $this->subject = new StatementLexer();
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_nothing_without_statements_token()
     {
         $this->assertEquals([], $this->subject->analyze([]));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_render_statement()
     {
         $tokens = [
@@ -59,9 +55,7 @@ class StatementLexerTest extends TestCase
         $this->assertSame([], $actual[0]->data());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_render_statement_with_data()
     {
         $tokens = [
@@ -77,9 +71,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_an_event_statement()
     {
         $tokens = [
@@ -95,9 +87,7 @@ class StatementLexerTest extends TestCase
         $this->assertSame([], $actual[0]->data());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_an_event_statement_with_data()
     {
         $tokens = [
@@ -113,9 +103,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_dispatch_statement()
     {
         $tokens = [
@@ -131,9 +119,7 @@ class StatementLexerTest extends TestCase
         $this->assertSame([], $actual[0]->data());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_dispatch_statement_with_data()
     {
         $tokens = [
@@ -149,9 +135,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement()
     {
         $tokens = [
@@ -169,9 +153,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_to_only()
     {
         $tokens = [
@@ -189,9 +171,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_with_only()
     {
         $tokens = [
@@ -209,9 +189,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_to_and_with()
     {
         $tokens = [
@@ -229,9 +207,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_type_notification_facade()
     {
         $tokens = [
@@ -249,9 +225,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_NOTIFICATION_WITH_FACADE, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_to_only_type_notification_facade()
     {
         $tokens = [
@@ -269,9 +243,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_NOTIFICATION_WITH_FACADE, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_with_only_type_notification_facade()
     {
         $tokens = [
@@ -289,9 +261,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_NOTIFICATION_WITH_FACADE, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_to_and_with_type_notification_facade()
     {
         $tokens = [
@@ -309,9 +279,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_NOTIFICATION_WITH_FACADE, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_with_type_notification_model()
     {
         $tokens = [
@@ -329,9 +297,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_NOTIFICATION_WITH_MODEL, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_to_only_type_notification_model()
     {
         $tokens = [
@@ -349,9 +315,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_NOTIFICATION_WITH_MODEL, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_with_only_type_notification_model()
     {
         $tokens = [
@@ -369,9 +333,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_NOTIFICATION_WITH_MODEL, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_send_statement_to_and_with_type_notification_model()
     {
         $tokens = [
@@ -389,9 +351,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(SendStatement::TYPE_NOTIFICATION_WITH_MODEL, $actual[0]->type());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_validate_statement()
     {
         $tokens = [
@@ -425,9 +385,7 @@ class StatementLexerTest extends TestCase
         $this->assertSame($reference, $actual[0]->reference());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_an_update_eloquent_statement_with_columns()
     {
         $tokens = [
@@ -463,9 +421,7 @@ class StatementLexerTest extends TestCase
         $this->assertSame($reference, $actual[0]->reference());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_redirect_statement()
     {
         $tokens = [
@@ -481,9 +437,7 @@ class StatementLexerTest extends TestCase
         $this->assertSame([], $actual[0]->data());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_redirect_statement_with_data()
     {
         $tokens = [
@@ -499,9 +453,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_response_statement_with_status_code()
     {
         $tokens = [
@@ -517,9 +469,7 @@ class StatementLexerTest extends TestCase
         $this->assertNull($actual[0]->content());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_response_statement_with_content()
     {
         $tokens = [
@@ -535,9 +485,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals('post', $actual[0]->content());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_query_all_statement()
     {
         $tokens = [
@@ -554,9 +502,7 @@ class StatementLexerTest extends TestCase
         $this->assertSame('Post', $actual[0]->model());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_query_all_statement_without_clause()
     {
         $tokens = [
@@ -573,9 +519,7 @@ class StatementLexerTest extends TestCase
         $this->assertNull($actual[0]->model());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_query_get_statement()
     {
         $tokens = [
@@ -592,9 +536,7 @@ class StatementLexerTest extends TestCase
         $this->assertNull($actual[0]->model());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_query_pluck_statement()
     {
         $tokens = [
@@ -611,9 +553,7 @@ class StatementLexerTest extends TestCase
         $this->assertNull($actual[0]->model());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_query_count_statement()
     {
         $tokens = [
@@ -630,9 +570,7 @@ class StatementLexerTest extends TestCase
         $this->assertNull($actual[0]->model());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_query_exists_statement()
     {
         $tokens = [
@@ -649,9 +587,7 @@ class StatementLexerTest extends TestCase
         $this->assertNull($actual[0]->model());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_resource_statement()
     {
         $tokens = [
@@ -669,9 +605,7 @@ class StatementLexerTest extends TestCase
         $this->assertFalse($actual[0]->paginate());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_resource_collection_statement()
     {
         $tokens = [
@@ -689,9 +623,7 @@ class StatementLexerTest extends TestCase
         $this->assertFalse($actual[0]->paginate());
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_a_resource_collection_statement_with_pagination()
     {
         $tokens = [

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -11,9 +11,7 @@ use Blueprint\Translators\Rules;
  */
 class RulesTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function forColumn_returns_required_rule_by_default()
     {
         $column = new Column('test', 'unknown');
@@ -32,9 +30,7 @@ class RulesTest extends TestCase
         $this->assertContains('string', Rules::fromColumn('context', $column));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function forColumn_returns_max_rule_for_string_attributes()
     {
         $column = new Column('test', 'string', [], [1000]);
@@ -96,9 +92,7 @@ class RulesTest extends TestCase
         $this->assertContains('integer', Rules::fromColumn('context', $column));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function forColumn_return_exists_rule_for_id_column()
     {
         $column = new Column('user_id', 'id');
@@ -106,9 +100,7 @@ class RulesTest extends TestCase
         $this->assertContains('exists:users,id', Rules::fromColumn('context', $column));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function forColumn_return_exists_rule_id_column_with_attribute()
     {
         $column = new Column('author_id', 'id', [], ['user']);
@@ -116,9 +108,7 @@ class RulesTest extends TestCase
         $this->assertContains('exists:users,id', Rules::fromColumn('context', $column));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function forColumn_return_exists_rule_for_the_unique_modifier()
     {
         $column = new Column('column', 'string', ['unique']);
@@ -140,9 +130,7 @@ class RulesTest extends TestCase
         $this->assertContains("exists:{$table},id", $actual);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function forColumn_returns_gt0_rule_for_unsigned_numeric_types()
     {
         $column = new Column('test', 'integer');
@@ -154,9 +142,7 @@ class RulesTest extends TestCase
         $this->assertContains('gt:0', Rules::fromColumn('context', $column));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function forColumn_returns_in_rule_for_enums_and_sets()
     {
         $column = new Column('test', 'enum', [], ['alpha', 'bravo', 'charlie']);
@@ -178,9 +164,7 @@ class RulesTest extends TestCase
         $this->assertContains('date', Rules::fromColumn('context', $column));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function forColumn_return_json_rule_for_the_json_type()
     {
         $column = new Column('column', 'json');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,4 +33,14 @@ class TestCase extends \Orchestra\Testbench\TestCase
             BlueprintServiceProvider::class,
         ];
     }
+
+    protected function useLaravel6($app)
+    {
+        $appMock = \Mockery::mock($app);
+        $appMock->shouldReceive('version')
+            ->withNoArgs()
+            ->andReturn('6.0.0');
+
+        \App::swap($appMock);
+    }
 }

--- a/tests/Traits/MocksFilesystem.php
+++ b/tests/Traits/MocksFilesystem.php
@@ -1,0 +1,12 @@
+<?php
+namespace Tests\Traits;
+
+trait MocksFilesystem
+{
+    protected function setUp():void
+    {
+        parent::setUp();
+        $this->files = $this->filesystem = $this->mock(\Illuminate\Filesystem\Filesystem::class);
+        $this->swap('files', $this->files);
+    }
+}

--- a/tests/Traits/MocksFilesystem.php
+++ b/tests/Traits/MocksFilesystem.php
@@ -6,7 +6,7 @@ trait MocksFilesystem
     protected function setUp():void
     {
         parent::setUp();
-        $this->files = $this->filesystem = $this->mock(\Illuminate\Filesystem\Filesystem::class);
+        $this->files = $this->mock(\Illuminate\Filesystem\Filesystem::class);
         $this->swap('files', $this->files);
     }
 }

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -10,9 +10,7 @@ use Tests\TestCase;
 
 class BuilderTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function execute_builds_draft_content()
     {
         $draft = 'draft blueprint content';
@@ -51,9 +49,7 @@ class BuilderTest extends TestCase
         $this->assertSame($generated, $actual);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function execute_uses_cache_and_remembers_models()
     {
         $cache = [
@@ -109,9 +105,7 @@ class BuilderTest extends TestCase
         $this->assertSame($generated, $actual);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function execute_calls_builder_without_stripping_dashes_for_draft_file_with_indexes_defined()
     {
         $draft = 'models:';

--- a/tests/Unit/Models/Statements/EloquentStatementTest.php
+++ b/tests/Unit/Models/Statements/EloquentStatementTest.php
@@ -10,9 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EloquentStatementTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_find()
     {
         $subject = new EloquentStatement('find', 'user.id');
@@ -20,9 +18,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$user = User::find($id);', $subject->output('', 'whatever'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_find_without_reference()
     {
         $subject = new EloquentStatement('find', 'id');
@@ -30,9 +26,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$post = Post::find($id);', $subject->output('Post', 'whatever'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_save()
     {
         $subject = new EloquentStatement('save', 'post');
@@ -40,9 +34,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$post->save();', $subject->output('', 'whatever'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_save_using_create()
     {
         $subject = new EloquentStatement('save', 'Post');
@@ -50,9 +42,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$post = Post::create($request->all());', $subject->output('', 'store'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_save_using_create_when_validation_is_used()
     {
         $subject = new EloquentStatement('save', 'Post');
@@ -60,9 +50,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$post = Post::create($request->validated());', $subject->output('', 'store', true));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_update_using_model()
     {
         $subject = new EloquentStatement('update', 'post');
@@ -70,9 +58,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$post->update([]);', $subject->output('', ''));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_update_using_column_list()
     {
         $subject = new EloquentStatement('update', null, ['name', 'title', 'age']);
@@ -80,9 +66,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$user->update([\'name\' => $name, \'title\' => $title, \'age\' => $age]);', $subject->output('User', ''));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_delete()
     {
         $subject = new EloquentStatement('delete', 'post');
@@ -90,9 +74,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$post->delete();', $subject->output('', 'whatever'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_delete_uses_delete_without_reference()
     {
         $subject = new EloquentStatement('delete', '');
@@ -100,9 +82,7 @@ class EloquentStatementTest extends TestCase
         $this->assertEquals('$comment->delete();', $subject->output('Comment', 'whatever'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_delete_using_destroy()
     {
         $subject = new EloquentStatement('delete', 'comment.id');

--- a/tests/Unit/Models/Statements/QueryStatementTest.php
+++ b/tests/Unit/Models/Statements/QueryStatementTest.php
@@ -10,9 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class QueryStatementTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_all()
     {
         $subject = new QueryStatement('all', ['posts']);
@@ -20,9 +18,7 @@ class QueryStatementTest extends TestCase
         $this->assertEquals('$posts = Post::all();', $subject->output(''));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_all_without_reference()
     {
         $subject = new QueryStatement('all');
@@ -30,9 +26,7 @@ class QueryStatementTest extends TestCase
         $this->assertEquals('$posts = Post::all();', $subject->output('Post'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_get_while_condensing_qualified_columns()
     {
         $subject = new QueryStatement('get', ['order:post.published_at']);
@@ -40,9 +34,7 @@ class QueryStatementTest extends TestCase
         $this->assertEquals('$posts = Post::orderBy(\'published_at\')->get();', $subject->output('Post'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_pluck_while_condensing_qualified_columns()
     {
         $subject = new QueryStatement('pluck', ['where:post.title', 'pluck:id']);
@@ -50,9 +42,7 @@ class QueryStatementTest extends TestCase
         $this->assertEquals('$post_ids = Post::where(\'title\', $post->title)->pluck(\'id\');', $subject->output('Post'));
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function output_generates_code_for_count_while_preserving_qualified_columns()
     {
         $subject = new QueryStatement('count', ['where:post.title']);


### PR DESCRIPTION
- prevents tests from creating .blueprint files.
- setup environment using annotation