### PR TITLE
fix: sanitize modifier attributes

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -198,11 +198,11 @@ class FactoryGenerator implements Generator
                     $definition
                 );
             } elseif (in_array($column->dataType(), ['json', 'jsonb'])) {
-                $default = $column->defaultValue() ?? "'{}'";
+                $default = $column->defaultValue() ?? "{}";
                 if (Blueprint::isLaravel8OrHigher()) {
-                    $definition .= str_repeat(self::INDENT, 3) . "'{$column->name()}' => {$default}," . PHP_EOL;
+                    $definition .= str_repeat(self::INDENT, 3) . "'{$column->name()}' => '{$default}'," . PHP_EOL;
                 } else {
-                    $definition .= str_repeat(self::INDENT, 2) . "'{$column->name()}' => {$default}," . PHP_EOL;
+                    $definition .= str_repeat(self::INDENT, 2) . "'{$column->name()}' => '{$default}'," . PHP_EOL;
                 }
             } elseif ($column->dataType() === 'morphs') {
                 if ($column->isNullable()) {

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -198,7 +198,7 @@ class MigrationGenerator implements Generator
 
             foreach ($modifiers as $modifier) {
                 if (is_array($modifier)) {
-                    $column_definition .= '->'.key($modifier).'('.current($modifier).')';
+                    $column_definition .= sprintf("->%s('%s')", key($modifier), addslashes(current($modifier)));
                 } elseif ($modifier === 'unsigned' && Str::startsWith($dataType, 'unsigned')) {
                     continue;
                 } elseif ($modifier === 'nullable' && Str::startsWith($dataType, 'nullable')) {

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -241,10 +241,10 @@ class ModelLexer implements Lexer
 
             if (isset(self::$modifiers[strtolower($value)])) {
                 $modifierAttributes = $parts[1] ?? null;
-                if ($modifierAttributes === null) {
+                if (is_null($modifierAttributes)) {
                     $modifiers[] = self::$modifiers[strtolower($value)];
                 } else {
-                    $modifiers[] = [self::$modifiers[strtolower($value)] => $modifierAttributes];
+                    $modifiers[] = [self::$modifiers[strtolower($value)] => preg_replace('~^[\'"]?(.*?)[\'"]?$~', '$1', $modifierAttributes)];
                 }
             }
         }

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -790,6 +790,7 @@ class MigrationGeneratorTest extends TestCase
             ['drafts/with-timezones.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/with-timezones.php'],
             ['drafts/relationships.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/relationships.php'],
             ['drafts/indexes.yaml', 'database/migrations/timestamp_create_posts_table.php', 'migrations/indexes.php'],
+            ['drafts/custom-indexes.yaml', 'database/migrations/timestamp_create_cooltables_table.php', 'migrations/custom-indexes.php'],
             ['drafts/unconventional.yaml', 'database/migrations/timestamp_create_teams_table.php', 'migrations/unconventional.php'],
             ['drafts/optimize.yaml', 'database/migrations/timestamp_create_optimizes_table.php', 'migrations/optimize.php'],
             ['drafts/model-key-constraints.yaml', 'database/migrations/timestamp_create_orders_table.php', 'migrations/model-key-constraints.php'],

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -664,11 +664,12 @@ class ModelLexerTest extends TestCase
             ['default:0.00', 'default', 0.00],
             ['default:0', 'default', 0],
             ['default:string', 'default', 'string'],
-            ["default:'empty'", 'default', "'empty'"],
-            ['default:""', 'default', '""'],
+            ["default:'empty'", 'default', 'empty'],
+            ['default:""', 'default', ''],
             ['charset:utf8', 'charset', 'utf8'],
             ['collation:utf8_unicode', 'collation', 'utf8_unicode'],
-            ['default:"space between"', 'default', '"space between"'],
+            ['default:"space between"', 'default', 'space between'],
+            ["default:'[]'", 'default', '[]'],
         ];
     }
 }

--- a/tests/fixtures/drafts/custom-indexes.yaml
+++ b/tests/fixtures/drafts/custom-indexes.yaml
@@ -1,0 +1,5 @@
+models:
+  cooltable:
+    timestamps: false
+    coolcool: id foreign:coolcool.id index:custom_index_coolcool
+    foobar: id foreign:foobars.id index:custom_index_foobar

--- a/tests/fixtures/migrations/columns-with-comments.php
+++ b/tests/fixtures/migrations/columns-with-comments.php
@@ -15,7 +15,7 @@ class CreateProfessionsTable extends Migration
     {
         Schema::create('professions', function (Blueprint $table) {
             $table->id();
-            $table->string('title', 400)->comment("Some title for the profession");
+            $table->string('title', 400)->comment('Some title for the profession');
             $table->string('description', 400)->nullable()->comment('Some description for the profession');
             $table->timestamps();
         });

--- a/tests/fixtures/migrations/custom-indexes.php
+++ b/tests/fixtures/migrations/custom-indexes.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCooltablesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('cooltables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('coolcool')->constrained('coolcool')->cascadeOnDelete()->index('custom_index_coolcool');
+            $table->foreignId('foobar')->constrained('foobars')->cascadeOnDelete()->index('custom_index_foobar');
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('cooltables');
+    }
+}


### PR DESCRIPTION
I used this`draft.yml` file.
```yaml
models:
   cooltable:
      coolcool: id foreign:coolcool.id index:custom_index_coolcool
      foobar: id foreign:foobars.id index:custom_index_foobar
```

reverse-engineered from the generated code on #402

```php
Schema::create('cooltable', function (Blueprint $table) {
     19▕             $table->id();
  ➜  20▕             $table->foreignId('coolcool')->constrained()->cascadeOnDelete()->index(custom_index_coolcool);
     21▕             $table->foreignId('foobar')->constrained()->cascadeOnDelete()->index(custom_index_foobar);
     22▕         });
```
Closes #402