### PR TITLE
Fix Trace command when non valid files are found

### DIFF
--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -60,13 +60,17 @@ class Tracer
             $classes = array_merge($classes, $this->filesystem->allFiles($path));
         }
 
-        return array_map(function (\SplFIleInfo $file) {
+        return array_filter(array_map(function (\SplFIleInfo $file) {
             $content = $this->filesystem->get($file->getPathName());
             preg_match("/namespace ([\w\\\\]+)/", $content, $namespace);
             preg_match("/class (\w+)/", $content, $class);
 
-            return ($namespace[1] ?? '').'\\'.($class[1] ?? '');
-        }, $classes);
+            if ($namespace) {
+                return $namespace[1].'\\'.$class[1];
+            }
+
+            return $class[1] ?? '';
+        }, $classes));
     }
 
     private function loadModel(string $class)

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -61,15 +61,15 @@ class Tracer
         }
 
         return array_filter(array_map(function (\SplFIleInfo $file) {
+            if ($file->getExtension() !== 'php') {
+                return;
+            }
+
             $content = $this->filesystem->get($file->getPathName());
             preg_match("/namespace ([\w\\\\]+)/", $content, $namespace);
             preg_match("/class (\w+)/", $content, $class);
 
-            if ($namespace) {
-                return $namespace[1].'\\'.$class[1];
-            }
-
-            return $class[1] ?? '';
+            return ($namespace[1] ?? '').'\\'.($class[1] ?? '');
         }, $classes));
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,6 +30,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $app['config']->set('blueprint.generate_phpdocs', false);
         $app['config']->set('blueprint.use_constraints', false);
         $app['config']->set('blueprint.fake_nullables', true);
+        $app['config']->set('database.default', 'testing');
     }
 
     public function fixture(string $path)


### PR DESCRIPTION
Hi @jasonmccreary!

My last PR (https://github.com/laravel-shift/blueprint/pull/488) introduced a possible problem on Trace command, so I'm here to fix it!

We found that non valid files, like a `.zip` file, breaks the Trace command, it generates an empty entry with a backslash (`"\"`), and `class_exists` breaks with that string.

It's a rare situation, but when it happens developers have no feedback about it.
This PR fixes it.