### PR TITLE
View generator test and fixtures

### DIFF
--- a/stubs/view.stub
+++ b/stubs/view.stub
@@ -1,5 +1,7 @@
-@extends('layouts.app')
+{--
+    @extends('layouts.app')
 
-@section('content')
-    {{ view }} template
-@endsection
+    @section('content')
+        {{ view }} template
+    @endsection
+--}

--- a/tests/Feature/Generators/Statements/ViewGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/ViewGeneratorTest.php
@@ -68,10 +68,9 @@ class ViewGeneratorTest extends TestCase
      */
     public function output_writes_views_for_render_statements()
     {
-        $template = $this->stub('view.stub');
         $this->files->expects('stub')
             ->with('view.stub')
-            ->andReturn($template);
+            ->andReturn($this->stub('view.stub'));
 
         $this->files->shouldReceive('exists')
             ->times(2)
@@ -81,13 +80,13 @@ class ViewGeneratorTest extends TestCase
             ->with('resources/views/user/index.blade.php')
             ->andReturnFalse();
         $this->files->expects('put')
-            ->with('resources/views/user/index.blade.php', str_replace('{{ view }}', 'user.index', $template));
+            ->with('resources/views/user/index.blade.php', $this->fixture('views/user.index.blade.php'));
 
         $this->files->expects('exists')
             ->with('resources/views/user/create.blade.php')
             ->andReturnFalse();
         $this->files->expects('put')
-            ->with('resources/views/user/create.blade.php', str_replace('{{ view }}', 'user.create', $template));
+            ->with('resources/views/user/create.blade.php', $this->fixture('views/user.create.blade.php'));
 
         $this->files->expects('exists')
             ->with('resources/views/post')
@@ -98,7 +97,7 @@ class ViewGeneratorTest extends TestCase
         $this->files->expects('makeDirectory')
             ->with('resources/views/post', 0755, true);
         $this->files->expects('put')
-            ->with('resources/views/post/show.blade.php', str_replace('{{ view }}', 'post.show', $template));
+            ->with('resources/views/post/show.blade.php', $this->fixture('views/post.show.blade.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/render-statements.yaml'));
         $tree = $this->blueprint->analyze($tokens);

--- a/tests/fixtures/views/post.show.blade.php
+++ b/tests/fixtures/views/post.show.blade.php
@@ -1,0 +1,7 @@
+{--
+    @extends('layouts.app')
+
+    @section('content')
+        post.show template
+    @endsection
+--}

--- a/tests/fixtures/views/user.create.blade.php
+++ b/tests/fixtures/views/user.create.blade.php
@@ -1,0 +1,7 @@
+{--
+    @extends('layouts.app')
+
+    @section('content')
+        user.create template
+    @endsection
+--}

--- a/tests/fixtures/views/user.index.blade.php
+++ b/tests/fixtures/views/user.index.blade.php
@@ -1,0 +1,7 @@
+{--
+    @extends('layouts.app')
+
+    @section('content')
+        user.index template
+    @endsection
+--}


### PR DESCRIPTION
Currently, if you: 
- Created a new app
- Install Blueprint
- Install laravel-test-assertions
- Run `php artisan blueprint:build readme-example.yaml`
- Run `php artisan migrate:refresh`
- Run `php artisan test`

The test fails with `500 error` because the `views` generated by Blueprint extend `layouts.app` which does not exist.

---

This PR: 
1. updated `stubs/view.stub` with a blade comment. devs will have a good starting point and test runs without errors.
2. updated `ViewGeneratorTest` to use fixtures instead of the inline template. 