### PR TITLE
Make `relativeClassName` return class name relative to models namespace

### DIFF
--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -237,9 +237,6 @@ class Tracer
     private function relativeClassName($model)
     {
         $name = Blueprint::relativeNamespace(get_class($model));
-        if (config('blueprint.models_namespace')) {
-            return $name;
-        }
 
         return ltrim(str_replace(config('blueprint.models_namespace'), '', $name), '\\');
     }

--- a/tests/Feature/Commands/TraceCommandTest.php
+++ b/tests/Feature/Commands/TraceCommandTest.php
@@ -47,4 +47,26 @@ class TraceCommandTest extends TestCase
             ->assertExitCode(0)
             ->expectsOutput('Traced 2 models');
     }
+
+    /** @test */
+    public function relative_class_name_removes_models_namespace()
+    {
+        $this->requireFixture('models/comment.php');
+        $this->requireFixture('models/custom-models-namespace.php');
+
+        $method = new \ReflectionMethod(Tracer::class, 'relativeClassName');
+        $method->setAccessible(true);
+
+        // App namespace
+        config(['blueprint.models_namespace' => '']);
+
+        $this->assertEquals($method->invoke(new Tracer(), app('App\Comment')), 'Comment');
+        $this->assertEquals($method->invoke(new Tracer(), app('App\Models\Tag')), 'Models\Tag');
+
+        // Models namespace
+        config(['blueprint.models_namespace' => 'Models']);
+
+        $this->assertEquals($method->invoke(new Tracer(), app('App\Comment')), 'Comment');
+        $this->assertEquals($method->invoke(new Tracer(), app('App\Models\Tag')), 'Tag');
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,6 +38,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
         return file_get_contents(__DIR__ . '/' . 'fixtures' . '/' . ltrim($path, '/'));
     }
 
+    public function requireFixture(string $path)
+    {
+        require_once __DIR__ . '/' . 'fixtures' . '/' . ltrim($path, '/');
+    }
+
     public function stub(string $path)
     {
         return file_get_contents(__DIR__ . '/../' . 'stubs' . '/' . ltrim($path, '/'));


### PR DESCRIPTION
This is a fix to #490.

This makes `relativeClassName` return the classname relative to models namespace.

The tests are ok, as far as I know this is only used to generate relationships of new entries, and that is working too.

This function was a little bit nonsense, because it first checked if config was set, if so, return, otherwise it would return a string where it would try to replace/remove the config, but there the config was never set anyway. I believe this was introduced to overcome the issue that was fixed on #477.

---

Before this PR, with `'models_namespace' => 'Models'` config, `Trace` would generate the following `.blueprint`;


```yaml
models:
    Models\Address: { street: 'string nullable', country: string, icon_id: 'integer nullable', monster_id: integer }
    Models\Icon: { name: string, icon: string }
```

With this, the paths are relative to `models_namepsace` config;

``` yaml
models:
    Address: { street: 'string nullable', country: string, icon_id: 'integer nullable', monster_id: integer }
    Icon: { name: string, icon: string }
```

This will avoid the "double" `Model\` on relationships namespaces.