### PR TITLE
If $on is a class, we will try to fetch the table from that class

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -300,7 +300,7 @@ class MigrationGenerator implements Generator
         } elseif (Str::contains($on, '.')) {
             [$table, $column] = explode('.', $on);
             $table = Str::snake($table);
-        } elseif (Str::contains($on, '\\') && class_exists($on)) {
+        } elseif (Str::contains($on, '\\')) {
             $table = (new $on())->getTable();
             $column = Str::afterLast($column_name, '_');
         } else {

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -300,6 +300,9 @@ class MigrationGenerator implements Generator
         } elseif (Str::contains($on, '.')) {
             [$table, $column] = explode('.', $on);
             $table = Str::snake($table);
+        } elseif (Str::contains($on, '\\') && class_exists($on)) {
+            $table = (new $on())->getTable();
+            $column = Str::afterLast($column_name, '_');
         } else {
             $table = Str::plural($on);
             $column = Str::afterLast($column_name, '_');

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -295,7 +295,7 @@ class MigrationGenerator implements Generator
             [$table, $column] = explode('.', $on);
             $table = Str::snake($table);
         } elseif (Str::contains($on, '\\')) {
-            $table = (new $on())->getTable();
+            $table = Str::lower(Str::plural(Str::afterLast($on, '\\')));
             $column = Str::afterLast($column_name, '_');
         } else {
             $table = Str::plural($on);

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -604,6 +604,7 @@ class MigrationGeneratorTest extends TestCase
             ['drafts/enum-options.yaml', 'database/migrations/timestamp_create_messages_table.php', 'migrations/enum-options.php'],
             ['drafts/columns-with-comments.yaml', 'database/migrations/timestamp_create_professions_table.php', 'migrations/columns-with-comments.php'],
             ['drafts/boolean-column-default.yaml', 'database/migrations/timestamp_create_posts_table.php', 'migrations/boolean-column-default.php'],
+            ['drafts/foreign-with-class.yaml', 'database/migrations/timestamp_create_events_table.php', 'migrations/foreign-with-class.php'],
         ];
     }
 }

--- a/tests/Models/Attachment.php
+++ b/tests/Models/Attachment.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Attachment extends Model
+{}

--- a/tests/Models/Attachment.php
+++ b/tests/Models/Attachment.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Tests\Models;
-
-use Illuminate\Database\Eloquent\Model;
-
-class Attachment extends Model
-{
-}

--- a/tests/Models/Attachment.php
+++ b/tests/Models/Attachment.php
@@ -5,4 +5,5 @@ namespace Tests\Models;
 use Illuminate\Database\Eloquent\Model;
 
 class Attachment extends Model
-{}
+{
+}

--- a/tests/fixtures/drafts/foreign-with-class.yaml
+++ b/tests/fixtures/drafts/foreign-with-class.yaml
@@ -1,0 +1,4 @@
+models:
+  Event:
+    working_title: string
+    image_id: uuid foreign:\Tests\Models\Attachment nullable

--- a/tests/fixtures/migrations/foreign-with-class.php
+++ b/tests/fixtures/migrations/foreign-with-class.php
@@ -18,8 +18,7 @@ class CreateEventsTable extends Migration
         Schema::create('events', function (Blueprint $table) {
             $table->id();
             $table->string('working_title');
-            $table->uuid('image_id')->nullable();
-            $table->foreign('image_id')->references('id')->on('attachments');
+            $table->foreignUuid('image_id')->nullable()->constrained('attachments');
             $table->timestamps();
         });
 

--- a/tests/fixtures/migrations/foreign-with-class.php
+++ b/tests/fixtures/migrations/foreign-with-class.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('events', function (Blueprint $table) {
+            $table->id();
+            $table->string('working_title');
+            $table->uuid('image_id')->nullable();
+            $table->foreign('image_id')->references('id')->on('attachments');
+            $table->timestamps();
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('events');
+    }
+}


### PR DESCRIPTION
This syntax is currently generating a wrong migration

```yaml
models:
  Event:
    working_title: string
    image_id: uuid foreign:\Foo\Bar\Attachment
```

```php
$table->foreign('image_id')->references('id')->on('\Foo\Bar\Attachments');
```

This makes that inserting record in mysql will fail, since `\Foo\Bar\Attachments` is not an existing table.

The changes in this pull request will fix this.

New output will be 
```php
$table->foreignUuid('image_id')->constrained('attachments');
```