### PR TITLE
Add string limit for faker words

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -245,6 +245,10 @@ class FactoryGenerator implements Generator
                     $faker = 'word';
                 }
 
+                if(($faker === 'word') && (!empty($column->attributes()))){
+                    $faker = sprintf("regexify('[A-Za-z0-9]{%s}')", current($column->attributes()));
+                }
+
                 if (Blueprint::isLaravel8OrHigher()) {
                     $definition .= '$this->faker->' . $faker;
                 } else {

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -245,7 +245,7 @@ class FactoryGenerator implements Generator
                     $faker = 'word';
                 }
 
-                if(($faker === 'word') && (!empty($column->attributes()))){
+                if (($faker === 'word') && (!empty($column->attributes()))) {
                     $faker = sprintf("regexify('[A-Za-z0-9]{%s}')", current($column->attributes()));
                 }
 

--- a/tests/fixtures/drafts/phone.yaml
+++ b/tests/fixtures/drafts/phone.yaml
@@ -7,3 +7,4 @@ models:
     status: set:archived,deleted
     foo: morphs
     bar: morphs nullable
+    tag: string:3

--- a/tests/fixtures/factories/phone-laravel8.php
+++ b/tests/fixtures/factories/phone-laravel8.php
@@ -31,6 +31,7 @@ class PhoneFactory extends Factory
             'status' => $this->faker->randomElement(["archived","deleted"]),
             'foo_id' => $this->faker->randomDigitNotNull,
             'foo_type' => $this->faker->word,
+            'tag' => $this->faker->regexify('[A-Za-z0-9]{3}'),
         ];
     }
 }

--- a/tests/fixtures/factories/phone.php
+++ b/tests/fixtures/factories/phone.php
@@ -14,5 +14,6 @@ $factory->define(Phone::class, function (Faker $faker) {
         'status' => $faker->randomElement(["archived","deleted"]),
         'foo_id' => $faker->randomDigitNotNull,
         'foo_type' => $faker->word,
+        'tag' => $faker->regexify('[A-Za-z0-9]{3}'),
     ];
 });


### PR DESCRIPTION
```
models:
  Post:
    tag: string:3
```

- `string:{limit}` syntax will now generate `$faker->regexify('[A-Za-z0-9]{limit}')` instead of  `$faker->word`.

Resolves #434