### PR TITLE
Fix plural-singular modelForContext

### DIFF
--- a/src/Tree.php
+++ b/src/Tree.php
@@ -41,6 +41,10 @@ class Tree
             return $this->models[Str::studly($context)];
         }
 
+        if (isset($this->models[Str::studly(Str::plural($context))])) {
+            return $this->models[Str::studly(Str::plural($context))];
+        }
+
         $matches = array_filter(array_keys($this->models), function ($key) use ($context) {
             return Str::endsWith($key, '/' . Str::studly($context));
         });


### PR DESCRIPTION
closes #464

eg. the singular of species is species.  so no need to force `WaterSpeciesController` to reference a `WaterSpecy` model. (Currently causing the `null` error)

This will check for and return a `studly` `plural` version of the model name in the `Tree`.