### PR TITLE
allow non-id columns to be nullable when using foreign

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -63,10 +63,9 @@ class MigrationGenerator implements Generator
         $tables = ['tableNames' => [], 'pivotTableNames' => []];
 
         $stub = $this->filesystem->stub('migration.stub');
-
         /**
- * @var \Blueprint\Models\Model $model
-*/
+         * @var \Blueprint\Models\Model $model
+         */
         foreach ($tree->models() as $model) {
             $tables['tableNames'][$model->tableName()] = $this->populateStub($stub, $model);
 
@@ -98,7 +97,6 @@ class MigrationGenerator implements Generator
             $path = $this->getTablePath($tableName, $sequential_timestamp->addSecond(), $overwrite);
             $action = $this->filesystem->exists($path) ? 'updated' : 'created';
             $this->filesystem->put($path, $data);
-
             $output[$action][] = $path;
         }
 
@@ -109,7 +107,6 @@ class MigrationGenerator implements Generator
 
             $output[$action][] = $path;
         }
-
         return $output;
     }
 
@@ -208,12 +205,12 @@ class MigrationGenerator implements Generator
 
                 // TODO: unset the proper modifier
                 $modifiers = collect($modifiers)->reject(
-                    function ($modifier) {
+                    function ($modifier) use ($column) {
                         return (is_array($modifier) && key($modifier) === 'foreign')
                         || (is_array($modifier) && key($modifier) === 'onDelete')
                         || (is_array($modifier) && key($modifier) === 'onUpdate')
                         || $modifier === 'foreign'
-                        || ($modifier === 'nullable' && $this->isLaravel7orNewer());
+                        || ($modifier === 'nullable' && $this->isLaravel7orNewer() && $column->dataType() === 'id');
                     }
                 );
             }

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -645,6 +645,33 @@ class MigrationGeneratorTest extends TestCase
 
     /**
      * @test
+     */
+    public function output_creates_nullable_foreign_key_without_column_type_beeing_id()
+    {
+        $this->filesystem->expects('stub')
+            ->with('migration.stub')
+            ->andReturn($this->stub('migration.stub'));
+
+        $now = Carbon::now();
+        Carbon::setTestNow($now);
+
+        $model_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comments_table.php');
+
+        $this->filesystem->expects('exists')->with($model_migration)->andReturn(false);
+
+        $this->files
+            ->expects('put')
+            ->with($model_migration, $this->fixture('migrations/nullable-columns-with-foreign.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/nullable-columns-with-foreign.yaml'));
+        
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$model_migration]], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
      * @environment-setup useLaravel6
      */
     public function output_creates_foreign_keys_with_nullable_chained_correctly_laravel6()

--- a/tests/fixtures/drafts/nullable-columns-with-foreign.yaml
+++ b/tests/fixtures/drafts/nullable-columns-with-foreign.yaml
@@ -1,0 +1,7 @@
+models:
+  Comment:
+    id
+    user_id: id foreign:users.id nullable
+    integer: integer foreign:monsteras.id nullable
+    timestamps
+    

--- a/tests/fixtures/migrations/nullable-columns-with-foreign.php
+++ b/tests/fixtures/migrations/nullable-columns-with-foreign.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained();
+            $table->integer('integer')->nullable();
+            $table->foreign('integer')->references('id')->on('monsteras');
+            $table->timestamps();
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}


### PR DESCRIPTION
Hello @jasonmccreary hope to find you well.

I think I found an issue with `Blueprint` when using **foreigns**.

So here is the scenario, given the following `yaml` file:

```yaml
models:
  SomeTestsMigration:
    id
    user_id: id foreign:users.id nullable
    something: integer foreign:monsteras.id nullable
    timestamps
```

This would produce the following migration: 

```php
        Schema::disableForeignKeyConstraints();

        Schema::create('some_tests_migrations', function (Blueprint $table) {
            $table->id();
            $table->foreignId('user_id')->nullable()->constrained();
            $table->integer('something'); //notice here its missing the nullable modifier.
            $table->foreign('something')->references('id')->on('monsteras');
            $table->timestamps();
        });

        Schema::enableForeignKeyConstraints();
```

Blueprint does handle the nullable modifier well when the column **dataType** is `id` as you can see here: https://github.com/laravel-shift/blueprint/blob/e446a418c28539f5cd0b6404692dd20930523780/src/Generators/MigrationGenerator.php#L328

After that, it checks and removes nullable from the modifier list as it was already handled: https://github.com/laravel-shift/blueprint/blob/e446a418c28539f5cd0b6404692dd20930523780/src/Generators/MigrationGenerator.php#L210

For `non-id` dataTypes (**something** in my example) it also removes the `nullable` modifier, and it shouldn't because those cases are not handled by Blueprint in prior code.

I've also added tests to prove this use case. 

Let me know if I missed something here.

Best,
Pedro
 