### PR TITLE
FIX - return types in controller when use resource: api

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -183,7 +183,11 @@ class ControllerGenerator implements Generator
             }
 
             if (Blueprint::supportsReturnTypeHits()) {
-                $method = str_replace(')' . PHP_EOL, '): \Illuminate\Http\Response' . PHP_EOL, $method);
+                if($controller->isApiResource()) {
+                    $method = str_replace(')' . PHP_EOL, '): \\' . $fqcn . PHP_EOL, $method);
+                } else {
+                    $method = str_replace(')' . PHP_EOL, '): \Illuminate\Http\Response' . PHP_EOL, $method);
+                }
             }
 
             $methods .= PHP_EOL . $method;

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -183,7 +183,7 @@ class ControllerGenerator implements Generator
             }
 
             if (Blueprint::supportsReturnTypeHits()) {
-                if ($controller->isApiResource()) {
+                if (isset($fqcn) && $name !== 'destroy' && $controller->isApiResource()) {
                     $method = str_replace(')' . PHP_EOL, '): \\' . $fqcn . PHP_EOL, $method);
                 } else {
                     $method = str_replace(')' . PHP_EOL, '): \Illuminate\Http\Response' . PHP_EOL, $method);

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -183,7 +183,7 @@ class ControllerGenerator implements Generator
             }
 
             if (Blueprint::supportsReturnTypeHits()) {
-                if($controller->isApiResource()) {
+                if ($controller->isApiResource()) {
                     $method = str_replace(')' . PHP_EOL, '): \\' . $fqcn . PHP_EOL, $method);
                 } else {
                     $method = str_replace(')' . PHP_EOL, '): \Illuminate\Http\Response' . PHP_EOL, $method);

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -195,6 +195,38 @@ class ControllerGeneratorTest extends TestCase
         $this->assertEquals(['created' => ['app/Http/Controllers/TermController.php']], $this->subject->output($tree));
     }
 
+    /**
+     * @test
+     * @environment-setup useLaravel8
+     */
+    public function output_using_return_types_for_api_resource_controller()
+    {
+        $this->app['config']->set('blueprint.use_return_types', true);
+
+        $this->filesystem->expects('stub')
+            ->with('controller.class.stub')
+            ->andReturn($this->stub('controller.class.stub'));
+
+        $this->filesystem->expects('stub')
+            ->with('controller.method.stub')
+            ->andReturn($this->stub('controller.method.stub'));
+
+        $this->filesystem->expects('exists')
+            ->with('app/Http/Controllers')
+            ->andReturnFalse();
+
+        $this->filesystem->expects('makeDirectory')
+            ->with('app/Http/Controllers', 0755, true);
+
+        $this->filesystem->expects('put')
+            ->with('app/Http/Controllers/PostController.php', $this->fixture('controllers/return-type-declarations-api-resource.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/return-type-declarations-api-controller.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['app/Http/Controllers/PostController.php']], $this->subject->output($tree));
+    }
+
     public function controllerTreeDataProvider()
     {
         return [

--- a/tests/fixtures/controllers/return-type-declarations-api-resource.php
+++ b/tests/fixtures/controllers/return-type-declarations-api-resource.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\PostStoreRequest;
+use App\Http\Requests\PostUpdateRequest;
+use App\Http\Resources\PostCollection;
+use App\Http\Resources\PostResource;
+use App\Post;
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \App\Http\Resources\PostCollection
+     */
+    public function index(Request $request): \App\Http\Resources\PostCollection
+    {
+        $posts = Post::paginate();
+
+        return new PostCollection($posts);
+    }
+
+    /**
+     * @param \App\Http\Requests\PostStoreRequest $request
+     * @return \App\Http\Resources\PostResource
+     */
+    public function store(PostStoreRequest $request): \App\Http\Resources\PostResource
+    {
+        $post = Post::create($request->validated());
+
+        return new PostResource($post);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Post $post
+     * @return \App\Http\Resources\PostResource
+     */
+    public function show(Request $request, Post $post): \App\Http\Resources\PostResource
+    {
+        return new PostResource($post);
+    }
+
+    /**
+     * @param \App\Http\Requests\PostUpdateRequest $request
+     * @param \App\Post $post
+     * @return \App\Http\Resources\PostResource
+     */
+    public function update(PostUpdateRequest $request, Post $post): \App\Http\Resources\PostResource
+    {
+        $post->update($request->validated());
+
+        return new PostResource($post);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Post $post
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Request $request, Post $post): \Illuminate\Http\Response
+    {
+        $post->delete();
+
+        return response()->noContent();
+    }
+}

--- a/tests/fixtures/drafts/return-type-declarations-api-controller.yaml
+++ b/tests/fixtures/drafts/return-type-declarations-api-controller.yaml
@@ -1,0 +1,11 @@
+models:
+  Post:
+    title: string
+    body: text
+controllers:
+  Post:
+    resource: api
+    index:
+      query: all
+      resource: 'paginate:posts'
+seeders: Post


### PR DESCRIPTION
Hello,

When I generate controllers with resource:api and with use_return_types set to true.

The return type controller is set to Response instead of the Resource

Before :
![image](https://user-images.githubusercontent.com/3316758/128887453-ee685eef-6fe5-498e-bd2c-7b15d10f3cf4.png)

After : 
![image](https://user-images.githubusercontent.com/3316758/128887352-ff7e7bdd-2522-48b5-afdd-eb242e572e99.png)

