### PR TITLE
Added path option to Trace command

### DIFF
--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -15,7 +15,9 @@ class TraceCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'blueprint:trace';
+    protected $signature = 'blueprint:trace
+                            {--path= : Comma separated list of paths to search in }
+                            ';
 
     /**
      * The console command description.
@@ -50,7 +52,8 @@ class TraceCommand extends Command
     public function handle()
     {
         $blueprint = resolve(Blueprint::class);
-        $definitions = $this->tracer->execute($blueprint, $this->filesystem);
+        $path = $this->option('path') ?: '';
+        $definitions = $this->tracer->execute($blueprint, $this->filesystem, $path);
 
         if (empty($definitions)) {
             $this->error('No models found');

--- a/src/Commands/TraceCommand.php
+++ b/src/Commands/TraceCommand.php
@@ -16,7 +16,7 @@ class TraceCommand extends Command
      * @var string
      */
     protected $signature = 'blueprint:trace
-                            {--path= : Comma separated list of paths to search in }
+                            {--path=* : List of paths to search in }
                             ';
 
     /**
@@ -52,7 +52,7 @@ class TraceCommand extends Command
     public function handle()
     {
         $blueprint = resolve(Blueprint::class);
-        $path = $this->option('path') ?: '';
+        $path = $this->option('path');
         $definitions = $this->tracer->execute($blueprint, $this->filesystem, $path);
 
         if (empty($definitions)) {

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -11,19 +11,17 @@ class Tracer
     /** @var Filesystem */
     private $filesystem;
 
-    public function execute(Blueprint $blueprint, Filesystem $filesystem, string $path): array
+    public function execute(Blueprint $blueprint, Filesystem $filesystem, array $paths = null): array
     {
         $this->filesystem = $filesystem;
 
-        if (!$path) {
-            $path = Blueprint::appPath();
+        if (empty($paths)) {
+            $paths = [Blueprint::appPath()];
 
             if (config('blueprint.models_namespace')) {
-                $path .= '/'.str_replace('\\', '/', config('blueprint.models_namespace'));
+                $paths[0] .= '/'.str_replace('\\', '/', config('blueprint.models_namespace'));
             }
         }
-
-        $paths = array_filter(explode(',', $path));
 
         $definitions = [];
         foreach ($this->appClasses($paths) as $class) {

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -61,11 +61,11 @@ class Tracer
         }
 
         return array_map(function (\SplFIleInfo $file) {
-            $content = \Str::of($this->filesystem->get($file->getPathName()));
-            $namespace = $content->match("/namespace ([\w\\\\]+)/");
-            $class = $content->match("/class (\w+)/");
+            $content = $this->filesystem->get($file->getPathName());
+            preg_match("/namespace ([\w\\\\]+)/", $content, $namespace);
+            preg_match("/class (\w+)/", $content, $class);
 
-            return "$namespace\\$class";
+            return ($namespace[1] ?? '').'\\'.($class[1] ?? '');
         }, $classes);
     }
 

--- a/tests/Feature/Commands/EraseCommandTest.php
+++ b/tests/Feature/Commands/EraseCommandTest.php
@@ -83,6 +83,6 @@ class EraseCommandTest extends TestCase
             ->assertExitCode(0);
 
         $tracer->shouldHaveReceived('execute')
-            ->with(resolve(Blueprint::class), $this->filesystem, '');
+            ->with(resolve(Blueprint::class), $this->filesystem, []);
     }
 }

--- a/tests/Feature/Commands/EraseCommandTest.php
+++ b/tests/Feature/Commands/EraseCommandTest.php
@@ -83,6 +83,6 @@ class EraseCommandTest extends TestCase
             ->assertExitCode(0);
 
         $tracer->shouldHaveReceived('execute')
-            ->with(resolve(Blueprint::class), $this->filesystem);
+            ->with(resolve(Blueprint::class), $this->filesystem, '');
     }
 }

--- a/tests/Feature/Commands/TraceCommandTest.php
+++ b/tests/Feature/Commands/TraceCommandTest.php
@@ -23,7 +23,7 @@ class TraceCommandTest extends TestCase
         $tracer = $this->mock(Tracer::class);
 
         $tracer->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $this->files)
+            ->with(resolve(Blueprint::class), $this->files, '')
             ->andReturn([]);
 
         $this->artisan('blueprint:trace')
@@ -37,7 +37,7 @@ class TraceCommandTest extends TestCase
         $tracer = $this->mock(Tracer::class);
 
         $tracer->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $this->files)
+            ->with(resolve(Blueprint::class), $this->files, '')
             ->andReturn([
                 "Model" => [],
                 "OtherModel" => [],
@@ -46,5 +46,22 @@ class TraceCommandTest extends TestCase
         $this->artisan('blueprint:trace')
             ->assertExitCode(0)
             ->expectsOutput('Traced 2 models');
+    }
+
+    /** @test */
+    public function it_passes_the_command_path_to_tracer()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->with('test.yml')
+            ->andReturnTrue();
+
+        $builder = $this->mock(Builder::class);
+
+        $builder->shouldReceive('execute')
+            ->with(resolve(Blueprint::class), $this->files, 'vendor/package/src/app/Models')
+            ->andReturn([]);
+
+        $this->artisan('blueprint:trace --path=vendor/package/src/app/Models')
+            ->assertExitCode(0);
     }
 }

--- a/tests/Feature/Commands/TraceCommandTest.php
+++ b/tests/Feature/Commands/TraceCommandTest.php
@@ -23,7 +23,7 @@ class TraceCommandTest extends TestCase
         $tracer = $this->mock(Tracer::class);
 
         $tracer->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $this->files, '')
+            ->with(resolve(Blueprint::class), $this->files, [])
             ->andReturn([]);
 
         $this->artisan('blueprint:trace')
@@ -37,7 +37,7 @@ class TraceCommandTest extends TestCase
         $tracer = $this->mock(Tracer::class);
 
         $tracer->shouldReceive('execute')
-            ->with(resolve(Blueprint::class), $this->files, '')
+            ->with(resolve(Blueprint::class), $this->files, [])
             ->andReturn([
                 "Model" => [],
                 "OtherModel" => [],


### PR DESCRIPTION
Hi @jasonmccreary.

Until now Trace Command would read files from app path, or if set, it would read files from `config('blueprint.models_namespace')`.

This PR adds the possibility to trace models outside `app`, for instance, developers may load files from `.\vendor\...` or `.\packages\...`, and they may provide multiple paths, comma separated.

```Batchfile
php artisan blueprint:trace --path="vendor\spatie\laravel-permission\src\Models,packages\my-package\src\Models"
Traced 7 models
```

The `appClasses` function now loads the file content to get its namespace, previously it was using the path of the working folder (for instance, `app` or `app\Models`) and the filename, to infer `App\Models\User`. 

Since now we can load files from other paths, like `vendor\spatie\laravel-permission\src\Models` we can't infer the namespace from that path, hence the file content is loaded to get the correct namespace `Spatie\Permission\Models\Role`.

I've also fixed the tests in order to receive the extra path argument, and added a Test to check if the option is received.

I tried to make the PR as short as possible, changing only the necessary lines.
Let me know if I miss something with this approach.