### PR TITLE
Feature: invokable controllers

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -65,6 +65,10 @@ class Blueprint
             return $matches[1].'resource: web';
         }, $content);
 
+        $content = preg_replace_callback('/^(\s+)invokable?$/mi', function ($matches) {
+            return $matches[1].'invokable: default';
+        }, $content);
+
         $content = preg_replace_callback('/^(\s+)uuid(: true)?$/mi', function ($matches) {
             return $matches[1].'id: uuid primary';
         }, $content);

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -66,7 +66,7 @@ class Blueprint
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)invokable?$/mi', function ($matches) {
-            return $matches[1].'invokable: default';
+            return $matches[1].'invokable: true';
         }, $content);
 
         $content = preg_replace_callback('/^(\s+)uuid(: true)?$/mi', function ($matches) {

--- a/src/Lexers/ControllerLexer.php
+++ b/src/Lexers/ControllerLexer.php
@@ -42,6 +42,14 @@ class ControllerLexer implements Lexer
                 $definition = array_merge($resource_definition, $definition);
             }
 
+            if (isset($definition['invokable'])) {
+                $definition['invokable'] === 'default'
+                    ? $definition['__invoke'] = ['render' => Str::camel($this->getControllerModelName($controller))]
+                    : $definition['__invoke'] = $definition['invokable'];
+
+                unset($definition['invokable']);
+            }
+
             foreach ($definition as $method => $body) {
                 $controller->addMethod($method, $this->statementLexer->analyze($body));
             }
@@ -61,7 +69,7 @@ class ControllerLexer implements Lexer
             ->mapWithKeys(function ($statements, $method) use ($controller) {
                 return [
                     str_replace('api.', '', $method) => collect($statements)->map(function ($statement) use ($controller) {
-                        $model = Str::singular($controller->prefix());
+                        $model = $this->getControllerModelName($controller);
 
                         return str_replace(
                             ['[singular]', '[plural]'],
@@ -72,6 +80,11 @@ class ControllerLexer implements Lexer
                 ];
             })
             ->toArray();
+    }
+
+    private function getControllerModelName(Controller $controller)
+    {
+        return Str::singular($controller->prefix());
     }
 
     private function resourceTokens()

--- a/src/Lexers/ControllerLexer.php
+++ b/src/Lexers/ControllerLexer.php
@@ -43,7 +43,7 @@ class ControllerLexer implements Lexer
             }
 
             if (isset($definition['invokable'])) {
-                $definition['invokable'] === 'default'
+                $definition['invokable'] === true
                     ? $definition['__invoke'] = ['render' => Str::camel($this->getControllerModelName($controller))]
                     : $definition['__invoke'] = $definition['invokable'];
 

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -115,7 +115,7 @@ class BlueprintTest extends TestCase
                     'resource' => 'web',
                 ],
                 'Report' => [
-                    'invokable' => 'default'
+                    'invokable' => true
                 ],
             ],
         ], $this->subject->parse($blueprint));

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -114,6 +114,9 @@ class BlueprintTest extends TestCase
                 'Context' => [
                     'resource' => 'web',
                 ],
+                'Report' => [
+                    'invokable' => 'default'
+                ],
             ],
         ], $this->subject->parse($blueprint));
     }

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -210,6 +210,7 @@ class ControllerGeneratorTest extends TestCase
             ['drafts/save-without-validation.yaml', 'app/Http/Controllers/PostController.php', 'controllers/save-without-validation.php'],
             ['drafts/api-routes-example.yaml', 'app/Http/Controllers/Api/CertificateController.php', 'controllers/api-routes-example.php'],
             ['drafts/invokable-controller.yaml', 'app/Http/Controllers/ReportController.php', 'controllers/invokable-controller.php'],
+            ['drafts/invokable-controller-shorthand.yaml', 'app/Http/Controllers/ReportController.php', 'controllers/invokable-controller-shorthand.php'],
         ];
     }
 }

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -176,6 +176,7 @@ class ControllerGeneratorTest extends TestCase
             ['drafts/resource-statements.yaml', 'app/Http/Controllers/UserController.php', 'controllers/resource-statements.php'],
             ['drafts/save-without-validation.yaml', 'app/Http/Controllers/PostController.php', 'controllers/save-without-validation.php'],
             ['drafts/api-routes-example.yaml', 'app/Http/Controllers/Api/CertificateController.php', 'controllers/api-routes-example.php'],
+            ['drafts/invokable-controller.yaml', 'app/Http/Controllers/ReportController.php', 'controllers/invokable-controller.php'],
         ];
     }
 }

--- a/tests/Feature/Generators/RouteGeneratorTest.php
+++ b/tests/Feature/Generators/RouteGeneratorTest.php
@@ -111,6 +111,8 @@ class RouteGeneratorTest extends TestCase
             ['drafts/cruddy.yaml', 'routes/cruddy.php'],
             ['drafts/non-cruddy.yaml', 'routes/non-cruddy.php'],
             ['drafts/respond-statements.yaml', 'routes/respond-statements.php'],
+            ['drafts/invokable-controller.yaml', 'routes/invokable-controller.php'],
+            ['drafts/invokable-controller-shorthand.yaml', 'routes/invokable-controller.php'],
         ];
     }
 }

--- a/tests/Feature/Lexers/ControllerLexerTest.php
+++ b/tests/Feature/Lexers/ControllerLexerTest.php
@@ -364,7 +364,6 @@ class ControllerLexerTest extends TestCase
 
         $methods = $controller->methods();
         $this->assertCount(3, $methods);
-
         $this->assertCount(1, $methods['index']);
         $this->assertEquals('custom-index-statements', $methods['index'][0]);
         $this->assertCount(1, $methods['show']);
@@ -420,5 +419,32 @@ class ControllerLexerTest extends TestCase
         $this->assertEquals('GalleryController', $controller->className());
         $this->assertCount(5, $controller->methods());
         $this->assertTrue($controller->isApiResource());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_invokable_controller()
+    {
+        $tokens = [
+            'controllers' => [
+                'Report' => [
+                    '__invoke' => [
+                        'render' => 'report'
+                    ]
+                ]
+            ]
+        ];
+
+        $this->statementLexer->shouldReceive('analyze');
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertCount(1, $actual['controllers']);
+
+        $controller = $actual['controllers']['Report'];
+        $this->assertEquals('ReportController', $controller->className());
+        $this->assertCount(1, $controller->methods());
+        $this->assertFalse($controller->isApiResource());
     }
 }

--- a/tests/fixtures/controllers/invokable-controller-shorthand.php
+++ b/tests/fixtures/controllers/invokable-controller-shorthand.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Events\ReportGenerated;
 use Illuminate\Http\Request;
 
 class ReportController extends Controller
@@ -13,8 +12,6 @@ class ReportController extends Controller
      */
     public function __invoke(Request $request)
     {
-        event(new ReportGenerated());
-
         return view('report');
     }
 }

--- a/tests/fixtures/controllers/invokable-controller.php
+++ b/tests/fixtures/controllers/invokable-controller.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ReportController extends Controller
+{
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        return view('report');
+    }
+}

--- a/tests/fixtures/drafts/invokable-controller-shorthand.yaml
+++ b/tests/fixtures/drafts/invokable-controller-shorthand.yaml
@@ -1,0 +1,3 @@
+controllers:
+  Report:
+    invokable

--- a/tests/fixtures/drafts/invokable-controller.yaml
+++ b/tests/fixtures/drafts/invokable-controller.yaml
@@ -1,4 +1,5 @@
 controllers:
   Report:
     __invoke:
+      fire: ReportGenerated
       render: report

--- a/tests/fixtures/drafts/invokable-controller.yaml
+++ b/tests/fixtures/drafts/invokable-controller.yaml
@@ -1,0 +1,4 @@
+controllers:
+  Report:
+    __invoke:
+      render: report

--- a/tests/fixtures/drafts/non-cruddy.yaml
+++ b/tests/fixtures/drafts/non-cruddy.yaml
@@ -12,3 +12,7 @@ controllers:
   Subscriptions:
     resume:
       redirect: subscriptions.index
+
+  Report:
+    __invoke:
+      render: report

--- a/tests/fixtures/drafts/routes-tuples.yaml
+++ b/tests/fixtures/drafts/routes-tuples.yaml
@@ -8,3 +8,6 @@ controllers:
   Some:
     whatever:
       redirect: some.index
+  Report:
+    __invoke:
+      render: report

--- a/tests/fixtures/drafts/shorthands.yaml
+++ b/tests/fixtures/drafts/shorthands.yaml
@@ -7,3 +7,5 @@ models:
 controllers:
   Context:
     resource
+  Report:
+    invokable

--- a/tests/fixtures/routes/invokable-controller.php
+++ b/tests/fixtures/routes/invokable-controller.php
@@ -1,0 +1,3 @@
+
+
+Route::get('report', 'ReportController');

--- a/tests/fixtures/routes/non-cruddy.php
+++ b/tests/fixtures/routes/non-cruddy.php
@@ -5,3 +5,5 @@ Route::get('some/whatever', 'SomeController@whatever');
 Route::get('some/slug-name', 'SomeController@slugName');
 
 Route::get('subscriptions/resume', 'SubscriptionsController@resume');
+
+Route::get('report', 'ReportController');

--- a/tests/fixtures/routes/routes-tuples.php
+++ b/tests/fixtures/routes/routes-tuples.php
@@ -3,3 +3,5 @@
 Route::resource('foo', App\Http\Controllers\FooController::class);
 
 Route::get('some/whatever', [App\Http\Controllers\SomeController::class, 'whatever']);
+
+Route::get('report', App\Http\Controllers\ReportController::class);


### PR DESCRIPTION
This change allows to properly generate routes for invokable controllers, by defining an `__invoke` method on a controller. 

Considering a definition like the following:
```
controllers:
  Report:
    __invoke:
      render: report
```
      
Before the change, the generated route would be
`Route::get('/report', [App\HttpControllers\ReportController::class, '__invoke']);`
(or `Route::get('/user/{id}', 'ReportController@__invoke']);` without tuples).

After the change, the generated route is
`Route::get('/report', App\HttpControllers\ReportController::class);`
(or `Route::get('/report', 'ReportController');` without tuples).