### PR TITLE
Remove duplicates with overwrite-migrations flag

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -8,6 +8,7 @@ use Blueprint\Tree;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
+use Symfony\Component\Finder\SplFileInfo;
 
 class MigrationGenerator implements Generator
 {
@@ -324,11 +325,22 @@ class MigrationGenerator implements Generator
         $dir = 'database/migrations/';
         $name = '_create_'.$tableName.'_table.php';
 
-        $file = $overwrite ? collect($this->files->files($dir))->first(function ($file) use ($tableName) {
-            return str_contains($file, $tableName);
-        }) : false;
+        if ($overwrite) {
+            $migrations = collect($this->files->files($dir))
+                ->filter(function (SplFileInfo $file) use ($name) {
+                    return str_contains($file->getFilename(), $name);
+                })
+                ->sort();
 
-        return $file ? (string) $file : $dir.$timestamp->format('Y_m_d_His').$name;
+            $migrations->diff($migrations->first()->getPathname())
+                ->each(function (SplFileInfo $file) {
+                    $this->files->delete($file->getPathname());
+                });
+
+            return $migrations->first()->getPathname();
+        }
+        
+        return $dir.$timestamp->format('Y_m_d_His').$name;
     }
 
     protected function isLaravel7orNewer()

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -332,14 +332,18 @@ class MigrationGenerator implements Generator
                 })
                 ->sort();
 
-            $migrations->diff($migrations->first()->getPathname())
-                ->each(function (SplFileInfo $file) {
-                    $this->files->delete($file->getPathname());
-                });
+            if ($migrations->isNotEmpty()) {
+                $migration = $migrations->first()->getPathname();
 
-            return $migrations->first()->getPathname();
+                $migrations->diff($migration)
+                    ->each(function (SplFileInfo $file) {
+                        $this->files->delete($file->getPathname());
+                    });
+
+                return $migration;
+            }
         }
-        
+
         return $dir.$timestamp->format('Y_m_d_His').$name;
     }
 


### PR DESCRIPTION
Currently: 
---
If you run `php artisan blueprint:build` **more than once**, without the `-m|--overwrite-migrations` flag, Blueprint will generate duplicate migrations with different timestamps.

If you then run `php artisan blueprint:build -m` or `php artisan blueprint:build --overwrite-migrations`, Blueprint will overwrite **ONLY** the first migration file it finds. All other duplicate migrations with different timestamps will still exist.

PR:
---

1. Running `php artisan blueprint:build`
    - Blueprint will still generate duplicate migrations with different timestamps with `php artisan blueprint:build` (for comparison,testing, etc.)

2. Running `php artisan blueprint:build -m` or `php artisan blueprint:build --overwrite-migrations`
    - Blueprint will update the oldest existing migration file.
    - Removes all other duplicate migrations with different timestamps.
    - Reports deleted files
![image](https://user-images.githubusercontent.com/9754361/93030086-67c1d800-f5ee-11ea-8027-e6124daa980b.png)

- resolves #370