### PR TITLE
change property tree to protected - issue 479 - now you can extend Mo…

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -20,7 +20,7 @@ class ModelGenerator implements Generator
     /**
      * @var Tree
      */
-    private $tree;
+    protected $tree;
 
     public function __construct(Filesystem $filesystem)
     {


### PR DESCRIPTION
Change propriety of variable three to protected

In Blueprint\Generators\ModelGenerator; There is a private propriety called $tree - line 18;
When I extends ModelGenerator, I get a error in line 435 because $tree is private.
$model = $this->tree->modelForContext($model_name);