### PR TITLE
Added support for `useCurrentOnUpdate` modifier

### DIFF
--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -90,6 +90,7 @@ class ModelLexer implements Lexer
         'nullable' => 'nullable',
         'unsigned' => 'unsigned',
         'usecurrent' => 'useCurrent',
+        'usecurrentonupdate' => 'useCurrentOnUpdate',
         'always' => 'always',
         'unique' => 'unique',
         'index' => 'index',

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -226,6 +226,7 @@ class ModelLexerTest extends TestCase
                     'sequence' => 'unsignedbiginteger autoincrement',
                     'content' => 'longtext',
                     'saved_at' => 'timestamptz usecurrent',
+                    'updated_at' => 'timestamptz usecurrent usecurrentOnUpdate',
                 ],
             ],
         ];
@@ -241,7 +242,7 @@ class ModelLexerTest extends TestCase
         $this->assertFalse($model->usesSoftDeletes());
 
         $columns = $model->columns();
-        $this->assertCount(4, $columns);
+        $this->assertCount(5, $columns);
         $this->assertEquals('id', $columns['id']->name());
         $this->assertEquals('id', $columns['id']->dataType());
         $this->assertEquals([], $columns['id']->attributes());
@@ -258,6 +259,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals('timestampTz', $columns['saved_at']->dataType());
         $this->assertEquals([], $columns['saved_at']->attributes());
         $this->assertEquals(['useCurrent'], $columns['saved_at']->modifiers());
+        $this->assertEquals(['useCurrent', 'useCurrentOnUpdate'], $columns['updated_at']->modifiers());
     }
 
     /**

--- a/tests/fixtures/drafts/post.yaml
+++ b/tests/fixtures/drafts/post.yaml
@@ -4,5 +4,6 @@ models:
     author_id: id
     author_bio: longtext
     content: bigtext nullable
-    published_at: timestamp nullable
+    published_at: timestamp nullable useCurrent
+    updated_at: timestamp nullable useCurrent useCurrentOnUpdate
     word_count: integer unsigned

--- a/tests/fixtures/factories/post-configured-laravel8.php
+++ b/tests/fixtures/factories/post-configured-laravel8.php
@@ -29,6 +29,7 @@ class PostFactory extends Factory
             'author_bio' => $this->faker->text,
             'content' => $this->faker->paragraphs(3, true),
             'published_at' => $this->faker->dateTime(),
+            'updated_at' => $this->faker->dateTime(),
             'word_count' => $this->faker->randomNumber(),
         ];
     }

--- a/tests/fixtures/factories/post-configured.php
+++ b/tests/fixtures/factories/post-configured.php
@@ -12,6 +12,7 @@ $factory->define(Post::class, function (Faker $faker) {
         'author_bio' => $faker->text,
         'content' => $faker->paragraphs(3, true),
         'published_at' => $faker->dateTime(),
+        'updated_at' => $faker->dateTime(),
         'word_count' => $faker->randomNumber(),
     ];
 });

--- a/tests/fixtures/factories/post-laravel8.php
+++ b/tests/fixtures/factories/post-laravel8.php
@@ -29,6 +29,7 @@ class PostFactory extends Factory
             'author_bio' => $this->faker->text,
             'content' => $this->faker->paragraphs(3, true),
             'published_at' => $this->faker->dateTime(),
+            'updated_at' => $this->faker->dateTime(),
             'word_count' => $this->faker->randomNumber(),
         ];
     }

--- a/tests/fixtures/factories/post.php
+++ b/tests/fixtures/factories/post.php
@@ -12,6 +12,7 @@ $factory->define(Post::class, function (Faker $faker) {
         'author_bio' => $faker->text,
         'content' => $faker->paragraphs(3, true),
         'published_at' => $faker->dateTime(),
+        'updated_at' => $faker->dateTime(),
         'word_count' => $faker->randomNumber(),
     ];
 });


### PR DESCRIPTION
Since [v8.36.0](https://github.com/laravel/framework/blob/b09394ed478551d01f5a6ce3111e4d140041bc82/CHANGELOG-8.x.md#v8360-2021-04-06), Laravel supports the `useCurrentOnUpdate` modifier – https://github.com/laravel/framework/pull/36817
This PR adds it to the list of `$modifiers`.

