### PR TITLE
Drop Blueprint stubs

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,7 +43,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             base_path('./../../../../vendor/laravel/framework/src/Illuminate/Database/Console/Factories/stubs'),
             base_path('./../../../../vendor/laravel/framework/src/Illuminate/Database/Console/Seeds/stubs'),
 
-        ])->first(function($directory) use($filename) {
+        ])->first(function ($directory) use ($filename) {
             return File::isFile($directory .'/'. $filename);
         });
 


### PR DESCRIPTION
Blueprint currently ships with a handful of custom stub files that were copied from Laravel's codebase.

This PR will remove all of the stubs in Blueprint and will instead use the default stub files provided by Laravel.

Pro:
- Ability to publish and customize stubs. (`php artisan stub:publish`)
- We will not be required to maintain the stub files for multiple versions of Laravel in this or a separate repo.
- Remove `php artisan vendor:publish --tag blueprint-stubs`

Con:
- Until we start using AST, using str_replace or preg_replace to generate the files will have some edge cases i [mentioned](https://github.com/laravel-shift/blueprint/pull/196#issuecomment-626813760).

## When creating a file that requires a stub file:

if dev used `php artisan stub:publish`, we will first check if that stub file exists in the base path.

`base_path('stubs')`

if not, well will check the default locations of the stub files.

```
base_path('./../../../../vendor/laravel/framework/src/Illuminate/Foundation/Console/stubs'),
base_path('./../../../../vendor/laravel/framework/src/Illuminate/Routing/Console/stubs'),
base_path('./../../../../vendor/laravel/framework/src/Illuminate/Database/Migrations/stubs'),
base_path('./../../../../vendor/laravel/framework/src/Illuminate/Database/Console/Factories/stubs'),
base_path('./../../../../vendor/laravel/framework/src/Illuminate/Database/Console/Seeds/stubs'),
```

```php
protected $stubs = [
        'channel.stub'                 => 'Illuminate/Foundation/Console/stubs/channel.stub',
        'console.stub'                 => 'Illuminate/Foundation/Console/stubs/console.stub',
        'controller.api.stub'          => 'Illuminate/Routing/Console/stubs/controller.api.stub',
        'controller.invokable.stub'    => 'Illuminate/Routing/Console/stubs/controller.invokable.stub',
        'controller.model.api.stub'    => 'Illuminate/Routing/Console/stubs/controller.model.api.stub',
        'controller.model.stub'        => 'Illuminate/Routing/Console/stubs/controller.model.stub',
        'controller.nested.api.stub'   => 'Illuminate/Routing/Console/stubs/controller.nested.api.stub',
        'controller.nested.stub'       => 'Illuminate/Routing/Console/stubs/controller.nested.stub',
        'controller.plain.stub'        => 'Illuminate/Routing/Console/stubs/controller.plain.stub',
        'controller.stub'              => 'Illuminate/Routing/Console/stubs/controller.stub',
        'event.stub'                   => 'Illuminate/Foundation/Console/stubs/event.stub',
        'exception-render-report.stub' => 'Illuminate/Foundation/Console/stubs/exception-render-report.stub',
        'exception-render.stub'        => 'Illuminate/Foundation/Console/stubs/exception-render.stub',
        'exception-report.stub'        => 'Illuminate/Foundation/Console/stubs/exception-report.stub',
        'exception.stub'               => 'Illuminate/Foundation/Console/stubs/exception.stub',
        'factory.stub'                 => 'Illuminate/Database/Console/Factories/stubs/factory.stub',
        'job.stub'                     => 'Illuminate/Foundation/Console/stubs/job.stub',
        'job-queued.stub'              => 'Illuminate/Foundation/Console/stubs/job-queued.stub',
        'listener-duck.stub'           => 'Illuminate/Foundation/Console/stubs/listener-duck.stub',
        'listener-queued-duck.stub'    => 'Illuminate/Foundation/Console/stubs/listener-queued-duck.stub',
        'listener-queued.stub'         => 'Illuminate/Foundation/Console/stubs/listener-queued.stub',
        'listener.stub'                => 'Illuminate/Foundation/Console/stubs/listener.stub',
        'mail.stub'                    => 'Illuminate/Foundation/Console/stubs/mail.stub',
        'markdown-mail.stub'           => 'Illuminate/Foundation/Console/stubs/markdown-mail.stub',
        'markdown-notification.stub'   => 'Illuminate/Foundation/Console/stubs/markdown-notification.stub',
        'markdown.stub'                => 'Illuminate/Foundation/Console/stubs/markdown.stub',
        'middleware.stub'              => 'Illuminate/Routing/Console/stubs/middleware.stub',
        'migration.blank.stub'         => 'Illuminate/Database/Migrations/stubs/blank.stub',
        'migration.create.stub'        => 'Illuminate/Database/Migrations/stubs/create.stub',
        'migration.update.stub'        => 'Illuminate/Database/Migrations/stubs/update.stub',
        'model.stub'                   => 'Illuminate/Foundation/Console/stubs/model.stub',
        'notification.stub'            => 'Illuminate/Foundation/Console/stubs/notification.stub',
        'observer.stub'                => 'Illuminate/Foundation/Console/stubs/observer.stub',
        'observer.plain.stub'          => 'Illuminate/Foundation/Console/stubs/observer.plain.stub',
        'pivot.model.stub'             => 'Illuminate/Foundation/Console/stubs/pivot.model.stub',
        'policy.plain.stub'            => 'Illuminate/Foundation/Console/stubs/policy.plain.stub',
        'policy.stub'                  => 'Illuminate/Foundation/Console/stubs/policy.stub',
        'provider.stub'                => 'Illuminate/Foundation/Console/stubs/provider.stub',
        'request.stub'                 => 'Illuminate/Foundation/Console/stubs/request.stub',
        'resource-collection.stub'     => 'Illuminate/Foundation/Console/stubs/resource-collection.stub',
        'resource.stub'                => 'Illuminate/Foundation/Console/stubs/resource.stub',
        'rule.stub'                    => 'Illuminate/Foundation/Console/stubs/rule.stub',
        'seeder.stub'                  => 'Illuminate/Database/Console/Seeds/stubs/seeder.stub',
        'test.stub'                    => 'Illuminate/Foundation/Console/stubs/test.stub',
        'unit-test.stub'               => 'Illuminate/Foundation/Console/stubs/unit-test.stub',
    ];
``` 