### PR TITLE
fix pivot table naming bug

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -155,7 +155,7 @@ class Model
 
     public function addPivotTable(string $reference)
     {
-        $segments = [$this->name(), $reference];
+        $segments = [$this->name(), basename($reference)];
         sort($segments);
         $this->pivotTables[] = $segments;
     }
@@ -164,7 +164,7 @@ class Model
     {
         return $this->indexes;
     }
-    
+
     public function addIndex(Index $index)
     {
         $this->indexes[] = $index;


### PR DESCRIPTION
the bug happens when using path prefix on models name

like this one :

```
  Lookup\Region:
    name_en: string:255 nullable
    softDeletes
    relationships:
      hasMany: Lookup\City
```

when there is a belongsToMany relationship, the path will be added to the pivot migration name which is not right