### PR TITLE
Fix resource pagination

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -142,6 +142,20 @@ class ControllerGenerator implements Generator
                     $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return \\' . $fqcn, $method);
                     $this->addImport($controller, $fqcn);
                     $body .= self::INDENT . $statement->output() . PHP_EOL;
+
+                    if ($statement->paginate()) {
+                        if (! Str::contains($body, '::all();')) {
+                            $queryStatement = new QueryStatement('all', [$statement->reference()]);
+                            $body = implode(PHP_EOL, [
+                                self::INDENT . $queryStatement->output($statement->reference()),
+                                PHP_EOL . $body
+                            ]);
+
+                            $this->addImport($controller, $this->determineModel($controller, $queryStatement->model()));
+                        }
+
+                        $body = str_replace('::all();', '::paginate();', $body);
+                    }
                 } elseif ($statement instanceof RedirectStatement) {
                     $body .= self::INDENT . $statement->output() . PHP_EOL;
                 } elseif ($statement instanceof RespondStatement) {

--- a/src/Models/Statements/ResourceStatement.php
+++ b/src/Models/Statements/ResourceStatement.php
@@ -54,15 +54,6 @@ class ResourceStatement
 
     public function output(): string
     {
-        $code = 'return new ' . $this->name();
-        $code .= '($' . $this->reference();
-
-        if ($this->paginate()) {
-            $code .= '->paginate()';
-        }
-
-        $code .= ');';
-
-        return $code;
+        return sprintf('return new %s($%s);', $this->name(), $this->reference());
     }
 }

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -208,6 +208,7 @@ class ControllerGeneratorTest extends TestCase
             ['drafts/respond-statements.yaml', 'app/Http/Controllers/Api/PostController.php', 'controllers/respond-statements.php'],
             ['drafts/resource-statements.yaml', 'app/Http/Controllers/UserController.php', 'controllers/resource-statements.php'],
             ['drafts/save-without-validation.yaml', 'app/Http/Controllers/PostController.php', 'controllers/save-without-validation.php'],
+            ['drafts/api-resource-pagination.yaml', 'app/Http/Controllers/PostController.php', 'controllers/api-resource-pagination.php'],
             ['drafts/api-routes-example.yaml', 'app/Http/Controllers/Api/CertificateController.php', 'controllers/api-routes-example.php'],
             ['drafts/invokable-controller.yaml', 'app/Http/Controllers/ReportController.php', 'controllers/invokable-controller.php'],
             ['drafts/invokable-controller-shorthand.yaml', 'app/Http/Controllers/ReportController.php', 'controllers/invokable-controller-shorthand.php'],

--- a/tests/Feature/Generators/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/ResourceGeneratorTest.php
@@ -136,4 +136,40 @@ class ResourceGeneratorTest extends TestCase
             'created' => ['app/Http/Resources/Api/CertificateCollection.php', 'app/Http/Resources/Api/CertificateResource.php'],
         ], $this->subject->output($tree));
     }
+
+    /**
+     * @test
+     */
+    public function output_api_resource_pagination()
+    {
+        $this->files->expects('stub')
+            ->with('resource.stub')
+            ->andReturn(file_get_contents('stubs/resource.stub'));
+
+        $this->files->shouldReceive('exists')
+            ->with('app/Http/Resources')
+            ->andReturns(false, true);
+        $this->files->expects('makeDirectory')
+            ->with('app/Http/Resources', 0755, true);
+
+        $this->files->expects('exists')
+            ->times(3)
+            ->with('app/Http/Resources/PostResource.php')
+            ->andReturns(false, true, true);
+        $this->files->expects('put')
+            ->with('app/Http/Resources/PostResource.php', $this->fixture('resources/api-post-resource.php'));
+
+        $this->files->expects('exists')
+            ->with('app/Http/Resources/PostCollection.php')
+            ->andReturns(false);
+        $this->files->expects('put')
+            ->with('app/Http/Resources/PostCollection.php', $this->fixture('resources/api-resource-pagination.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/api-resource-pagination.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals([
+            'created' => ['app/Http/Resources/PostCollection.php', 'app/Http/Resources/PostResource.php'],
+        ], $this->subject->output($tree));
+    }
 }

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -589,7 +589,7 @@ class StatementLexerTest extends TestCase
 
         $this->assertEquals('get', $actual[0]->operation());
         $this->assertSame(['where:post.title', 'order:post.created_at'], $actual[0]->clauses());
-        $this->assertNull($actual[0]->model());
+        $this->assertSame('Post', $actual[0]->model());
     }
 
     /**
@@ -608,7 +608,7 @@ class StatementLexerTest extends TestCase
 
         $this->assertEquals('pluck', $actual[0]->operation());
         $this->assertSame(['order:post.created_at', 'pluck:id'], $actual[0]->clauses());
-        $this->assertNull($actual[0]->model());
+        $this->assertSame('Post', $actual[0]->model());
     }
 
     /**

--- a/tests/fixtures/controllers/api-resource-pagination.php
+++ b/tests/fixtures/controllers/api-resource-pagination.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\PostStoreRequest;
+use App\Http\Requests\PostUpdateRequest;
+use App\Http\Resources\PostCollection;
+use App\Http\Resources\PostResource;
+use App\Post;
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \App\Http\Resources\PostCollection
+     */
+    public function index(Request $request)
+    {
+        $posts = Post::paginate();
+
+        return new PostCollection($posts);
+    }
+
+    /**
+     * @param \App\Http\Requests\PostStoreRequest $request
+     * @return \App\Http\Resources\PostResource
+     */
+    public function store(PostStoreRequest $request)
+    {
+        $post = Post::create($request->validated());
+
+        return new PostResource($post);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Post $post
+     * @return \App\Http\Resources\PostResource
+     */
+    public function show(Request $request, Post $post)
+    {
+        return new PostResource($post);
+    }
+
+    /**
+     * @param \App\Http\Requests\PostUpdateRequest $request
+     * @param \App\Post $post
+     * @return \App\Http\Resources\PostResource
+     */
+    public function update(PostUpdateRequest $request, Post $post)
+    {
+        $post->update($request->validated());
+
+        return new PostResource($post);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Post $post
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Request $request, Post $post)
+    {
+        $post->delete();
+
+        return response()->noContent();
+    }
+}

--- a/tests/fixtures/controllers/resource-statements.php
+++ b/tests/fixtures/controllers/resource-statements.php
@@ -15,7 +15,9 @@ class UserController extends Controller
      */
     public function index(Request $request)
     {
-        return new UserCollection($users->paginate());
+        $users = User::paginate();
+
+        return new UserCollection($users);
     }
 
     /**

--- a/tests/fixtures/drafts/api-resource-pagination.yaml
+++ b/tests/fixtures/drafts/api-resource-pagination.yaml
@@ -1,0 +1,11 @@
+models:
+  Post:
+    title: string
+    body: text
+controllers:
+  Post:
+    resource: api
+    index:
+      query: all
+      resource: 'paginate:posts'
+seeders: Post

--- a/tests/fixtures/resources/api-post-resource.php
+++ b/tests/fixtures/resources/api-post-resource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'body' => $this->body,
+        ];
+    }
+}

--- a/tests/fixtures/resources/api-resource-pagination.php
+++ b/tests/fixtures/resources/api-resource-pagination.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'data' => $this->collection,
+        ];
+    }
+}


### PR DESCRIPTION
- resolves #439
- `QueryStatement` can now determine the Model from `get` and `pluck` operations.
- No longer a need to define `query: all` when you define `resource: 'paginate:{model}'`.

```diff
# eg. draft.yaml
models:
  Post:
    title: string
    body: text
controllers:
  Post:
    resource: api
    index:
-      query: all
      resource: 'paginate:posts'
seeders: Post
```