### PR TITLE
Respect draft file column order

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -172,6 +172,8 @@ class MigrationGenerator implements Generator
                 $column_definition .= '$table->id(';
             } elseif ($dataType === 'rememberToken') {
                 $column_definition .= '$table->rememberToken(';
+            }elseif ($dataType === $model->softDeletesDataType()) {
+                $column_definition .= '$table->' . $model->softDeletesDataType() . '(';
             } else {
                 $column_definition .= '$table->' . $dataType . "('{$column->name()}'";
             }
@@ -242,10 +244,6 @@ class MigrationGenerator implements Generator
             }
 
             $definition .= $column_definition;
-        }
-
-        if ($model->usesSoftDeletes()) {
-            $definition .= self::INDENT . '$table->' . $model->softDeletesDataType() . '();' . PHP_EOL;
         }
 
         if ($model->morphTo()) {

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -172,7 +172,7 @@ class MigrationGenerator implements Generator
                 $column_definition .= '$table->id(';
             } elseif ($dataType === 'rememberToken') {
                 $column_definition .= '$table->rememberToken(';
-            }elseif ($dataType === $model->softDeletesDataType()) {
+            } elseif ($dataType === $model->softDeletesDataType()) {
                 $column_definition .= '$table->' . $model->softDeletesDataType() . '(';
             } else {
                 $column_definition .= '$table->' . $dataType . "('{$column->name()}'";

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -125,15 +125,16 @@ class ModelGenerator implements Generator
                 $phpDoc .= PHP_EOL;
                 $phpDoc .= ' * @property string|null $' . $column->name() . '_type';
                 $phpDoc .= PHP_EOL;
+            } elseif (
+                $model->usesSoftDeletes() &&
+                $model->softDeletesDataType() === mb_strtolower($column->dataType())
+            ) {
+                $phpDoc .= ' * @property \Carbon\Carbon $deleted_at';
+                $phpDoc .= PHP_EOL;
             } else {
                 $phpDoc .= sprintf(' * @property %s $%s', $this->phpDataType($column->dataType()), $column->name());
                 $phpDoc .= PHP_EOL;
             }
-        }
-
-        if ($model->usesSoftDeletes()) {
-            $phpDoc .= ' * @property \Carbon\Carbon $deleted_at';
-            $phpDoc .= PHP_EOL;
         }
 
         if ($model->usesTimestamps()) {

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -157,7 +157,7 @@ class ModelLexer implements Lexer
             unset($columns['softdeletestz']);
         }
 
-        if($model->usesSoftDeletes()){
+        if ($model->usesSoftDeletes()) {
             $model->addColumn($this->buildColumn('deleted_at', $model->softDeletesDataType()));
         }
 

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -126,6 +126,11 @@ class ModelLexer implements Lexer
     {
         $model = new Model($name);
 
+        if (!isset($columns['id']) && $model->usesPrimaryKey()) {
+            $column = $this->buildColumn('id', 'id');
+            $model->addColumn($column);
+        }
+        
         if (isset($columns['id'])) {
             if ($columns['id'] === false) {
                 $model->disablePrimaryKey();
@@ -152,6 +157,10 @@ class ModelLexer implements Lexer
             unset($columns['softdeletestz']);
         }
 
+        if($model->usesSoftDeletes()){
+            $model->addColumn($this->buildColumn('deleted_at', $model->softDeletesDataType()));
+        }
+
         if (isset($columns['relationships'])) {
             if (is_array($columns['relationships'])) {
                 foreach ($columns['relationships'] as $type => $relationships) {
@@ -173,11 +182,6 @@ class ModelLexer implements Lexer
                 $model->addIndex(new Index(key($index), array_map('trim', explode(',', current($index)))));
             }
             unset($columns['indexes']);
-        }
-
-        if (!isset($columns['id']) && $model->usesPrimaryKey()) {
-            $column = $this->buildColumn('id', 'id');
-            $model->addColumn($column);
         }
 
         foreach ($columns as $name => $definition) {

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -375,7 +375,7 @@ class ModelLexerTest extends TestCase
         $this->assertTrue($model->usesSoftDeletes());
 
         $columns = $model->columns();
-        $this->assertCount(1, $columns);
+        $this->assertCount(2, $columns);
         $this->assertEquals('id', $columns['id']->name());
         $this->assertEquals('id', $columns['id']->dataType());
         $this->assertEquals([], $columns['id']->modifiers());

--- a/tests/fixtures/migrations/soft-deletes.php
+++ b/tests/fixtures/migrations/soft-deletes.php
@@ -15,8 +15,8 @@ class CreateCommentsTable extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('post_id');
             $table->softDeletes();
+            $table->unsignedBigInteger('post_id');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/with-path-prefix-table-name-region-laravel6.php
+++ b/tests/fixtures/migrations/with-path-prefix-table-name-region-laravel6.php
@@ -15,8 +15,8 @@ class CreateRegionsTable extends Migration
     {
         Schema::create('regions', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('name_en', 255)->nullable();
             $table->softDeletes();
+            $table->string('name_en', 255)->nullable();
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/with-path-prefix-table-name-region.php
+++ b/tests/fixtures/migrations/with-path-prefix-table-name-region.php
@@ -15,8 +15,8 @@ class CreateRegionsTable extends Migration
     {
         Schema::create('regions', function (Blueprint $table) {
             $table->id();
-            $table->string('name_en', 255)->nullable();
             $table->softDeletes();
+            $table->string('name_en', 255)->nullable();
             $table->timestamps();
         });
     }

--- a/tests/fixtures/models/soft-deletes-phpdoc-laravel8.php
+++ b/tests/fixtures/models/soft-deletes-phpdoc-laravel8.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property int $id
- * @property int $post_id
  * @property \Carbon\Carbon $deleted_at
+ * @property int $post_id
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  */

--- a/tests/fixtures/models/soft-deletes-phpdoc.php
+++ b/tests/fixtures/models/soft-deletes-phpdoc.php
@@ -7,8 +7,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property int $id
- * @property int $post_id
  * @property \Carbon\Carbon $deleted_at
+ * @property int $post_id
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  */


### PR DESCRIPTION
Migrations should now respect the explicit order from the draft file.

Resolves #485 