### PR TITLE
fixed issue with default for boolean type column

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -200,7 +200,7 @@ class MigrationGenerator implements Generator
                 if (is_array($modifier)) {
                     $modifierKey = key($modifier);
                     $modifierValue = addslashes(current($modifier));
-                    if ($dataType === 'boolean' && $modifierKey === 'default') {
+                    if (($dataType === 'boolean' || $dataType === 'tinyinteger') && $modifierKey === 'default') {
                         $column_definition .= sprintf("->%s(%s)", $modifierKey, $modifierValue);
                     } else {
                         $column_definition .= sprintf("->%s('%s')", $modifierKey, $modifierValue);

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -198,7 +198,13 @@ class MigrationGenerator implements Generator
 
             foreach ($modifiers as $modifier) {
                 if (is_array($modifier)) {
-                    $column_definition .= sprintf("->%s('%s')", key($modifier), addslashes(current($modifier)));
+                    $modifierKey = key($modifier);
+                    $modifierValue = addslashes(current($modifier));
+                    if ($dataType === 'boolean' && $modifierKey === 'default') {
+                        $column_definition .= sprintf("->%s(%s)", $modifierKey, $modifierValue);
+                    } else {
+                        $column_definition .= sprintf("->%s('%s')", $modifierKey, $modifierValue);
+                    }
                 } elseif ($modifier === 'unsigned' && Str::startsWith($dataType, 'unsigned')) {
                     continue;
                 } elseif ($modifier === 'nullable' && Str::startsWith($dataType, 'nullable')) {


### PR DESCRIPTION
If i wanna create a boolean column called is_active
i will do it like that

```
// Without Default
models:
  Product:
    is_active: boolean
```

but what if i need a default value for such column i will of course add 
```
default:true / default:false
// not all of us will use
default:1 /default:0
```
```
// With Default
models:
  Product:
    is_active: boolean default:true
```

till now everything is okey but the problem comes after the generator generate the migration 
for the boolean value ( before my pull request ) the above code ( with default ) will generate this line

`$table->boolean('is_active')->default('true');`

which by dafault will cause the following MySQL exception

```
SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'is_active' (SQL: create table products
```


most of you will say that i can set the default:1 or default:0 which works great ( yes it works and won't cause the exception but boolean means ( true and false ) 

## **Booleans** 
from php documentaion
[Language.types.boolean.php](https://www.php.net/manual/en/language.types.boolean.php)
This is the simplest type. A bool expresses a truth value. It can be either true or false. 

in the other side MySQL [mysql-boolean](https://www.javatpoint.com/mysql-boolean) documentation says 
`
If you want to use Boolean literals, use true or false that always evaluates to 0 and 1 value`

they say also that is

`The 0 and 1 represent the integer values.`

so adding support for true and false is needed here to fix this Invalid default value exception

hope it's clear.