### PR TITLE
Set a date format on a date column for update test.

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -461,7 +461,8 @@ class TestGenerator implements Generator
                             $local_model = $this->tree->modelForContext($model);
                             foreach ($request_data as $key => $datum) {
                                 if (! is_null($local_model) && $local_model->hasColumn($key) && $local_model->column($key)->dataType() === 'date') {
-                                    $assertions['generic'][] = sprintf('$this->assertEquals(%s, $%s->%s->format(\'Y-m-d\'));', $datum, $variable, $key);
+                                    $this->addImport($controller, 'Carbon\\Carbon');
+                                    $assertions['generic'][] = sprintf('$this->assertEquals(Carbon::parse(%s), $%s->%s);', $datum, $variable, $key);
                                 } else {
                                     $assertions['generic'][] = sprintf('$this->assertEquals(%s, $%s->%s);', $datum, $variable, $key);
                                 }

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -457,8 +457,14 @@ class TestGenerator implements Generator
                         $assertions['sanity'][] = sprintf('$%s->refresh();', $variable);
 
                         if ($request_data) {
+                            /** @var \Blueprint\Models\Model $local_model */
+                            $local_model = $this->tree->modelForContext($model);
                             foreach ($request_data as $key => $datum) {
-                                $assertions['generic'][] = sprintf('$this->assertEquals(%s, $%s->%s);', $datum, $variable, $key);
+                                if (! is_null($local_model) && $local_model->hasColumn($key) && $local_model->column($key)->dataType() === 'date') {
+                                    $assertions['generic'][] = sprintf('$this->assertEquals(%s, $%s->%s->format(\'Y-m-d\'));', $datum, $variable, $key);
+                                } else {
+                                    $assertions['generic'][] = sprintf('$this->assertEquals(%s, $%s->%s);', $datum, $variable, $key);
+                                }
                             }
                         }
                     }

--- a/tests/fixtures/tests/api-shorthand-validation-laravel8.php
+++ b/tests/fixtures/tests/api-shorthand-validation-laravel8.php
@@ -131,7 +131,7 @@ class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals($expiry_date, $certificate->expiry_date);
+        $this->assertEquals($expiry_date, $certificate->expiry_date->format('Y-m-d'));
     }
 
 

--- a/tests/fixtures/tests/api-shorthand-validation-laravel8.php
+++ b/tests/fixtures/tests/api-shorthand-validation-laravel8.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Certificate;
 use App\CertificateType;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
@@ -131,7 +132,7 @@ class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals($expiry_date, $certificate->expiry_date->format('Y-m-d'));
+        $this->assertEquals(Carbon::parse($expiry_date), $certificate->expiry_date);
     }
 
 

--- a/tests/fixtures/tests/api-shorthand-validation.php
+++ b/tests/fixtures/tests/api-shorthand-validation.php
@@ -131,7 +131,7 @@ class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals($expiry_date, $certificate->expiry_date);
+        $this->assertEquals($expiry_date, $certificate->expiry_date->format('Y-m-d'));
     }
 
 

--- a/tests/fixtures/tests/api-shorthand-validation.php
+++ b/tests/fixtures/tests/api-shorthand-validation.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Certificate;
 use App\CertificateType;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
@@ -131,7 +132,7 @@ class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals($expiry_date, $certificate->expiry_date->format('Y-m-d'));
+        $this->assertEquals(Carbon::parse($expiry_date), $certificate->expiry_date);
     }
 
 

--- a/tests/fixtures/tests/certificate-pascal-case-example-laravel8.php
+++ b/tests/fixtures/tests/certificate-pascal-case-example-laravel8.php
@@ -131,7 +131,7 @@ class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals($expiry_date, $certificate->expiry_date);
+        $this->assertEquals($expiry_date, $certificate->expiry_date->format('Y-m-d'));
     }
 
 

--- a/tests/fixtures/tests/certificate-pascal-case-example-laravel8.php
+++ b/tests/fixtures/tests/certificate-pascal-case-example-laravel8.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Certificate;
 use App\CertificateType;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
@@ -131,7 +132,7 @@ class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals($expiry_date, $certificate->expiry_date->format('Y-m-d'));
+        $this->assertEquals(Carbon::parse($expiry_date), $certificate->expiry_date);
     }
 
 

--- a/tests/fixtures/tests/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-pascal-case-example.php
@@ -131,7 +131,7 @@ class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals($expiry_date, $certificate->expiry_date);
+        $this->assertEquals($expiry_date, $certificate->expiry_date->format('Y-m-d'));
     }
 
 

--- a/tests/fixtures/tests/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/certificate-pascal-case-example.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Certificate;
 use App\CertificateType;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use JMac\Testing\Traits\AdditionalAssertions;
@@ -131,7 +132,7 @@ class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals($expiry_date, $certificate->expiry_date->format('Y-m-d'));
+        $this->assertEquals(Carbon::parse($expiry_date), $certificate->expiry_date);
     }
 
 


### PR DESCRIPTION
When using a `date` field without time the tests need to check against a formatted date.

Otherwise when running the tests you get an error that the date string does not match a Carbon object.

I'm using this basic `draft.yaml`
```
models:
  Post:
    published_date: date

controllers:
  Post:
    resource
```

This update checks if the field type is a `date` during the test generator and includes a format. This was the simplest way I could find to check if the column was a `date`. If there was more than 1 exception, I could see refactoring this out to a Registry like for Faker.

I tested this against both Laravel 7 and 8