### PR TITLE
[BUG] Fix for deprecated `fetchAll` > `fetchAllAssociative`

### DIFF
--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -103,7 +103,7 @@ class Tracer
         });
 
         if ($uses_enums) {
-            $definitions = $model->getConnection()->getDoctrineConnection()->fetchAll($schema->getDatabasePlatform()->getListTableColumnsSQL($table, $database));
+            $definitions = $model->getConnection()->getDoctrineConnection()->fetchAllAssociative($schema->getDatabasePlatform()->getListTableColumnsSQL($table, $database));
 
             collect($columns)->filter(function ($column) {
                 return $column->getType() instanceof \Blueprint\EnumType;


### PR DESCRIPTION
While doing a `Trace` I was getting:
```
Error
Call to undefined method Doctrine\DBAL\Connection::fetchAll()
```

Changing `fetchAll` to `fetchAllAssociative` fixes the issue.

This was introduced by https://github.com/laravel-shift/blueprint/pull/409.

On DBal 2.9 source code, the `fetchAll` method has the comment `@deprecated Use fetchAllAssociative()`.
On DBal 3.0 it was removed [https://github.com/doctrine/dbal/.../src/Connection.php](https://github.com/doctrine/dbal/blob/20bcec57aae2e24b82a32a33d2e9227dde6c1bba/src/Connection.php#L766).