### PR TITLE
Laravel 8 class-based model factories

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -5,13 +5,14 @@ namespace Blueprint\Generators;
 use Blueprint\Contracts\Generator;
 use Blueprint\Models\Column;
 use Blueprint\Models\Model;
-use Shift\Faker\Registry as FakerRegistry;
 use Blueprint\Tree;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
+use Shift\Faker\Registry as FakerRegistry;
 
 class FactoryGenerator implements Generator
 {
-    const INDENT = '        ';
+    const INDENT = '    ';
 
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     private $files;
@@ -27,11 +28,18 @@ class FactoryGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->stub('factory.stub');
+
+        if ($this->isLaravel8Up()) {
+            $stub = $this->files->stub('factory.stub');
+        } else {
+            $stub = $this->files->stub('factory.closure.stub');
+        }
 
         /** @var \Blueprint\Models\Model $model */
         foreach ($tree->models() as $model) {
-            $this->addImport($model, 'Faker\Generator as Faker');
+            if (! $this->isLaravel8Up()) {
+                $this->addImport($model, 'Faker\Generator as Faker');
+            }
             $this->addImport($model, $model->fullyQualifiedClassName());
 
             $path = $this->getPath($model);
@@ -65,9 +73,13 @@ class FactoryGenerator implements Generator
 
     protected function populateStub(string $stub, Model $model)
     {
-        $stub = str_replace('{{ class }}', $model->name(), $stub);
-        $stub = str_replace('{{ definition }}', $this->buildDefinition($model), $stub);
-        $stub = str_replace('{{ imports }}', $this->buildImports($model), $stub);
+        $stub = str_replace('{{ model }}', $model->name(), $stub);
+        $stub = str_replace('//', $this->buildDefinition($model), $stub);
+        if ($this->isLaravel8Up()) {
+            $stub = str_replace('use {{ namespacedModel }};', $this->buildImports($model), $stub);
+        } else {
+            $stub = str_replace('use Faker\Generator as Faker;'.PHP_EOL.'use {{ namespacedModel }};', $this->buildImports($model), $stub);
+        }
 
         return $stub;
     }
@@ -109,28 +121,54 @@ class FactoryGenerator implements Generator
 
                 $class = Str::studly(Str::singular($table));
 
+                if ($this->isLaravel8Up()) {
+                    $this->addImport($model, $model->fullyQualifiedNamespace().'\\'.$class);
+                }
                 if ($key === 'id') {
-                    $definition .= self::INDENT."'{$column->name()}' => ";
-                    $definition .= sprintf('factory(%s::class)', '\\'.$model->fullyQualifiedNamespace().'\\'.$class);
-                    $definition .= ','.PHP_EOL;
+                    if ($this->isLaravel8Up()) {
+                        $definition .= str_repeat(self::INDENT, 3)."'{$column->name()}' => ";
+                        $definition .= sprintf('%s::factory()', $class);
+                        $definition .= ','.PHP_EOL;
+                    } else {
+                        $definition .= str_repeat(self::INDENT, 2)."'{$column->name()}' => ";
+                        $definition .= sprintf('factory(%s::class)', '\\'.$model->fullyQualifiedNamespace().'\\'.$class);
+                        $definition .= ','.PHP_EOL;
+                    }
                 } else {
-                    $definition .= self::INDENT."'{$column->name()}' => function () {";
-                    $definition .= PHP_EOL;
-                    $definition .= self::INDENT.'    '.sprintf('return factory(%s::class)->create()->%s;', '\\'.$model->fullyQualifiedNamespace().'\\'.$class, $key);
-                    $definition .= PHP_EOL;
-                    $definition .= self::INDENT.'},'.PHP_EOL;
+                    if ($this->isLaravel8Up()) {
+                        $definition .= str_repeat(self::INDENT, 3)."'{$column->name()}' => ";
+                        $definition .= sprintf('%s::factory()->create()->%s', $class, $key);
+                        $definition .= ','.PHP_EOL;
+                    } else {
+                        $definition .= str_repeat(self::INDENT, 2)."'{$column->name()}' => function () {";
+                        $definition .= PHP_EOL;
+                        $definition .= str_repeat(self::INDENT, 3).sprintf('return factory(%s::class)->create()->%s;', '\\'.$model->fullyQualifiedNamespace().'\\'.$class, $key);
+                        $definition .= PHP_EOL;
+                        $definition .= str_repeat(self::INDENT, 2).'},'.PHP_EOL;
+                    }
                 }
             } elseif ($column->dataType() === 'id' || ($column->dataType() === 'uuid' && Str::endsWith($column->name(), '_id'))) {
                 $name = Str::beforeLast($column->name(), '_id');
                 $class = Str::studly($column->attributes()[0] ?? $name);
 
-                $definition .= self::INDENT."'{$column->name()}' => ";
-                $definition .= sprintf('factory(%s::class)', '\\'.$model->fullyQualifiedNamespace().'\\'.$class);
+                if ($this->isLaravel8Up()) {
+                    $this->addImport($model, $model->fullyQualifiedNamespace().'\\'.$class);
+                    $definition .= str_repeat(self::INDENT, 3)."'{$column->name()}' => ";
+                    $definition .= sprintf('%s::factory()', $class);
+                } else {
+                    $definition .= str_repeat(self::INDENT, 2)."'{$column->name()}' => ";
+                    $definition .= sprintf('factory(%s::class)', '\\'.$model->fullyQualifiedNamespace().'\\'.$class);
+                }
                 $definition .= ','.PHP_EOL;
             } elseif (in_array($column->dataType(), ['enum', 'set']) && ! empty($column->attributes())) {
-                $definition .= self::INDENT."'{$column->name()}' => ";
                 $faker = FakerRegistry::fakerData($column->name()) ?? FakerRegistry::fakerDataType($column->dataType());
-                $definition .= '$faker->'.$faker;
+                if ($this->isLaravel8Up()) {
+                    $definition .= str_repeat(self::INDENT, 3)."'{$column->name()}' => ";
+                    $definition .= '$this->faker->'.$faker;
+                } else {
+                    $definition .= str_repeat(self::INDENT, 2)."'{$column->name()}' => ";
+                    $definition .= '$faker->'.$faker;
+                }
                 $definition .= ','.PHP_EOL;
                 $definition = str_replace(
                     "/** {$column->dataType()}_attributes **/",
@@ -138,9 +176,14 @@ class FactoryGenerator implements Generator
                     $definition
                 );
             } elseif (in_array($column->dataType(), ['decimal', 'double', 'float'])) {
-                $definition .= self::INDENT."'{$column->name()}' => ";
                 $faker = FakerRegistry::fakerData($column->name()) ?? FakerRegistry::fakerDataType($column->dataType());
-                $definition .= '$faker->'.$faker;
+                if ($this->isLaravel8Up()) {
+                    $definition .= str_repeat(self::INDENT, 3)."'{$column->name()}' => ";
+                    $definition .= '$this->faker->'.$faker;
+                } else {
+                    $definition .= str_repeat(self::INDENT, 2)."'{$column->name()}' => ";
+                    $definition .= '$faker->'.$faker;
+                }
                 $definition .= ','.PHP_EOL;
 
                 $precision = min([65, intval($column->attributes()[0] ?? 10)]);
@@ -153,21 +196,37 @@ class FactoryGenerator implements Generator
                 );
             } elseif (in_array($column->dataType(), ['json', 'jsonb'])) {
                 $default = $column->defaultValue() ?? "'{}'";
-                $definition .= self::INDENT."'{$column->name()}' => {$default},".PHP_EOL;
+                if ($this->isLaravel8Up()) {
+                    $definition .= str_repeat(self::INDENT, 3)."'{$column->name()}' => {$default},".PHP_EOL;
+                } else {
+                    $definition .= str_repeat(self::INDENT, 2)."'{$column->name()}' => {$default},".PHP_EOL;
+                }
             } elseif ($column->dataType() === 'morphs') {
                 if ($column->isNullable()) {
                     continue;
                 }
-                $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_id'", FakerRegistry::fakerDataType('id'), PHP_EOL);
-                $definition .= sprintf('%s%s => $faker->%s,%s', self::INDENT, "'{$column->name()}_type'", FakerRegistry::fakerDataType('string'), PHP_EOL);
+                if ($this->isLaravel8Up()) {
+                    $definition .= sprintf('%s%s => $this->faker->%s,%s', str_repeat(self::INDENT, 3), "'{$column->name()}_id'", FakerRegistry::fakerDataType('id'), PHP_EOL);
+                    $definition .= sprintf('%s%s => $this->faker->%s,%s', str_repeat(self::INDENT, 3), "'{$column->name()}_type'", FakerRegistry::fakerDataType('string'), PHP_EOL);
+                } else {
+                    $definition .= sprintf('%s%s => $faker->%s,%s', str_repeat(self::INDENT, 2), "'{$column->name()}_id'", FakerRegistry::fakerDataType('id'), PHP_EOL);
+                    $definition .= sprintf('%s%s => $faker->%s,%s', str_repeat(self::INDENT, 2), "'{$column->name()}_type'", FakerRegistry::fakerDataType('string'), PHP_EOL);
+                }
             } elseif ($column->dataType() === 'rememberToken') {
-                $this->addImport($model, 'Illuminate\Support\Str');
-                $definition .= self::INDENT."'{$column->name()}' => ";
+                if ($this->isLaravel8Up()) {
+                    $definition .= str_repeat(self::INDENT, 3)."'{$column->name()}' => ";
+                } else {
+                    $this->addImport($model, 'Illuminate\Support\Str');
+                    $definition .= str_repeat(self::INDENT, 2)."'{$column->name()}' => ";
+                }
                 $definition .= 'Str::random(10)';
                 $definition .= ','.PHP_EOL;
             } else {
-                $definition .= self::INDENT."'{$column->name()}' => ";
-
+                if ($this->isLaravel8Up()) {
+                    $definition .= str_repeat(self::INDENT, 3)."'{$column->name()}' => ";
+                } else {
+                    $definition .= str_repeat(self::INDENT, 2)."'{$column->name()}' => ";
+                }
                 $type = $column->dataType();
                 if ($column->isUnsigned()) {
                     $type = 'unsigned'.$type;
@@ -179,7 +238,11 @@ class FactoryGenerator implements Generator
                     $faker = 'word';
                 }
 
-                $definition .= '$faker->'.$faker;
+                if ($this->isLaravel8Up()) {
+                    $definition .= '$this->faker->'.$faker;
+                } else {
+                    $definition .= '$faker->'.$faker;
+                }
                 $definition .= ','.PHP_EOL;
             }
         }
@@ -211,5 +274,10 @@ class FactoryGenerator implements Generator
         return array_filter($columns, function (Column $column) {
             return ! in_array('nullable', $column->modifiers());
         });
+    }
+
+    protected function isLaravel8Up()
+    {
+        return version_compare(App::version(), '8.0.0', '>=');
     }
 }

--- a/src/Generators/SeederGenerator.php
+++ b/src/Generators/SeederGenerator.php
@@ -4,6 +4,7 @@ namespace Blueprint\Generators;
 
 use Blueprint\Contracts\Generator;
 use Blueprint\Tree;
+use Illuminate\Support\Facades\App;
 
 class SeederGenerator implements Generator
 {
@@ -12,6 +13,8 @@ class SeederGenerator implements Generator
 
     /** @var Tree */
     private $tree;
+
+    private $imports = [];
 
     public function __construct($files)
     {
@@ -28,7 +31,11 @@ class SeederGenerator implements Generator
 
         $output = [];
 
-        $stub = $this->files->stub('seeder.stub');
+        if ($this->isLaravel8Up()) {
+            $stub = $this->files->stub('seeder.stub');
+        } else {
+            $stub = $this->files->stub('seeder.no-factory.stub');
+        }
 
         foreach ($tree->seeders() as $model) {
             $path = $this->getPath($model);
@@ -48,8 +55,14 @@ class SeederGenerator implements Generator
     protected function populateStub(string $stub, string $model)
     {
         $stub = str_replace('{{ class }}', $this->getClassName($model), $stub);
-        $stub = str_replace('{{ body }}', $this->build($model), $stub);
+        if ($this->isLaravel8Up()) {
+            $this->addImport($model, 'Illuminate\Database\Seeder');
 
+            $stub = str_replace('//', $this->build($model), $stub);
+            $stub = str_replace('use Illuminate\Database\Seeder;', $this->buildImports($model), $stub);
+        } else {
+            $stub = str_replace('{{ body }}', $this->build($model), $stub);
+        }
         return $stub;
     }
 
@@ -60,11 +73,35 @@ class SeederGenerator implements Generator
 
     protected function build(string $model)
     {
+        if ($this->isLaravel8Up()) {
+            $this->addImport($model, $this->tree->fqcnForContext($model));
+            return sprintf('%s::factory()->times(5)->create();', class_basename($this->tree->fqcnForContext($model)));
+        }
         return sprintf('factory(\\%s::class, 5)->create();', $this->tree->fqcnForContext($model));
+    }
+
+    protected function buildImports(string $model)
+    {
+        $imports = array_unique($this->imports[$model]);
+        sort($imports);
+
+        return implode(PHP_EOL, array_map(function ($class) {
+            return 'use '.$class.';';
+        }, $imports));
+    }
+
+    private function addImport(string $model, $class)
+    {
+        $this->imports[$model][] = $class;
     }
 
     private function getPath($model)
     {
         return 'database/seeds/'.$model.'Seeder.php';
+    }
+
+    protected function isLaravel8Up()
+    {
+        return version_compare(App::version(), '8.0.0', '>=');
     }
 }

--- a/stubs/factory.closure.stub
+++ b/stubs/factory.closure.stub
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator as Faker;
+use {{ namespacedModel }};
+
+$factory->define({{ model }}::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -1,11 +1,29 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
-{{ imports }}
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use {{ namespacedModel }};
 
-$factory->define({{ class }}::class, function (Faker $faker) {
-    return [
-        {{ definition }}
-    ];
-});
+class {{ model }}Factory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = {{ model }}::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/stubs/model.class.no-factory.stub
+++ b/stubs/model.class.no-factory.stub
@@ -2,10 +2,9 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-
+{{ PHPDoc }}
 class {{ class }} extends Model
 {
-    use HasFactory;
+    {{ body }}
 }

--- a/stubs/seeder.no-factory.stub
+++ b/stubs/seeder.no-factory.stub
@@ -1,7 +1,5 @@
 <?php
 
-namespace Database\Seeders;
-
 use Illuminate\Database\Seeder;
 
 class {{ class }} extends Seeder
@@ -13,6 +11,6 @@ class {{ class }} extends Seeder
      */
     public function run()
     {
-        //
+        {{ body }}
     }
 }

--- a/tests/Feature/Generators/FactoryGeneratorTest.php
+++ b/tests/Feature/Generators/FactoryGeneratorTest.php
@@ -70,6 +70,54 @@ class FactoryGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
+     * @dataProvider modelTreeDataProvider
+     */
+    public function output_writes_factory_for_model_tree_l6($definition, $path, $factory)
+    {
+        $this->files->expects('stub')
+            ->with('factory.closure.stub')
+            ->andReturn($this->stub('factory.closure.stub'));
+
+        $this->files->expects('exists')
+            ->with('database/factories')
+            ->andReturnTrue();
+
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('factories', 'factories/closure-based', $factory)));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel7
+     * @dataProvider modelTreeDataProvider
+     */
+    public function output_writes_factory_for_model_tree_l7($definition, $path, $factory)
+    {
+        $this->files->expects('stub')
+            ->with('factory.closure.stub')
+            ->andReturn($this->stub('factory.closure.stub'));
+
+        $this->files->expects('exists')
+            ->with('database/factories')
+            ->andReturnTrue();
+
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('factories', 'factories/closure-based', $factory)));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
      */
     public function output_ignores_nullables_if_fake_nullables_configuration_is_set_to_false()
     {

--- a/tests/Feature/Generators/FactoryGeneratorTest.php
+++ b/tests/Feature/Generators/FactoryGeneratorTest.php
@@ -6,6 +6,7 @@ use Blueprint\Tree;
 use Tests\TestCase;
 use Blueprint\Blueprint;
 use Blueprint\Generators\FactoryGenerator;
+use Illuminate\Support\Facades\App;
 
 /**
  * @see FactoryGenerator
@@ -24,6 +25,7 @@ class FactoryGeneratorTest extends TestCase
         parent::setUp();
 
         $this->files = \Mockery::mock();
+        $this->factoryStub = version_compare(App::version(), '8.0.0', '>=') ? 'factory.stub' : 'factory.closure.stub';
         $this->subject = new FactoryGenerator($this->files);
 
         $this->blueprint = new Blueprint();
@@ -37,8 +39,8 @@ class FactoryGeneratorTest extends TestCase
     public function output_writes_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
-            ->with('factory.stub')
-            ->andReturn($this->stub('factory.stub'));
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -52,8 +54,8 @@ class FactoryGeneratorTest extends TestCase
     public function output_writes_factory_for_model_tree($definition, $path, $factory)
     {
         $this->files->expects('stub')
-            ->with('factory.stub')
-            ->andReturn($this->stub('factory.stub'));
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
 
         $this->files->expects('exists')
             ->with('database/factories')
@@ -76,8 +78,8 @@ class FactoryGeneratorTest extends TestCase
     public function output_writes_factory_for_model_tree_l6($definition, $path, $factory)
     {
         $this->files->expects('stub')
-            ->with('factory.closure.stub')
-            ->andReturn($this->stub('factory.closure.stub'));
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
 
         $this->files->expects('exists')
             ->with('database/factories')
@@ -100,8 +102,8 @@ class FactoryGeneratorTest extends TestCase
     public function output_writes_factory_for_model_tree_l7($definition, $path, $factory)
     {
         $this->files->expects('stub')
-            ->with('factory.closure.stub')
-            ->andReturn($this->stub('factory.closure.stub'));
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
 
         $this->files->expects('exists')
             ->with('database/factories')
@@ -124,8 +126,8 @@ class FactoryGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.fake_nullables', false);
 
         $this->files->expects('stub')
-            ->with('factory.stub')
-            ->andReturn($this->stub('factory.stub'));
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
 
         $this->files->expects('exists')
             ->with('database/factories')
@@ -149,8 +151,8 @@ class FactoryGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.models_namespace', 'Models');
 
         $this->files->expects('stub')
-            ->with('factory.stub')
-            ->andReturn($this->stub('factory.stub'));
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
 
         $this->files->expects('exists')
             ->with('database/factories')
@@ -171,8 +173,8 @@ class FactoryGeneratorTest extends TestCase
     public function output_creates_directory_for_nested_components()
     {
         $this->files->expects('stub')
-            ->with('factory.stub')
-            ->andReturn($this->stub('factory.stub'));
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
 
         $this->files->expects('exists')
             ->with('database/factories/Admin')

--- a/tests/Feature/Generators/FactoryGeneratorTest.php
+++ b/tests/Feature/Generators/FactoryGeneratorTest.php
@@ -49,6 +49,7 @@ class FactoryGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      * @dataProvider modelTreeDataProvider
      */
     public function output_writes_factory_for_model_tree($definition, $path, $factory)
@@ -63,30 +64,6 @@ class FactoryGeneratorTest extends TestCase
 
         $this->files->expects('put')
             ->with($path, $this->fixture($factory));
-
-        $tokens = $this->blueprint->parse($this->fixture($definition));
-        $tree = $this->blueprint->analyze($tokens);
-
-        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
-    }
-
-    /**
-     * @test
-     * @environment-setup useLaravel6
-     * @dataProvider modelTreeDataProvider
-     */
-    public function output_writes_factory_for_model_tree_l6($definition, $path, $factory)
-    {
-        $this->files->expects('stub')
-            ->with($this->factoryStub)
-            ->andReturn($this->stub($this->factoryStub));
-
-        $this->files->expects('exists')
-            ->with('database/factories')
-            ->andReturnTrue();
-
-        $this->files->expects('put')
-            ->with($path, $this->fixture(str_replace('factories', 'factories/closure-based', $factory)));
 
         $tokens = $this->blueprint->parse($this->fixture($definition));
         $tree = $this->blueprint->analyze($tokens);
@@ -120,6 +97,31 @@ class FactoryGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
+     * @dataProvider modelTreeDataProvider
+     */
+    public function output_writes_factory_for_model_tree_l6($definition, $path, $factory)
+    {
+        $this->files->expects('stub')
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
+
+        $this->files->expects('exists')
+            ->with('database/factories')
+            ->andReturnTrue();
+
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('factories', 'factories/closure-based', $factory)));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel8
      */
     public function output_ignores_nullables_if_fake_nullables_configuration_is_set_to_false()
     {
@@ -144,6 +146,7 @@ class FactoryGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_respects_configuration()
     {
@@ -169,6 +172,7 @@ class FactoryGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_creates_directory_for_nested_components()
     {

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -46,6 +46,7 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      * @dataProvider modelTreeDataProvider
      */
     public function output_generates_models($definition, $path, $model)
@@ -87,57 +88,6 @@ class ModelGeneratorTest extends TestCase
             ->andReturnTrue();
         $this->files->expects('put')
             ->with($path, $this->fixture($model));
-
-        $tokens = $this->blueprint->parse($this->fixture($definition));
-        $tree = $this->blueprint->analyze($tokens);
-
-        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
-    }
-
-    /**
-     * @test
-     * @environment-setup useLaravel6
-     * @dataProvider modelTreeDataProvider
-     */
-    public function output_generates_models_l6($definition, $path, $model)
-    {
-        $this->files->expects('stub')
-            ->with($this->modelStub)
-            ->andReturn($this->stub($this->modelStub));
-
-        $this->files->expects('stub')
-            ->with('model.fillable.stub')
-            ->andReturn($this->stub('model.fillable.stub'));
-
-        if (in_array($definition, ['drafts/nested-components.yaml', 'drafts/resource-statements.yaml'])) {
-            $this->files->expects('stub')
-                ->with('model.hidden.stub')
-                ->andReturn($this->stub('model.hidden.stub'));
-        }
-
-        $this->files->expects('stub')
-            ->with('model.casts.stub')
-            ->andReturn($this->stub('model.casts.stub'));
-
-        if (in_array($definition, ['drafts/readme-example.yaml', 'drafts/all-column-types.yaml'])) {
-            $this->files->expects('stub')
-                ->with('model.dates.stub')
-                ->andReturn($this->stub('model.dates.stub'));
-        }
-
-        $this->files->shouldReceive('stub')
-            ->with('model.method.stub')
-            ->andReturn($this->stub('model.method.stub'));
-
-        $this->files->shouldReceive('stub')
-            ->with('model.method.comment.stub')
-            ->andReturn($this->stub('model.method.comment.stub'));
-
-        $this->files->expects('exists')
-            ->with(dirname($path))
-            ->andReturnTrue();
-        $this->files->expects('put')
-            ->with($path, $this->fixture(str_replace('models', 'models/no-factory', $model)));
 
         $tokens = $this->blueprint->parse($this->fixture($definition));
         $tree = $this->blueprint->analyze($tokens);
@@ -198,6 +148,58 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
+     * @dataProvider modelTreeDataProvider
+     */
+    public function output_generates_models_l6($definition, $path, $model)
+    {
+        $this->files->expects('stub')
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
+
+        $this->files->expects('stub')
+            ->with('model.fillable.stub')
+            ->andReturn($this->stub('model.fillable.stub'));
+
+        if (in_array($definition, ['drafts/nested-components.yaml', 'drafts/resource-statements.yaml'])) {
+            $this->files->expects('stub')
+                ->with('model.hidden.stub')
+                ->andReturn($this->stub('model.hidden.stub'));
+        }
+
+        $this->files->expects('stub')
+            ->with('model.casts.stub')
+            ->andReturn($this->stub('model.casts.stub'));
+
+        if (in_array($definition, ['drafts/readme-example.yaml', 'drafts/all-column-types.yaml'])) {
+            $this->files->expects('stub')
+                ->with('model.dates.stub')
+                ->andReturn($this->stub('model.dates.stub'));
+        }
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.stub')
+            ->andReturn($this->stub('model.method.stub'));
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.comment.stub')
+            ->andReturn($this->stub('model.method.comment.stub'));
+
+        $this->files->expects('exists')
+            ->with(dirname($path))
+            ->andReturnTrue();
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('models', 'models/no-factory', $model)));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel8
      */
     public function output_works_for_pascal_case_definition()
     {
@@ -243,6 +245,7 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_generates_relationships()
     {
@@ -273,6 +276,7 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_generates_polymorphic_relationships()
     {
@@ -318,6 +322,7 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_generates_disabled_auto_columns()
     {
@@ -351,6 +356,7 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_respects_configuration()
     {
@@ -390,6 +396,7 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      * @dataProvider docBlockModelsDataProvider
      */
     public function output_generates_phpdoc_for_model($definition, $path, $model)
@@ -434,60 +441,6 @@ class ModelGeneratorTest extends TestCase
 
         $this->files->expects('put')
             ->with($path, $this->fixture($model));
-
-        $tokens = $this->blueprint->parse($this->fixture($definition));
-        $tree = $this->blueprint->analyze($tokens);
-
-        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
-    }
-
-    /**
-     * @test
-     * @environment-setup useLaravel6
-     * @dataProvider docBlockModelsDataProvider
-     */
-    public function output_generates_phpdoc_for_model_l6($definition, $path, $model)
-    {
-        $this->app['config']->set('blueprint.generate_phpdocs', true);
-
-        $this->files->expects('stub')
-            ->with($this->modelStub)
-            ->andReturn($this->stub($this->modelStub));
-
-        if ($definition === 'drafts/disable-auto-columns.yaml') {
-            $this->files->expects('stub')
-                ->with('model.timestamps.stub')
-                ->andReturn($this->stub('model.timestamps.stub'));
-        }
-
-        $this->files->expects('stub')
-            ->with('model.fillable.stub')
-            ->andReturn($this->stub('model.fillable.stub'));
-
-        $this->files->expects('stub')
-            ->with('model.casts.stub')
-            ->andReturn($this->stub('model.casts.stub'));
-
-        if ($definition === 'drafts/readme-example.yaml') {
-            $this->files->expects('stub')
-                ->with('model.dates.stub')
-                ->andReturn($this->stub('model.dates.stub'));
-        }
-
-        $this->files->shouldReceive('stub')
-            ->with('model.method.stub')
-            ->andReturn($this->stub('model.method.stub'));
-
-        $this->files->shouldReceive('stub')
-            ->with('model.method.comment.stub')
-            ->andReturn($this->stub('model.method.comment.stub'));
-
-        $this->files->expects('exists')
-            ->with(dirname($path))
-            ->andReturnTrue();
-
-        $this->files->expects('put')
-            ->with($path, $this->fixture(str_replace('models', 'models/no-factory', $model)));
 
         $tokens = $this->blueprint->parse($this->fixture($definition));
         $tree = $this->blueprint->analyze($tokens);
@@ -551,6 +504,61 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
+     * @dataProvider docBlockModelsDataProvider
+     */
+    public function output_generates_phpdoc_for_model_l6($definition, $path, $model)
+    {
+        $this->app['config']->set('blueprint.generate_phpdocs', true);
+
+        $this->files->expects('stub')
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
+
+        if ($definition === 'drafts/disable-auto-columns.yaml') {
+            $this->files->expects('stub')
+                ->with('model.timestamps.stub')
+                ->andReturn($this->stub('model.timestamps.stub'));
+        }
+
+        $this->files->expects('stub')
+            ->with('model.fillable.stub')
+            ->andReturn($this->stub('model.fillable.stub'));
+
+        $this->files->expects('stub')
+            ->with('model.casts.stub')
+            ->andReturn($this->stub('model.casts.stub'));
+
+        if ($definition === 'drafts/readme-example.yaml') {
+            $this->files->expects('stub')
+                ->with('model.dates.stub')
+                ->andReturn($this->stub('model.dates.stub'));
+        }
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.stub')
+            ->andReturn($this->stub('model.method.stub'));
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.comment.stub')
+            ->andReturn($this->stub('model.method.comment.stub'));
+
+        $this->files->expects('exists')
+            ->with(dirname($path))
+            ->andReturnTrue();
+
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('models', 'models/no-factory', $model)));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel8
      */
     public function output_generates_models_with_guarded_property_when_config_option_is_set()
     {
@@ -587,6 +595,7 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_generates_models_with_custom_namespace_correctly()
     {
@@ -623,6 +632,7 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_generates_models_with_custom_pivot_columns()
     {

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Generators;
 use Blueprint\Blueprint;
 use Blueprint\Generators\ModelGenerator;
 use Blueprint\Tree;
+use Illuminate\Support\Facades\App;
 use Tests\TestCase;
 
 class ModelGeneratorTest extends TestCase
@@ -21,6 +22,7 @@ class ModelGeneratorTest extends TestCase
         parent::setUp();
 
         $this->files = \Mockery::mock();
+        $this->modelStub = version_compare(App::version(), '8.0.0', '>=') ? 'model.class.stub' : 'model.class.no-factory.stub';
         $this->subject = new ModelGenerator($this->files);
 
         $this->blueprint = new Blueprint();
@@ -34,8 +36,8 @@ class ModelGeneratorTest extends TestCase
     public function output_generates_nothing_for_empty_tree()
     {
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         $this->files->shouldNotHaveReceived('put');
 
@@ -49,8 +51,8 @@ class ModelGeneratorTest extends TestCase
     public function output_generates_models($definition, $path, $model)
     {
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         $this->files->expects('stub')
             ->with('model.fillable.stub')
@@ -100,8 +102,8 @@ class ModelGeneratorTest extends TestCase
     public function output_generates_models_l6($definition, $path, $model)
     {
         $this->files->expects('stub')
-            ->with('model.class.no-factory.stub')
-            ->andReturn($this->stub('model.class.no-factory.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         $this->files->expects('stub')
             ->with('model.fillable.stub')
@@ -151,8 +153,8 @@ class ModelGeneratorTest extends TestCase
     public function output_generates_models_l7($definition, $path, $model)
     {
         $this->files->expects('stub')
-            ->with('model.class.no-factory.stub')
-            ->andReturn($this->stub('model.class.no-factory.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         $this->files->expects('stub')
             ->with('model.fillable.stub')
@@ -200,8 +202,8 @@ class ModelGeneratorTest extends TestCase
     public function output_works_for_pascal_case_definition()
     {
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
             ->andReturn($this->stub('model.fillable.stub'))
@@ -245,8 +247,8 @@ class ModelGeneratorTest extends TestCase
     public function output_generates_relationships()
     {
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
             ->andReturn($this->stub('model.fillable.stub'));
@@ -275,8 +277,8 @@ class ModelGeneratorTest extends TestCase
     public function output_generates_polymorphic_relationships()
     {
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
         $this->files->expects('stub')
             ->times(3)
             ->with('model.fillable.stub')
@@ -320,8 +322,8 @@ class ModelGeneratorTest extends TestCase
     public function output_generates_disabled_auto_columns()
     {
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
         $this->files->expects('stub')
             ->with('model.timestamps.stub')
             ->andReturn($this->stub('model.timestamps.stub'));
@@ -357,8 +359,8 @@ class ModelGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.models_namespace', 'Models');
 
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         $this->files->expects('stub')
             ->with('model.fillable.stub')
@@ -395,8 +397,8 @@ class ModelGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.generate_phpdocs', true);
 
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         if ($definition === 'drafts/disable-auto-columns.yaml') {
             $this->files->expects('stub')
@@ -449,8 +451,8 @@ class ModelGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.generate_phpdocs', true);
 
         $this->files->expects('stub')
-            ->with('model.class.no-factory.stub')
-            ->andReturn($this->stub('model.class.no-factory.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         if ($definition === 'drafts/disable-auto-columns.yaml') {
             $this->files->expects('stub')
@@ -503,8 +505,8 @@ class ModelGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.generate_phpdocs', true);
 
         $this->files->expects('stub')
-            ->with('model.class.no-factory.stub')
-            ->andReturn($this->stub('model.class.no-factory.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         if ($definition === 'drafts/disable-auto-columns.yaml') {
             $this->files->expects('stub')
@@ -555,8 +557,8 @@ class ModelGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.use_guarded', true);
 
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
 
         $this->files->expects('stub')
             ->with('model.guarded.stub')
@@ -595,8 +597,8 @@ class ModelGeneratorTest extends TestCase
         $this->app['config']->set('blueprint.models_namespace', 'Models');
 
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
             ->andReturn($this->stub('model.fillable.stub'));
@@ -625,8 +627,8 @@ class ModelGeneratorTest extends TestCase
     public function output_generates_models_with_custom_pivot_columns()
     {
         $this->files->expects('stub')
-            ->with('model.class.stub')
-            ->andReturn($this->stub('model.class.stub'));
+            ->with($this->modelStub)
+            ->andReturn($this->stub($this->modelStub));
         $this->files->expects('stub')
             ->with('model.fillable.stub')
             ->andReturn($this->stub('model.fillable.stub'));

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -94,6 +94,108 @@ class ModelGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel6
+     * @dataProvider modelTreeDataProvider
+     */
+    public function output_generates_models_l6($definition, $path, $model)
+    {
+        $this->files->expects('stub')
+            ->with('model.class.no-factory.stub')
+            ->andReturn($this->stub('model.class.no-factory.stub'));
+
+        $this->files->expects('stub')
+            ->with('model.fillable.stub')
+            ->andReturn($this->stub('model.fillable.stub'));
+
+        if (in_array($definition, ['drafts/nested-components.yaml', 'drafts/resource-statements.yaml'])) {
+            $this->files->expects('stub')
+                ->with('model.hidden.stub')
+                ->andReturn($this->stub('model.hidden.stub'));
+        }
+
+        $this->files->expects('stub')
+            ->with('model.casts.stub')
+            ->andReturn($this->stub('model.casts.stub'));
+
+        if (in_array($definition, ['drafts/readme-example.yaml', 'drafts/all-column-types.yaml'])) {
+            $this->files->expects('stub')
+                ->with('model.dates.stub')
+                ->andReturn($this->stub('model.dates.stub'));
+        }
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.stub')
+            ->andReturn($this->stub('model.method.stub'));
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.comment.stub')
+            ->andReturn($this->stub('model.method.comment.stub'));
+
+        $this->files->expects('exists')
+            ->with(dirname($path))
+            ->andReturnTrue();
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('models', 'models/no-factory', $model)));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel7
+     * @dataProvider modelTreeDataProvider
+     */
+    public function output_generates_models_l7($definition, $path, $model)
+    {
+        $this->files->expects('stub')
+            ->with('model.class.no-factory.stub')
+            ->andReturn($this->stub('model.class.no-factory.stub'));
+
+        $this->files->expects('stub')
+            ->with('model.fillable.stub')
+            ->andReturn($this->stub('model.fillable.stub'));
+
+        if (in_array($definition, ['drafts/nested-components.yaml', 'drafts/resource-statements.yaml'])) {
+            $this->files->expects('stub')
+                ->with('model.hidden.stub')
+                ->andReturn($this->stub('model.hidden.stub'));
+        }
+
+        $this->files->expects('stub')
+            ->with('model.casts.stub')
+            ->andReturn($this->stub('model.casts.stub'));
+
+        if (in_array($definition, ['drafts/readme-example.yaml', 'drafts/all-column-types.yaml'])) {
+            $this->files->expects('stub')
+                ->with('model.dates.stub')
+                ->andReturn($this->stub('model.dates.stub'));
+        }
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.stub')
+            ->andReturn($this->stub('model.method.stub'));
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.comment.stub')
+            ->andReturn($this->stub('model.method.comment.stub'));
+
+        $this->files->expects('exists')
+            ->with(dirname($path))
+            ->andReturnTrue();
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('models', 'models/no-factory', $model)));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
      */
     public function output_works_for_pascal_case_definition()
     {
@@ -330,6 +432,114 @@ class ModelGeneratorTest extends TestCase
 
         $this->files->expects('put')
             ->with($path, $this->fixture($model));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel6
+     * @dataProvider docBlockModelsDataProvider
+     */
+    public function output_generates_phpdoc_for_model_l6($definition, $path, $model)
+    {
+        $this->app['config']->set('blueprint.generate_phpdocs', true);
+
+        $this->files->expects('stub')
+            ->with('model.class.no-factory.stub')
+            ->andReturn($this->stub('model.class.no-factory.stub'));
+
+        if ($definition === 'drafts/disable-auto-columns.yaml') {
+            $this->files->expects('stub')
+                ->with('model.timestamps.stub')
+                ->andReturn($this->stub('model.timestamps.stub'));
+        }
+
+        $this->files->expects('stub')
+            ->with('model.fillable.stub')
+            ->andReturn($this->stub('model.fillable.stub'));
+
+        $this->files->expects('stub')
+            ->with('model.casts.stub')
+            ->andReturn($this->stub('model.casts.stub'));
+
+        if ($definition === 'drafts/readme-example.yaml') {
+            $this->files->expects('stub')
+                ->with('model.dates.stub')
+                ->andReturn($this->stub('model.dates.stub'));
+        }
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.stub')
+            ->andReturn($this->stub('model.method.stub'));
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.comment.stub')
+            ->andReturn($this->stub('model.method.comment.stub'));
+
+        $this->files->expects('exists')
+            ->with(dirname($path))
+            ->andReturnTrue();
+
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('models', 'models/no-factory', $model)));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel7
+     * @dataProvider docBlockModelsDataProvider
+     */
+    public function output_generates_phpdoc_for_model_l7($definition, $path, $model)
+    {
+        $this->app['config']->set('blueprint.generate_phpdocs', true);
+
+        $this->files->expects('stub')
+            ->with('model.class.no-factory.stub')
+            ->andReturn($this->stub('model.class.no-factory.stub'));
+
+        if ($definition === 'drafts/disable-auto-columns.yaml') {
+            $this->files->expects('stub')
+                ->with('model.timestamps.stub')
+                ->andReturn($this->stub('model.timestamps.stub'));
+        }
+
+        $this->files->expects('stub')
+            ->with('model.fillable.stub')
+            ->andReturn($this->stub('model.fillable.stub'));
+
+        $this->files->expects('stub')
+            ->with('model.casts.stub')
+            ->andReturn($this->stub('model.casts.stub'));
+
+        if ($definition === 'drafts/readme-example.yaml') {
+            $this->files->expects('stub')
+                ->with('model.dates.stub')
+                ->andReturn($this->stub('model.dates.stub'));
+        }
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.stub')
+            ->andReturn($this->stub('model.method.stub'));
+
+        $this->files->shouldReceive('stub')
+            ->with('model.method.comment.stub')
+            ->andReturn($this->stub('model.method.comment.stub'));
+
+        $this->files->expects('exists')
+            ->with(dirname($path))
+            ->andReturnTrue();
+
+        $this->files->expects('put')
+            ->with($path, $this->fixture(str_replace('models', 'models/no-factory', $model)));
 
         $tokens = $this->blueprint->parse($this->fixture($definition));
         $tree = $this->blueprint->analyze($tokens);

--- a/tests/Feature/Generators/SeederGeneratorTest.php
+++ b/tests/Feature/Generators/SeederGeneratorTest.php
@@ -30,7 +30,7 @@ class SeederGeneratorTest extends TestCase
         parent::setUp();
 
         $this->files = \Mockery::mock();
-
+        $this->seederStub = version_compare(App::version(), '8.0.0', '>=') ? 'seeder.stub' : 'seeder.no-factory.stub';
         $this->subject = new SeederGenerator($this->files);
 
         $this->blueprint = new Blueprint();
@@ -51,12 +51,13 @@ class SeederGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel8
      */
     public function output_generates_seeders()
     {
         $this->files->expects('stub')
-            ->with('seeder.stub')
-            ->andReturn($this->stub('seeder.stub'));
+            ->with($this->seederStub)
+            ->andReturn($this->stub($this->seederStub));
 
         $this->files->expects('put')
             ->with('database/seeds/PostSeeder.php', $this->fixture('seeders/PostSeeder.php'));
@@ -71,17 +72,108 @@ class SeederGeneratorTest extends TestCase
 
     /**
      * @test
+     * @environment-setup useLaravel7
+     */
+    public function output_generates_seeders_l7()
+    {
+        $this->files->expects('stub')
+            ->with($this->seederStub)
+            ->andReturn($this->stub($this->seederStub));
+
+        $this->files->expects('put')
+            ->with('database/seeds/PostSeeder.php', $this->fixture('seeders/no-factory/PostSeeder.php'));
+        $this->files->expects('put')
+            ->with('database/seeds/CommentSeeder.php', $this->fixture('seeders/no-factory/CommentSeeder.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/seeders.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['database/seeds/PostSeeder.php', 'database/seeds/CommentSeeder.php']], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel6
+     */
+    public function output_generates_seeders_l6()
+    {
+        $this->files->expects('stub')
+            ->with($this->seederStub)
+            ->andReturn($this->stub($this->seederStub));
+
+        $this->files->expects('put')
+            ->with('database/seeds/PostSeeder.php', $this->fixture('seeders/no-factory/PostSeeder.php'));
+        $this->files->expects('put')
+            ->with('database/seeds/CommentSeeder.php', $this->fixture('seeders/no-factory/CommentSeeder.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/seeders.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['database/seeds/PostSeeder.php', 'database/seeds/CommentSeeder.php']], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel8
      */
     public function output_generates_seeders_from_traced_models()
     {
         $this->files->expects('stub')
-            ->with('seeder.stub')
-            ->andReturn($this->stub('seeder.stub'));
+            ->with($this->seederStub)
+            ->andReturn($this->stub($this->seederStub));
 
         $this->files->expects('put')
             ->with('database/seeds/PostSeeder.php', $this->fixture('seeders/PostSeeder.php'));
         $this->files->expects('put')
             ->with('database/seeds/CommentSeeder.php', $this->fixture('seeders/CommentSeeder.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/seeders.yaml'));
+        $tree = $this->blueprint->analyze($tokens)->toArray();
+        $tree['cache'] = $tree['models'];
+        unset($tree['models']);
+        $tree = new Tree($tree);
+
+        $this->assertEquals(['created' => ['database/seeds/PostSeeder.php', 'database/seeds/CommentSeeder.php']], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel7
+     */
+    public function output_generates_seeders_from_traced_models_l7()
+    {
+        $this->files->expects('stub')
+            ->with($this->seederStub)
+            ->andReturn($this->stub($this->seederStub));
+
+        $this->files->expects('put')
+            ->with('database/seeds/PostSeeder.php', $this->fixture('seeders/no-factory/PostSeeder.php'));
+        $this->files->expects('put')
+            ->with('database/seeds/CommentSeeder.php', $this->fixture('seeders/no-factory/CommentSeeder.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/seeders.yaml'));
+        $tree = $this->blueprint->analyze($tokens)->toArray();
+        $tree['cache'] = $tree['models'];
+        unset($tree['models']);
+        $tree = new Tree($tree);
+
+        $this->assertEquals(['created' => ['database/seeds/PostSeeder.php', 'database/seeds/CommentSeeder.php']], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     * @environment-setup useLaravel6
+     */
+    public function output_generates_seeders_from_traced_models_l6()
+    {
+        $this->files->expects('stub')
+            ->with($this->seederStub)
+            ->andReturn($this->stub($this->seederStub));
+
+        $this->files->expects('put')
+            ->with('database/seeds/PostSeeder.php', $this->fixture('seeders/no-factory/PostSeeder.php'));
+        $this->files->expects('put')
+            ->with('database/seeds/CommentSeeder.php', $this->fixture('seeders/no-factory/CommentSeeder.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/seeders.yaml'));
         $tree = $this->blueprint->analyze($tokens)->toArray();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,4 +43,14 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         \App::swap($appMock);
     }
+
+    protected function useLaravel7($app)
+    {
+        $appMock = \Mockery::mock($app);
+        $appMock->shouldReceive('version')
+            ->withNoArgs()
+            ->andReturn('7.0.0');
+
+        \App::swap($appMock);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,4 +53,14 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         \App::swap($appMock);
     }
+
+    protected function useLaravel8($app)
+    {
+        $appMock = \Mockery::mock($app);
+        $appMock->shouldReceive('version')
+            ->withNoArgs()
+            ->andReturn('8.0.0');
+
+        \App::swap($appMock);
+    }
 }

--- a/tests/fixtures/factories/all-column-types.php
+++ b/tests/fixtures/factories/all-column-types.php
@@ -1,60 +1,76 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
-use App\AllType;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use App\AllType;
 
-$factory->define(AllType::class, function (Faker $faker) {
-    return [
-        'bigInteger' => $faker->numberBetween(-100000, 100000),
-        'binary' => $faker->sha256,
-        'boolean' => $faker->boolean,
-        'char' => $faker->randomLetter,
-        'date' => $faker->date(),
-        'dateTime' => $faker->dateTime(),
-        'dateTimeTz' => $faker->dateTime(),
-        'decimal' => $faker->randomFloat(0, 0, 9999999999.),
-        'double' => $faker->randomFloat(0, 0, 9999999999.),
-        'enum' => $faker->randomElement(["1","2","3"]),
-        'float' => $faker->randomFloat(0, 0, 9999999999.),
-        'geometry' => $faker->word,
-        'geometryCollection' => $faker->word,
-        'integer' => $faker->numberBetween(-10000, 10000),
-        'ipAddress' => $faker->ipv4,
-        'json' => '{}',
-        'jsonb' => '{}',
-        'lineString' => $faker->word,
-        'longText' => $faker->text,
-        'macAddress' => $faker->macAddress,
-        'mediumInteger' => $faker->numberBetween(-10000, 10000),
-        'mediumText' => $faker->text,
-        'morphs_id' => $faker->randomDigitNotNull,
-        'morphs_type' => $faker->word,
-        'uuidMorphs' => $faker->word,
-        'multiLineString' => $faker->word,
-        'multiPoint' => $faker->word,
-        'multiPolygon' => $faker->word,
-        'point' => $faker->word,
-        'polygon' => $faker->word,
-        'rememberToken' => Str::random(10),
-        'set' => $faker->randomElement(["1","2","3"]),
-        'smallInteger' => $faker->numberBetween(-1000, 1000),
-        'string' => $faker->word,
-        'text' => $faker->text,
-        'time' => $faker->time(),
-        'timeTz' => $faker->time(),
-        'timestamp' => $faker->dateTime(),
-        'timestampTz' => $faker->dateTime(),
-        'tinyInteger' => $faker->numberBetween(-8, 8),
-        'unsignedBigInteger' => $faker->randomNumber(),
-        'unsignedDecimal' => $faker->randomNumber(),
-        'unsignedInteger' => $faker->randomNumber(),
-        'unsignedMediumInteger' => $faker->randomNumber(),
-        'unsignedSmallInteger' => $faker->randomNumber(),
-        'unsignedTinyInteger' => $faker->randomDigitNotNull,
-        'uuid' => $faker->uuid,
-        'year' => $faker->year(),
-    ];
-});
+class AllTypeFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = AllType::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'bigInteger' => $this->faker->numberBetween(-100000, 100000),
+            'binary' => $this->faker->sha256,
+            'boolean' => $this->faker->boolean,
+            'char' => $this->faker->randomLetter,
+            'date' => $this->faker->date(),
+            'dateTime' => $this->faker->dateTime(),
+            'dateTimeTz' => $this->faker->dateTime(),
+            'decimal' => $this->faker->randomFloat(0, 0, 9999999999.),
+            'double' => $this->faker->randomFloat(0, 0, 9999999999.),
+            'enum' => $this->faker->randomElement(["1","2","3"]),
+            'float' => $this->faker->randomFloat(0, 0, 9999999999.),
+            'geometry' => $this->faker->word,
+            'geometryCollection' => $this->faker->word,
+            'integer' => $this->faker->numberBetween(-10000, 10000),
+            'ipAddress' => $this->faker->ipv4,
+            'json' => '{}',
+            'jsonb' => '{}',
+            'lineString' => $this->faker->word,
+            'longText' => $this->faker->text,
+            'macAddress' => $this->faker->macAddress,
+            'mediumInteger' => $this->faker->numberBetween(-10000, 10000),
+            'mediumText' => $this->faker->text,
+            'morphs_id' => $this->faker->randomDigitNotNull,
+            'morphs_type' => $this->faker->word,
+            'uuidMorphs' => $this->faker->word,
+            'multiLineString' => $this->faker->word,
+            'multiPoint' => $this->faker->word,
+            'multiPolygon' => $this->faker->word,
+            'point' => $this->faker->word,
+            'polygon' => $this->faker->word,
+            'rememberToken' => Str::random(10),
+            'set' => $this->faker->randomElement(["1","2","3"]),
+            'smallInteger' => $this->faker->numberBetween(-1000, 1000),
+            'string' => $this->faker->word,
+            'text' => $this->faker->text,
+            'time' => $this->faker->time(),
+            'timeTz' => $this->faker->time(),
+            'timestamp' => $this->faker->dateTime(),
+            'timestampTz' => $this->faker->dateTime(),
+            'tinyInteger' => $this->faker->numberBetween(-8, 8),
+            'unsignedBigInteger' => $this->faker->randomNumber(),
+            'unsignedDecimal' => $this->faker->randomNumber(),
+            'unsignedInteger' => $this->faker->randomNumber(),
+            'unsignedMediumInteger' => $this->faker->randomNumber(),
+            'unsignedSmallInteger' => $this->faker->randomNumber(),
+            'unsignedTinyInteger' => $this->faker->randomDigitNotNull,
+            'uuid' => $this->faker->uuid,
+            'year' => $this->faker->year(),
+        ];
+    }
+}

--- a/tests/fixtures/factories/closure-based/all-column-types.php
+++ b/tests/fixtures/factories/closure-based/all-column-types.php
@@ -1,0 +1,60 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\AllType;
+use Faker\Generator as Faker;
+use Illuminate\Support\Str;
+
+$factory->define(AllType::class, function (Faker $faker) {
+    return [
+        'bigInteger' => $faker->numberBetween(-100000, 100000),
+        'binary' => $faker->sha256,
+        'boolean' => $faker->boolean,
+        'char' => $faker->randomLetter,
+        'date' => $faker->date(),
+        'dateTime' => $faker->dateTime(),
+        'dateTimeTz' => $faker->dateTime(),
+        'decimal' => $faker->randomFloat(0, 0, 9999999999.),
+        'double' => $faker->randomFloat(0, 0, 9999999999.),
+        'enum' => $faker->randomElement(["1","2","3"]),
+        'float' => $faker->randomFloat(0, 0, 9999999999.),
+        'geometry' => $faker->word,
+        'geometryCollection' => $faker->word,
+        'integer' => $faker->numberBetween(-10000, 10000),
+        'ipAddress' => $faker->ipv4,
+        'json' => '{}',
+        'jsonb' => '{}',
+        'lineString' => $faker->word,
+        'longText' => $faker->text,
+        'macAddress' => $faker->macAddress,
+        'mediumInteger' => $faker->numberBetween(-10000, 10000),
+        'mediumText' => $faker->text,
+        'morphs_id' => $faker->randomDigitNotNull,
+        'morphs_type' => $faker->word,
+        'uuidMorphs' => $faker->word,
+        'multiLineString' => $faker->word,
+        'multiPoint' => $faker->word,
+        'multiPolygon' => $faker->word,
+        'point' => $faker->word,
+        'polygon' => $faker->word,
+        'rememberToken' => Str::random(10),
+        'set' => $faker->randomElement(["1","2","3"]),
+        'smallInteger' => $faker->numberBetween(-1000, 1000),
+        'string' => $faker->word,
+        'text' => $faker->text,
+        'time' => $faker->time(),
+        'timeTz' => $faker->time(),
+        'timestamp' => $faker->dateTime(),
+        'timestampTz' => $faker->dateTime(),
+        'tinyInteger' => $faker->numberBetween(-8, 8),
+        'unsignedBigInteger' => $faker->randomNumber(),
+        'unsignedDecimal' => $faker->randomNumber(),
+        'unsignedInteger' => $faker->randomNumber(),
+        'unsignedMediumInteger' => $faker->randomNumber(),
+        'unsignedSmallInteger' => $faker->randomNumber(),
+        'unsignedTinyInteger' => $faker->randomDigitNotNull,
+        'uuid' => $faker->uuid,
+        'year' => $faker->year(),
+    ];
+});

--- a/tests/fixtures/factories/closure-based/factory-smallint-and-tinyint.php
+++ b/tests/fixtures/factories/closure-based/factory-smallint-and-tinyint.php
@@ -1,0 +1,13 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Model;
+use Faker\Generator as Faker;
+
+$factory->define(Model::class, function (Faker $faker) {
+    return [
+        'market_type' => $faker->numberBetween(-8, 8),
+        'deposit' => $faker->randomNumber(),
+    ];
+});

--- a/tests/fixtures/factories/closure-based/fake-nullables.php
+++ b/tests/fixtures/factories/closure-based/fake-nullables.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Post;
+use Faker\Generator as Faker;
+
+$factory->define(Post::class, function (Faker $faker) {
+    return [
+        'title' => $faker->sentence(4),
+        'content' => $faker->paragraphs(3, true),
+        'author_id' => factory(\App\User::class),
+    ];
+});

--- a/tests/fixtures/factories/closure-based/foreign-key-shorthand.php
+++ b/tests/fixtures/factories/closure-based/foreign-key-shorthand.php
@@ -1,0 +1,16 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Comment;
+use Faker\Generator as Faker;
+
+$factory->define(Comment::class, function (Faker $faker) {
+    return [
+        'post_id' => factory(\App\Post::class),
+        'author_id' => factory(\App\User::class),
+        'ccid' => function () {
+            return factory(\App\Country::class)->create()->code;
+        },
+    ];
+});

--- a/tests/fixtures/factories/closure-based/model-key-constraints.php
+++ b/tests/fixtures/factories/closure-based/model-key-constraints.php
@@ -1,0 +1,16 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Order;
+use Faker\Generator as Faker;
+
+$factory->define(Order::class, function (Faker $faker) {
+    return [
+        'user_id' => factory(\App\User::class),
+        'external_id' => $faker->word,
+        'sub_id' => factory(\App\Subscription::class),
+        'expires_at' => $faker->dateTime(),
+        'meta' => '[]',
+    ];
+});

--- a/tests/fixtures/factories/closure-based/model-modifiers.php
+++ b/tests/fixtures/factories/closure-based/model-modifiers.php
@@ -1,0 +1,19 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Modifier;
+use Faker\Generator as Faker;
+
+$factory->define(Modifier::class, function (Faker $faker) {
+    return [
+        'title' => $faker->sentence(4),
+        'name' => $faker->name,
+        'content' => $faker->paragraphs(3, true),
+        'amount' => $faker->randomFloat(3, 0, 999999.999),
+        'total' => $faker->randomFloat(2, 0, 99999999.99),
+        'overflow' => $faker->randomFloat(30, 0, 99999999999999999999999999999999999.999999999999999999999999999999),
+        'ssn' => $faker->ssn,
+        'role' => $faker->randomElement(["user","admin","owner"]),
+    ];
+});

--- a/tests/fixtures/factories/closure-based/nested-components.php
+++ b/tests/fixtures/factories/closure-based/nested-components.php
@@ -1,0 +1,13 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Admin\User;
+use Faker\Generator as Faker;
+
+$factory->define(User::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'password' => $faker->password,
+    ];
+});

--- a/tests/fixtures/factories/closure-based/phone.php
+++ b/tests/fixtures/factories/closure-based/phone.php
@@ -1,0 +1,18 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Phone;
+use Faker\Generator as Faker;
+
+$factory->define(Phone::class, function (Faker $faker) {
+    return [
+        'label' => $faker->word,
+        'user_id' => factory(\App\User::class),
+        'phone_number' => $faker->phoneNumber,
+        'type' => $faker->randomElement(["home","cell"]),
+        'status' => $faker->randomElement(["archived","deleted"]),
+        'foo_id' => $faker->randomDigitNotNull,
+        'foo_type' => $faker->word,
+    ];
+});

--- a/tests/fixtures/factories/closure-based/post-configured.php
+++ b/tests/fixtures/factories/closure-based/post-configured.php
@@ -1,0 +1,17 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator as Faker;
+use Some\App\Models\Post;
+
+$factory->define(Post::class, function (Faker $faker) {
+    return [
+        'title' => $faker->sentence(4),
+        'author_id' => factory(\Some\App\Models\Author::class),
+        'author_bio' => $faker->text,
+        'content' => $faker->paragraphs(3, true),
+        'published_at' => $faker->dateTime(),
+        'word_count' => $faker->randomNumber(),
+    ];
+});

--- a/tests/fixtures/factories/closure-based/post.php
+++ b/tests/fixtures/factories/closure-based/post.php
@@ -1,0 +1,17 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Post;
+use Faker\Generator as Faker;
+
+$factory->define(Post::class, function (Faker $faker) {
+    return [
+        'title' => $faker->sentence(4),
+        'author_id' => factory(\App\Author::class),
+        'author_bio' => $faker->text,
+        'content' => $faker->paragraphs(3, true),
+        'published_at' => $faker->dateTime(),
+        'word_count' => $faker->randomNumber(),
+    ];
+});

--- a/tests/fixtures/factories/closure-based/resource-statements.php
+++ b/tests/fixtures/factories/closure-based/resource-statements.php
@@ -1,0 +1,16 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\User;
+use Faker\Generator as Faker;
+use Illuminate\Support\Str;
+
+$factory->define(User::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'email' => $faker->safeEmail,
+        'password' => $faker->password,
+        'remember_token' => Str::random(10),
+    ];
+});

--- a/tests/fixtures/factories/closure-based/team.php
+++ b/tests/fixtures/factories/closure-based/team.php
@@ -1,0 +1,13 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Team;
+use Faker\Generator as Faker;
+
+$factory->define(Team::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'owner_id' => factory(\App\User::class),
+    ];
+});

--- a/tests/fixtures/factories/closure-based/unconventional-foreign-key.php
+++ b/tests/fixtures/factories/closure-based/unconventional-foreign-key.php
@@ -1,0 +1,22 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\State;
+use Faker\Generator as Faker;
+
+$factory->define(State::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'countries_id' => factory(\App\Country::class),
+        'country_code' => function () {
+            return factory(\App\Country::class)->create()->code;
+        },
+        'ccid' => function () {
+            return factory(\App\Country::class)->create()->ccid;
+        },
+        'c_code' => function () {
+            return factory(\App\Country::class)->create()->code;
+        },
+    ];
+});

--- a/tests/fixtures/factories/closure-based/unconventional.php
+++ b/tests/fixtures/factories/closure-based/unconventional.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Team;
+use Faker\Generator as Faker;
+
+$factory->define(Team::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'owner' => factory(\App\Owner::class),
+        'manager' => factory(\App\User::class),
+        'options' => '{}',
+    ];
+});

--- a/tests/fixtures/factories/factory-smallint-and-tinyint.php
+++ b/tests/fixtures/factories/factory-smallint-and-tinyint.php
@@ -1,13 +1,30 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use App\Model;
-use Faker\Generator as Faker;
 
-$factory->define(Model::class, function (Faker $faker) {
-    return [
-        'market_type' => $faker->numberBetween(-8, 8),
-        'deposit' => $faker->randomNumber(),
-    ];
-});
+class ModelFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Model::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'market_type' => $this->faker->numberBetween(-8, 8),
+            'deposit' => $this->faker->randomNumber(),
+        ];
+    }
+}

--- a/tests/fixtures/factories/fake-nullables.php
+++ b/tests/fixtures/factories/fake-nullables.php
@@ -1,14 +1,32 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use App\Post;
-use Faker\Generator as Faker;
+use App\User;
 
-$factory->define(Post::class, function (Faker $faker) {
-    return [
-        'title' => $faker->sentence(4),
-        'content' => $faker->paragraphs(3, true),
-        'author_id' => factory(\App\User::class),
-    ];
-});
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Post::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->sentence(4),
+            'content' => $this->faker->paragraphs(3, true),
+            'author_id' => User::factory(),
+        ];
+    }
+}

--- a/tests/fixtures/factories/foreign-key-shorthand.php
+++ b/tests/fixtures/factories/foreign-key-shorthand.php
@@ -1,16 +1,34 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use App\Comment;
-use Faker\Generator as Faker;
+use App\Country;
+use App\Post;
+use App\User;
 
-$factory->define(Comment::class, function (Faker $faker) {
-    return [
-        'post_id' => factory(\App\Post::class),
-        'author_id' => factory(\App\User::class),
-        'ccid' => function () {
-            return factory(\App\Country::class)->create()->code;
-        },
-    ];
-});
+class CommentFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Comment::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'post_id' => Post::factory(),
+            'author_id' => User::factory(),
+            'ccid' => Country::factory()->create()->code,
+        ];
+    }
+}

--- a/tests/fixtures/factories/model-key-constraints.php
+++ b/tests/fixtures/factories/model-key-constraints.php
@@ -1,16 +1,35 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use App\Order;
-use Faker\Generator as Faker;
+use App\Subscription;
+use App\User;
 
-$factory->define(Order::class, function (Faker $faker) {
-    return [
-        'user_id' => factory(\App\User::class),
-        'external_id' => $faker->word,
-        'sub_id' => factory(\App\Subscription::class),
-        'expires_at' => $faker->dateTime(),
-        'meta' => '[]',
-    ];
-});
+class OrderFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Order::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'external_id' => $this->faker->word,
+            'sub_id' => Subscription::factory(),
+            'expires_at' => $this->faker->dateTime(),
+            'meta' => '[]',
+        ];
+    }
+}

--- a/tests/fixtures/factories/model-modifiers.php
+++ b/tests/fixtures/factories/model-modifiers.php
@@ -1,19 +1,36 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use App\Modifier;
-use Faker\Generator as Faker;
 
-$factory->define(Modifier::class, function (Faker $faker) {
-    return [
-        'title' => $faker->sentence(4),
-        'name' => $faker->name,
-        'content' => $faker->paragraphs(3, true),
-        'amount' => $faker->randomFloat(3, 0, 999999.999),
-        'total' => $faker->randomFloat(2, 0, 99999999.99),
-        'overflow' => $faker->randomFloat(30, 0, 99999999999999999999999999999999999.999999999999999999999999999999),
-        'ssn' => $faker->ssn,
-        'role' => $faker->randomElement(["user","admin","owner"]),
-    ];
-});
+class ModifierFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Modifier::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->sentence(4),
+            'name' => $this->faker->name,
+            'content' => $this->faker->paragraphs(3, true),
+            'amount' => $this->faker->randomFloat(3, 0, 999999.999),
+            'total' => $this->faker->randomFloat(2, 0, 99999999.99),
+            'overflow' => $this->faker->randomFloat(30, 0, 99999999999999999999999999999999999.999999999999999999999999999999),
+            'ssn' => $this->faker->ssn,
+            'role' => $this->faker->randomElement(["user","admin","owner"]),
+        ];
+    }
+}

--- a/tests/fixtures/factories/nested-components.php
+++ b/tests/fixtures/factories/nested-components.php
@@ -1,13 +1,30 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use App\Admin\User;
-use Faker\Generator as Faker;
 
-$factory->define(User::class, function (Faker $faker) {
-    return [
-        'name' => $faker->name,
-        'password' => $faker->password,
-    ];
-});
+class UserFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+            'password' => $this->faker->password,
+        ];
+    }
+}

--- a/tests/fixtures/factories/phone.php
+++ b/tests/fixtures/factories/phone.php
@@ -1,18 +1,36 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use App\Phone;
-use Faker\Generator as Faker;
+use App\User;
 
-$factory->define(Phone::class, function (Faker $faker) {
-    return [
-        'label' => $faker->word,
-        'user_id' => factory(\App\User::class),
-        'phone_number' => $faker->phoneNumber,
-        'type' => $faker->randomElement(["home","cell"]),
-        'status' => $faker->randomElement(["archived","deleted"]),
-        'foo_id' => $faker->randomDigitNotNull,
-        'foo_type' => $faker->word,
-    ];
-});
+class PhoneFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Phone::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'label' => $this->faker->word,
+            'user_id' => User::factory(),
+            'phone_number' => $this->faker->phoneNumber,
+            'type' => $this->faker->randomElement(["home","cell"]),
+            'status' => $this->faker->randomElement(["archived","deleted"]),
+            'foo_id' => $this->faker->randomDigitNotNull,
+            'foo_type' => $this->faker->word,
+        ];
+    }
+}

--- a/tests/fixtures/factories/post-configured.php
+++ b/tests/fixtures/factories/post-configured.php
@@ -1,17 +1,35 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use Some\App\Models\Author;
 use Some\App\Models\Post;
 
-$factory->define(Post::class, function (Faker $faker) {
-    return [
-        'title' => $faker->sentence(4),
-        'author_id' => factory(\Some\App\Models\Author::class),
-        'author_bio' => $faker->text,
-        'content' => $faker->paragraphs(3, true),
-        'published_at' => $faker->dateTime(),
-        'word_count' => $faker->randomNumber(),
-    ];
-});
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Post::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->sentence(4),
+            'author_id' => Author::factory(),
+            'author_bio' => $this->faker->text,
+            'content' => $this->faker->paragraphs(3, true),
+            'published_at' => $this->faker->dateTime(),
+            'word_count' => $this->faker->randomNumber(),
+        ];
+    }
+}

--- a/tests/fixtures/factories/post.php
+++ b/tests/fixtures/factories/post.php
@@ -1,17 +1,35 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use App\Author;
 use App\Post;
-use Faker\Generator as Faker;
 
-$factory->define(Post::class, function (Faker $faker) {
-    return [
-        'title' => $faker->sentence(4),
-        'author_id' => factory(\App\Author::class),
-        'author_bio' => $faker->text,
-        'content' => $faker->paragraphs(3, true),
-        'published_at' => $faker->dateTime(),
-        'word_count' => $faker->randomNumber(),
-    ];
-});
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Post::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->sentence(4),
+            'author_id' => Author::factory(),
+            'author_bio' => $this->faker->text,
+            'content' => $this->faker->paragraphs(3, true),
+            'published_at' => $this->faker->dateTime(),
+            'word_count' => $this->faker->randomNumber(),
+        ];
+    }
+}

--- a/tests/fixtures/factories/resource-statements.php
+++ b/tests/fixtures/factories/resource-statements.php
@@ -1,16 +1,32 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
-use App\User;
-use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use App\User;
 
-$factory->define(User::class, function (Faker $faker) {
-    return [
-        'name' => $faker->name,
-        'email' => $faker->safeEmail,
-        'password' => $faker->password,
-        'remember_token' => Str::random(10),
-    ];
-});
+class UserFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+            'email' => $this->faker->safeEmail,
+            'password' => $this->faker->password,
+            'remember_token' => Str::random(10),
+        ];
+    }
+}

--- a/tests/fixtures/factories/team.php
+++ b/tests/fixtures/factories/team.php
@@ -1,13 +1,31 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use App\Team;
-use Faker\Generator as Faker;
+use App\User;
 
-$factory->define(Team::class, function (Faker $faker) {
-    return [
-        'name' => $faker->name,
-        'owner_id' => factory(\App\User::class),
-    ];
-});
+class TeamFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Team::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+            'owner_id' => User::factory(),
+        ];
+    }
+}

--- a/tests/fixtures/factories/unconventional-foreign-key.php
+++ b/tests/fixtures/factories/unconventional-foreign-key.php
@@ -1,22 +1,34 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use App\Country;
 use App\State;
-use Faker\Generator as Faker;
 
-$factory->define(State::class, function (Faker $faker) {
-    return [
-        'name' => $faker->name,
-        'countries_id' => factory(\App\Country::class),
-        'country_code' => function () {
-            return factory(\App\Country::class)->create()->code;
-        },
-        'ccid' => function () {
-            return factory(\App\Country::class)->create()->ccid;
-        },
-        'c_code' => function () {
-            return factory(\App\Country::class)->create()->code;
-        },
-    ];
-});
+class StateFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = State::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+            'countries_id' => Country::factory(),
+            'country_code' => Country::factory()->create()->code,
+            'ccid' => Country::factory()->create()->ccid,
+            'c_code' => Country::factory()->create()->code,
+        ];
+    }
+}

--- a/tests/fixtures/factories/unconventional.php
+++ b/tests/fixtures/factories/unconventional.php
@@ -1,15 +1,34 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
+namespace Database\Factories;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use App\Owner;
 use App\Team;
-use Faker\Generator as Faker;
+use App\User;
 
-$factory->define(Team::class, function (Faker $faker) {
-    return [
-        'name' => $faker->name,
-        'owner' => factory(\App\Owner::class),
-        'manager' => factory(\App\User::class),
-        'options' => '{}',
-    ];
-});
+class TeamFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Team::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+            'owner' => Owner::factory(),
+            'manager' => User::factory(),
+            'options' => '{}',
+        ];
+    }
+}

--- a/tests/fixtures/models/alias-relationships.php
+++ b/tests/fixtures/models/alias-relationships.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Salesman extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/all-column-types.php
+++ b/tests/fixtures/models/all-column-types.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class AllType extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/certificate-pascal-case-example.php
+++ b/tests/fixtures/models/certificate-pascal-case-example.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Certificate extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/certificate-type-pascal-case-example.php
+++ b/tests/fixtures/models/certificate-type-pascal-case-example.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class CertificateType extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/comment.php
+++ b/tests/fixtures/models/comment.php
@@ -2,12 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Comment extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/tests/fixtures/models/custom-models-namespace.php
+++ b/tests/fixtures/models/custom-models-namespace.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Tag extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/tests/fixtures/models/custom-pivot-table-name.php
+++ b/tests/fixtures/models/custom-pivot-table-name.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/disable-auto-columns-phpdoc.php
+++ b/tests/fixtures/models/disable-auto-columns-phpdoc.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class State extends Model
 {
+    use HasFactory;
+
     /**
      * Indicates if the model should be timestamped.
      *

--- a/tests/fixtures/models/disable-auto-columns.php
+++ b/tests/fixtures/models/disable-auto-columns.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class State extends Model
 {
+    use HasFactory;
+
     /**
      * Indicates if the model should be timestamped.
      *

--- a/tests/fixtures/models/foreign-key-shorthand-phpdoc.php
+++ b/tests/fixtures/models/foreign-key-shorthand-phpdoc.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Comment extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/image-polymorphic-relationship.php
+++ b/tests/fixtures/models/image-polymorphic-relationship.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Image extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/model-configured.php
+++ b/tests/fixtures/models/model-configured.php
@@ -2,10 +2,13 @@
 
 namespace Some\App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Comment extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/model-guarded.php
+++ b/tests/fixtures/models/model-guarded.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Comment extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/tests/fixtures/models/model-relationships.php
+++ b/tests/fixtures/models/model-relationships.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Subscription extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/nested-components.php
+++ b/tests/fixtures/models/nested-components.php
@@ -2,10 +2,13 @@
 
 namespace App\Admin;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/no-factory/alias-relationships.php
+++ b/tests/fixtures/models/no-factory/alias-relationships.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Salesman extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+
+
+    public function lead()
+    {
+        return $this->hasOne(\App\User::class);
+    }
+
+    public function methodNames()
+    {
+        return $this->hasMany(\App\ClassName::class);
+    }
+
+    public function methodName()
+    {
+        return $this->belongsTo(\App\ClassName::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/all-column-types.php
+++ b/tests/fixtures/models/no-factory/all-column-types.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AllType extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'bigInteger',
+        'binary',
+        'boolean',
+        'char',
+        'date',
+        'dateTime',
+        'dateTimeTz',
+        'decimal',
+        'double',
+        'enum',
+        'float',
+        'geometry',
+        'geometryCollection',
+        'integer',
+        'ipAddress',
+        'json',
+        'jsonb',
+        'lineString',
+        'longText',
+        'macAddress',
+        'mediumInteger',
+        'mediumText',
+        'morphs',
+        'uuidMorphs',
+        'multiLineString',
+        'multiPoint',
+        'multiPolygon',
+        'nullableMorphs',
+        'nullableUuidMorphs',
+        'nullableTimestamps',
+        'point',
+        'polygon',
+        'rememberToken',
+        'set',
+        'smallInteger',
+        'string',
+        'text',
+        'time',
+        'timeTz',
+        'timestamp',
+        'timestampTz',
+        'tinyInteger',
+        'unsignedBigInteger',
+        'unsignedDecimal',
+        'unsignedInteger',
+        'unsignedMediumInteger',
+        'unsignedSmallInteger',
+        'unsignedTinyInteger',
+        'uuid',
+        'year',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'bigInteger' => 'integer',
+        'boolean' => 'boolean',
+        'decimal' => 'decimal',
+        'double' => 'double',
+        'float' => 'float',
+        'json' => 'array',
+        'mediumInteger' => 'integer',
+        'smallInteger' => 'integer',
+        'tinyInteger' => 'integer',
+        'unsignedBigInteger' => 'integer',
+        'unsignedDecimal' => 'decimal',
+        'unsignedInteger' => 'integer',
+        'unsignedMediumInteger' => 'integer',
+        'unsignedSmallInteger' => 'integer',
+        'unsignedTinyInteger' => 'integer',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'date',
+        'dateTime',
+        'dateTimeTz',
+        'nullableTimestamps',
+        'timestamp',
+        'timestampTz',
+    ];
+
+
+    public function uuid()
+    {
+        return $this->belongsTo(\App\Uuid::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/certificate-pascal-case-example.php
+++ b/tests/fixtures/models/no-factory/certificate-pascal-case-example.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Certificate extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'certificate_type_id',
+        'reference',
+        'document',
+        'expiry_date',
+        'remarks',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'certificate_type_id' => 'integer',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'expiry_date',
+    ];
+
+
+    public function certificateType()
+    {
+        return $this->belongsTo(\App\CertificateType::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/certificate-type-pascal-case-example.php
+++ b/tests/fixtures/models/no-factory/certificate-type-pascal-case-example.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CertificateType extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+
+
+    public function certificates()
+    {
+        return $this->hasMany(\App\Certificate::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/comment.php
+++ b/tests/fixtures/models/no-factory/comment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Comment extends Model
+{
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+}

--- a/tests/fixtures/models/no-factory/custom-models-namespace.php
+++ b/tests/fixtures/models/no-factory/custom-models-namespace.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Tag extends Model
+{
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'icon',
+        'active',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'active' => 'boolean',
+    ];
+}

--- a/tests/fixtures/models/no-factory/custom-pivot-table-name.php
+++ b/tests/fixtures/models/no-factory/custom-pivot-table-name.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'remember_token',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+
+
+    public function accounts()
+    {
+        return $this->belongsToMany(\App\Account::class, 'test');
+    }
+}

--- a/tests/fixtures/models/no-factory/disable-auto-columns-phpdoc.php
+++ b/tests/fixtures/models/no-factory/disable-auto-columns-phpdoc.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $name
+ * @property string $code
+ * @property int $country_id
+ */
+class State extends Model
+{
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'code',
+        'country_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'country_id' => 'integer',
+    ];
+}

--- a/tests/fixtures/models/no-factory/disable-auto-columns.php
+++ b/tests/fixtures/models/no-factory/disable-auto-columns.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class State extends Model
+{
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'code',
+        'country_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'country_id' => 'integer',
+    ];
+}

--- a/tests/fixtures/models/no-factory/foreign-key-shorthand-phpdoc.php
+++ b/tests/fixtures/models/no-factory/foreign-key-shorthand-phpdoc.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $post_id
+ * @property int $author_id
+ * @property int $ccid
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class Comment extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'post_id',
+        'author_id',
+        'ccid',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'post_id' => 'integer',
+        'author_id' => 'integer',
+        'ccid' => 'integer',
+    ];
+
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function post()
+    {
+        return $this->belongsTo(\App\Post::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function author()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function country()
+    {
+        return $this->belongsTo(\App\Country::class, 'ccid', 'code');
+    }
+}

--- a/tests/fixtures/models/no-factory/image-polymorphic-relationship.php
+++ b/tests/fixtures/models/no-factory/image-polymorphic-relationship.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Image extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'url',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+
+
+    public function imageable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/fixtures/models/no-factory/model-configured.php
+++ b/tests/fixtures/models/no-factory/model-configured.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Some\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'post_id',
+        'author_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'post_id' => 'integer',
+        'author_id' => 'integer',
+    ];
+
+
+    public function post()
+    {
+        return $this->belongsTo(\Some\App\Models\Post::class);
+    }
+
+    public function author()
+    {
+        return $this->belongsTo(\Some\App\Models\User::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/model-guarded.php
+++ b/tests/fixtures/models/no-factory/model-guarded.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+}

--- a/tests/fixtures/models/no-factory/model-relationships.php
+++ b/tests/fixtures/models/no-factory/model-relationships.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Subscription extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'user_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'user_id' => 'integer',
+    ];
+
+
+    public function teams()
+    {
+        return $this->belongsToMany(\App\Team::class);
+    }
+
+    public function orders()
+    {
+        return $this->hasMany(\App\Order::class);
+    }
+
+    public function duration()
+    {
+        return $this->hasOne(\App\Duration::class);
+    }
+
+    public function transaction()
+    {
+        return $this->hasOne(\App\Transaction::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/nested-components.php
+++ b/tests/fixtures/models/no-factory/nested-components.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+}

--- a/tests/fixtures/models/no-factory/post-polymorphic-relationship.php
+++ b/tests/fixtures/models/no-factory/post-polymorphic-relationship.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+
+
+    public function images()
+    {
+        return $this->morphMany(\App\Image::class, 'imageable');
+    }
+}

--- a/tests/fixtures/models/no-factory/readme-example-phpdoc.php
+++ b/tests/fixtures/models/no-factory/readme-example-phpdoc.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $title
+ * @property string $content
+ * @property \Carbon\Carbon $published_at
+ * @property int $author_id
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class Post extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'title',
+        'content',
+        'published_at',
+        'author_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'author_id' => 'integer',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'published_at',
+    ];
+
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function author()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/readme-example.php
+++ b/tests/fixtures/models/no-factory/readme-example.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'title',
+        'content',
+        'published_at',
+        'author_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'author_id' => 'integer',
+    ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'published_at',
+    ];
+
+
+    public function author()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/relationships-phpdoc.php
+++ b/tests/fixtures/models/no-factory/relationships-phpdoc.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $post_id
+ * @property int $author_id
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class Comment extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'post_id',
+        'author_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'post_id' => 'integer',
+        'author_id' => 'integer',
+    ];
+
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function post()
+    {
+        return $this->belongsTo(\App\Post::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function author()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/relationships.php
+++ b/tests/fixtures/models/no-factory/relationships.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'post_id',
+        'author_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'post_id' => 'integer',
+        'author_id' => 'integer',
+    ];
+
+
+    public function post()
+    {
+        return $this->belongsTo(\App\Post::class);
+    }
+
+    public function author()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/resource-statements.php
+++ b/tests/fixtures/models/no-factory/resource-statements.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+}

--- a/tests/fixtures/models/no-factory/soft-deletes-phpdoc.php
+++ b/tests/fixtures/models/no-factory/soft-deletes-phpdoc.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property int $id
+ * @property int $post_id
+ * @property \Carbon\Carbon $deleted_at
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class Comment extends Model
+{
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'post_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'post_id' => 'integer',
+    ];
+
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function post()
+    {
+        return $this->belongsTo(\App\Post::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/soft-deletes.php
+++ b/tests/fixtures/models/no-factory/soft-deletes.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Comment extends Model
+{
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'post_id',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'post_id' => 'integer',
+    ];
+
+
+    public function post()
+    {
+        return $this->belongsTo(\App\Post::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/unconventional.php
+++ b/tests/fixtures/models/no-factory/unconventional.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'owner',
+        'manager',
+        'options',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'owner' => 'integer',
+        'manager' => 'integer',
+        'options' => 'array',
+    ];
+
+
+    public function owner()
+    {
+        return $this->belongsTo(\App\Owner::class);
+    }
+
+    public function manager()
+    {
+        return $this->belongsTo(\App\User::class);
+    }
+}

--- a/tests/fixtures/models/no-factory/user-polymorphic-relationship.php
+++ b/tests/fixtures/models/no-factory/user-polymorphic-relationship.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'id' => 'integer',
+    ];
+
+
+    public function images()
+    {
+        return $this->morphMany(\App\Image::class, 'imageable');
+    }
+}

--- a/tests/fixtures/models/post-polymorphic-relationship.php
+++ b/tests/fixtures/models/post-polymorphic-relationship.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/readme-example-phpdoc.php
+++ b/tests/fixtures/models/readme-example-phpdoc.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Post extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/readme-example.php
+++ b/tests/fixtures/models/readme-example.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/relationships-phpdoc.php
+++ b/tests/fixtures/models/relationships-phpdoc.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Comment extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/relationships.php
+++ b/tests/fixtures/models/relationships.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Comment extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/resource-statements.php
+++ b/tests/fixtures/models/resource-statements.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/soft-deletes-phpdoc.php
+++ b/tests/fixtures/models/soft-deletes-phpdoc.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -14,7 +15,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  */
 class Comment extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/tests/fixtures/models/soft-deletes.php
+++ b/tests/fixtures/models/soft-deletes.php
@@ -2,12 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Comment extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/tests/fixtures/models/unconventional.php
+++ b/tests/fixtures/models/unconventional.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Team extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/models/user-polymorphic-relationship.php
+++ b/tests/fixtures/models/user-polymorphic-relationship.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/fixtures/seeders/CommentSeeder.php
+++ b/tests/fixtures/seeders/CommentSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Database\Seeders;
+
+use App\Blog\Comment;
 use Illuminate\Database\Seeder;
 
 class CommentSeeder extends Seeder
@@ -11,6 +14,6 @@ class CommentSeeder extends Seeder
      */
     public function run()
     {
-        factory(\App\Blog\Comment::class, 5)->create();
+        Comment::factory()->times(5)->create();
     }
 }

--- a/tests/fixtures/seeders/PostSeeder.php
+++ b/tests/fixtures/seeders/PostSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Database\Seeders;
+
+use App\Post;
 use Illuminate\Database\Seeder;
 
 class PostSeeder extends Seeder
@@ -11,6 +14,6 @@ class PostSeeder extends Seeder
      */
     public function run()
     {
-        factory(\App\Post::class, 5)->create();
+        Post::factory()->times(5)->create();
     }
 }

--- a/tests/fixtures/seeders/no-factory/CommentSeeder.php
+++ b/tests/fixtures/seeders/no-factory/CommentSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class CommentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(\App\Blog\Comment::class, 5)->create();
+    }
+}

--- a/tests/fixtures/seeders/no-factory/PostSeeder.php
+++ b/tests/fixtures/seeders/no-factory/PostSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class PostSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(\App\Post::class, 5)->create();
+    }
+}


### PR DESCRIPTION
- Add `useLaravel7()`  and `useLaravel8()` environment setup in `TestCase`
- Update `FactoryGenerator`
- Update `ModelGenerator`
- Update `SeederGenerator`
- Backward compatible with Laravel 6 & 7 
