### PR TITLE
Update build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,20 +77,42 @@ jobs:
           coverage: none
           ini-values: "memory_limit=-1"
 
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
       - name: Install highest dependencies from composer.json
         if: matrix.dependencies == 'highest'
-        run: composer config platform --unset && composer update ${{ env.COMPOSER_FLAGS }}
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer config platform --unset && composer update ${{ env.COMPOSER_FLAGS }}
 
       - name: Install lowest dependencies from composer.json
         if: matrix.dependencies == 'lowest'
-        run: composer install ${{ env.COMPOSER_FLAGS }} --prefer-lowest
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer install ${{ env.COMPOSER_FLAGS }} --prefer-lowest
 
       - name: Install dependencies from composer.lock
         if: matrix.dependencies == 'locked'
-        run: composer install ${{ env.COMPOSER_FLAGS }}
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer install ${{ env.COMPOSER_FLAGS }}
 
       - name: Select Laravel version
-        run: composer require "laravel/framework:${{ matrix.laravel-version }}.*" --no-update
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require "laravel/framework:${{ matrix.laravel-version }}.*" --no-update
 
       - name: Run tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php-version: [7.2, 7.3, 7.4]
 
-        laravel-version: [6, 7]
+        laravel-version: [6, 7, 8]
 
         os: [ubuntu-latest]
 
@@ -58,12 +58,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Determine composer cache directory
+        id: determine-composer-cache-directory
+        run: 'echo "::set-output name=directory::$(composer config cache-dir)"'
+
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: ~/.composer/cache/files
+          path: ${{ steps.determine-composer-cache-directory.outputs.directory }}
           key: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}
+          restore-keys: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
- Test Laravel 8
- Update `actions/cache@v2`
- Added `nick-invision/retry@v1` to handle composer timeouts.
- Setup problem matchers for `PHP` & `PHPUnit`

    >This will scan the logs for PHP & PHPUnit errors and warnings, and surface them prominently in the GitHub Actions UI by creating annotations and log file decorations.