### PR TITLE
The destroy test should assert for SoftDeleted

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -446,7 +446,13 @@ class TestGenerator implements Generator
                         } else {
                             $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
                         }
-                        $assertions['generic'][] = sprintf('$this->assertDeleted($%s);', $variable);
+                        /** @var \Blueprint\Models\Model $local_model */
+                        $local_model = $this->tree->modelForContext($model);
+                        if (! is_null($local_model) && $local_model->usesSoftDeletes()) {
+                            $assertions['generic'][] = sprintf('$this->assertSoftDeleted($%s);', $variable);
+                        } else {
+                            $assertions['generic'][] = sprintf('$this->assertDeleted($%s);', $variable);
+                        }
                     } elseif ($statement->operation() === 'update') {
                         $assertions['sanity'][] = sprintf('$%s->refresh();', $variable);
 

--- a/tests/fixtures/tests/models-with-custom-namespace-laravel8.php
+++ b/tests/fixtures/tests/models-with-custom-namespace-laravel8.php
@@ -133,6 +133,6 @@ class CategoryControllerTest extends TestCase
 
         $response->assertNoContent();
 
-        $this->assertDeleted($category);
+        $this->assertSoftDeleted($category);
     }
 }

--- a/tests/fixtures/tests/models-with-custom-namespace.php
+++ b/tests/fixtures/tests/models-with-custom-namespace.php
@@ -133,6 +133,6 @@ class CategoryControllerTest extends TestCase
 
         $response->assertNoContent();
 
-        $this->assertDeleted($category);
+        $this->assertSoftDeleted($category);
     }
 }


### PR DESCRIPTION
When using a model with `softDeletes`.

The `assertDeleted` check fails with soft deleted models.

This checks if the model has soft deletes and applies the correct assertion.

`draft.yaml` used for testing.
```
models:
  Post:
    title: string
    softDeletes

controllers:
  Post:
    resource
```