### PR TITLE
Add foreignUuid method to replace uuid() and foreign()

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -173,7 +173,7 @@ class MigrationGenerator implements Generator
                 $column_definition .= '$table->' . $dataType . "('{$column->name()}'";
             }
 
-            if (! empty($column->attributes()) && ! in_array($column->dataType(), ['id', 'uuid'])) {
+            if (! empty($column->attributes()) && ! $this->isIdOrUuid($column->dataType())) {
                 $column_definition .= ', ';
                 if (in_array($column->dataType(), ['set', 'enum'])) {
                     $column_definition .= json_encode($column->attributes());
@@ -198,7 +198,7 @@ class MigrationGenerator implements Generator
                     $column->modifiers()
                 );
 
-                if ($column->dataType() === 'id' && $this->isLaravel7orNewer()) {
+                if ($this->isIdOrUuid($column->dataType()) && $this->isLaravel7orNewer()) {
                     $column_definition = $foreign;
                     $foreign = '';
                 }
@@ -210,7 +210,7 @@ class MigrationGenerator implements Generator
                         || (is_array($modifier) && key($modifier) === 'onDelete')
                         || (is_array($modifier) && key($modifier) === 'onUpdate')
                         || $modifier === 'foreign'
-                        || ($modifier === 'nullable' && $this->isLaravel7orNewer() && $column->dataType() === 'id');
+                        || ($modifier === 'nullable' && $this->isLaravel7orNewer() && $this->isIdOrUuid($column->dataType()));
                     }
                 );
             }
@@ -237,7 +237,6 @@ class MigrationGenerator implements Generator
             if (! empty($foreign)) {
                 $column_definition .= $foreign . ';' . PHP_EOL;
             }
-
             $definition .= $column_definition;
         }
 
@@ -305,7 +304,7 @@ class MigrationGenerator implements Generator
             $column = Str::afterLast($column_name, '_');
         }
 
-        if ($type === 'id' && ! empty($attributes)) {
+        if ($this->isIdOrUuid($type) && ! empty($attributes)) {
             $table = Str::lower(Str::plural($attributes[0]));
         }
 
@@ -322,10 +321,16 @@ class MigrationGenerator implements Generator
             $on_update_suffix = self::ON_UPDATE_CLAUSES[$on_update_clause];
         }
 
-        if ($this->isLaravel7orNewer() && $type === 'id') {
+        if ($this->isLaravel7orNewer() && $this->isIdOrUuid($type)) {
+            if ($type === 'uuid') {
+                $method = 'foreignUuid';
+            } else {
+                $method = 'foreignId';
+            }
+
             $prefix = in_array('nullable', $modifiers)
-                ? '$table->foreignId' . "('{$column_name}')->nullable()"
-                : '$table->foreignId' . "('{$column_name}')";
+                ? '$table->' . "{$method}('{$column_name}')->nullable()"
+                : '$table->' . "{$method}('{$column_name}')";
 
             if ($on_delete_clause === 'cascade') {
                 $on_delete_suffix = '->cascadeOnDelete()';
@@ -448,7 +453,7 @@ class MigrationGenerator implements Generator
         }
 
         return config('blueprint.use_constraints')
-            && ($column->dataType() === 'id' || $column->dataType() === 'uuid' && Str::endsWith($column->name(), '_id'));
+            && ($this->isIdOrUuid($column->dataType()) && Str::endsWith($column->name(), '_id'));
     }
 
     protected function isNumericDefault(string $type, string $value): bool
@@ -467,5 +472,10 @@ class MigrationGenerator implements Generator
                     return strtolower($value) === strtolower($type);
                 }
             );
+    }
+
+    protected function isIdOrUuid(string $dataType)
+    {
+        return in_array($dataType, ['id', 'uuid']);
     }
 }

--- a/tests/fixtures/migrations/model-key-constraints.php
+++ b/tests/fixtures/migrations/model-key-constraints.php
@@ -19,8 +19,7 @@ class CreateOrdersTable extends Migration
             $table->uuid('id')->primary();
             $table->foreignId('user_id')->constrained();
             $table->string('external_id')->nullable()->index();
-            $table->uuid('sub_id');
-            $table->foreign('sub_id')->references('id')->on('subscriptions');
+            $table->foreignUuid('sub_id')->constrained('subscriptions');
             $table->timestamp('expires_at')->nullable()->index();
             $table->json('meta')->default('[]');
             $table->timestamps();

--- a/tests/fixtures/migrations/uuid-shorthand-constraint.php
+++ b/tests/fixtures/migrations/uuid-shorthand-constraint.php
@@ -17,8 +17,7 @@ class CreatePeopleTable extends Migration
 
         Schema::create('people', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->uuid('company_id');
-            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade')->onUpdate('cascade');
+            $table->foreignUuid('company_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
             $table->timestamps();
         });
 


### PR DESCRIPTION
This pull request will change

```php
$table->uuid('sub_id');
$table->foreign('sub_id')->references('id')->on('subscriptions');
```

with the Laravel 8 `foreignUuid` method

```php
$table->foreignUuid('sub_id')->constrained('subscriptions');
```