### PR TITLE
feat: remove private in favor of protected

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -29,12 +29,12 @@ class ControllerGenerator implements Generator
      */
     protected $filesystem;
 
-    private $imports = [];
+    protected $imports = [];
 
     /**
      * @var Tree
      */
-    private $tree;
+    protected $tree;
 
     public function __construct(Filesystem $filesystem)
     {
@@ -219,12 +219,12 @@ class ControllerGenerator implements Generator
         );
     }
 
-    private function addImport(Controller $controller, $class)
+    protected function addImport(Controller $controller, $class)
     {
         $this->imports[$controller->name()][] = $class;
     }
 
-    private function determineModel(Controller $controller, ?string $reference)
+    protected function determineModel(Controller $controller, ?string $reference)
     {
         if (empty($reference) || $reference === 'id') {
             return $this->fullyQualifyModelReference($controller->namespace(), Str::studly(Str::singular($controller->prefix())));
@@ -237,7 +237,7 @@ class ControllerGenerator implements Generator
         return $this->fullyQualifyModelReference($controller->namespace(), Str::studly($reference));
     }
 
-    private function fullyQualifyModelReference(string $sub_namespace, string $model_name)
+    protected function fullyQualifyModelReference(string $sub_namespace, string $model_name)
     {
         // TODO: get model_name from tree.
         // If not found, assume parallel namespace as controller.

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -23,9 +23,9 @@ class FactoryGenerator implements Generator
     /**
      * @var Tree
      */
-    private $tree;
+    protected $tree;
 
-    private $imports = [];
+    protected $imports = [];
 
     public function __construct(Filesystem $filesystem)
     {
@@ -228,12 +228,12 @@ class FactoryGenerator implements Generator
         );
     }
 
-    private function addImport(Model $model, $class)
+    protected function addImport(Model $model, $class)
     {
         $this->imports[$model->name()][] = $class;
     }
 
-    private function fillableColumns(array $columns): array
+    protected function fillableColumns(array $columns): array
     {
         if (config('blueprint.fake_nullables')) {
             return $columns;
@@ -247,7 +247,7 @@ class FactoryGenerator implements Generator
         );
     }
 
-    private function fullyQualifyModelReference(string $model_name)
+    protected function fullyQualifyModelReference(string $model_name)
     {
         return $this->tree->modelForContext($model_name);
     }

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -48,9 +48,9 @@ class MigrationGenerator implements Generator
      */
     protected $filesystem;
 
-    private $output = [];
+    protected $output = [];
 
-    private $hasForeignKeyConstraints = false;
+    protected $hasForeignKeyConstraints = false;
 
     public function __construct(Filesystem $filesystem)
     {
@@ -435,7 +435,7 @@ class MigrationGenerator implements Generator
         return strtolower(implode('_', $segments));
     }
 
-    private function shouldAddForeignKeyConstraint(\Blueprint\Models\Column $column)
+    protected function shouldAddForeignKeyConstraint(\Blueprint\Models\Column $column)
     {
         if ($column->name() === 'id') {
             return false;

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -268,7 +268,7 @@ class ModelGenerator implements Generator
         return $stub;
     }
 
-    private function fillableColumns(array $columns)
+    protected function fillableColumns(array $columns)
     {
         return array_diff(
             array_keys($columns),
@@ -282,7 +282,7 @@ class ModelGenerator implements Generator
         );
     }
 
-    private function hiddenColumns(array $columns)
+    protected function hiddenColumns(array $columns)
     {
         return array_intersect(
             array_keys($columns),
@@ -293,7 +293,7 @@ class ModelGenerator implements Generator
         );
     }
 
-    private function castableColumns(array $columns)
+    protected function castableColumns(array $columns)
     {
         return array_filter(
             array_map(
@@ -305,7 +305,7 @@ class ModelGenerator implements Generator
         );
     }
 
-    private function dateColumns(array $columns)
+    protected function dateColumns(array $columns)
     {
         return array_map(
             function (Column $column) {
@@ -322,7 +322,7 @@ class ModelGenerator implements Generator
         );
     }
 
-    private function castForColumn(Column $column)
+    protected function castForColumn(Column $column)
     {
         if ($column->dataType() === 'date') {
             return 'date';
@@ -357,7 +357,7 @@ class ModelGenerator implements Generator
         }
     }
 
-    private function pretty_print_array(array $data, $assoc = true)
+    protected function pretty_print_array(array $data, $assoc = true)
     {
         $output = var_export($data, true);
         $output = preg_replace('/^\s+/m', '        ', $output);
@@ -370,7 +370,7 @@ class ModelGenerator implements Generator
         return trim(str_replace("\n", PHP_EOL, $output));
     }
 
-    private function phpDataType(string $dataType)
+    protected function phpDataType(string $dataType)
     {
         static $php_data_types = [
             'id' => 'int',
@@ -413,7 +413,7 @@ class ModelGenerator implements Generator
         return $php_data_types[strtolower($dataType)] ?? 'string';
     }
 
-    private function fullyQualifyModelReference(string $model_name)
+    protected function fullyQualifyModelReference(string $model_name)
     {
         // TODO: get model_name from tree.
         // If not found, assume parallel namespace as controller.

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -13,7 +13,7 @@ class RouteGenerator implements Generator
     /**
      * @var Filesystem
      */
-    private $filesystem;
+    protected $filesystem;
 
     public function __construct(Filesystem $filesystem)
     {

--- a/src/Generators/SeederGenerator.php
+++ b/src/Generators/SeederGenerator.php
@@ -17,9 +17,9 @@ class SeederGenerator implements Generator
     /**
      * @var Tree
      */
-    private $tree;
+    protected $tree;
 
-    private $imports = [];
+    protected $imports = [];
 
     public function __construct(Filesystem $filesystem)
     {
@@ -93,12 +93,12 @@ class SeederGenerator implements Generator
         );
     }
 
-    private function addImport(string $model, $class)
+    protected function addImport(string $model, $class)
     {
         $this->imports[$model][] = $class;
     }
 
-    private function getPath($model)
+    protected function getPath($model)
     {
         return 'database/seeders/' . $model . 'Seeder.php';
     }

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Str;
 
 class FormRequestGenerator implements Generator
 {
-    private const INDENT = '            ';
+    protected const INDENT = '            ';
 
     /**
      * @var Filesystem
@@ -23,7 +23,7 @@ class FormRequestGenerator implements Generator
     /**
      * @var Tree
      */
-    private $tree;
+    protected $tree;
 
     public function __construct(Filesystem $filesystem)
     {
@@ -120,12 +120,12 @@ class FormRequestGenerator implements Generator
         );
     }
 
-    private function getName(string $context, string $method)
+    protected function getName(string $context, string $method)
     {
         return $context . Str::studly($method) . 'Request';
     }
 
-    private function splitField($field)
+    protected function splitField($field)
     {
         if (Str::contains($field, '.')) {
             return explode('.', $field, 2);
@@ -134,7 +134,7 @@ class FormRequestGenerator implements Generator
         return [null, $field];
     }
 
-    private function validationRules(string $qualifier, string $column)
+    protected function validationRules(string $qualifier, string $column)
     {
         /**
  * @var \Blueprint\Models\Model $model

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -24,7 +24,7 @@ class ResourceGenerator implements Generator
     /**
      * @var Tree
      */
-    private $tree;
+    protected $tree;
 
     public function __construct(Filesystem $filesystem)
     {
@@ -146,7 +146,7 @@ class ResourceGenerator implements Generator
         return implode(PHP_EOL, $data);
     }
 
-    private function visibleColumns(Model $model)
+    protected function visibleColumns(Model $model)
     {
         return array_diff(
             array_keys($model->columns()),

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -34,11 +34,11 @@ class TestGenerator implements Generator
     protected $filesystem;
 
     /** @var Tree */
-    private $tree;
+    protected $tree;
 
-    private $imports = [];
-    private $stubs = [];
-    private $traits = [];
+    protected $imports = [];
+    protected $stubs = [];
+    protected $traits = [];
 
     public function __construct(Filesystem $filesystem)
     {
@@ -529,7 +529,7 @@ class TestGenerator implements Generator
         }, $imports));
     }
 
-    private function buildTraits(Controller $controller)
+    protected function buildTraits(Controller $controller)
     {
         if (empty($this->traits[$controller->name()])) {
             return '';
@@ -541,7 +541,7 @@ class TestGenerator implements Generator
         return 'use ' . implode(', ', $traits) . ';';
     }
 
-    private function testCaseStub()
+    protected function testCaseStub()
     {
         if (empty($this->stubs['test-case'])) {
             $this->stubs['test-case'] = $this->filesystem->stub('test.case.stub');
@@ -550,7 +550,7 @@ class TestGenerator implements Generator
         return $this->stubs['test-case'];
     }
 
-    private function determineModel(string $prefix, ?string $reference)
+    protected function determineModel(string $prefix, ?string $reference)
     {
         if (empty($reference) || $reference === 'id') {
             return Str::studly(Str::singular($prefix));
@@ -563,7 +563,7 @@ class TestGenerator implements Generator
         return Str::studly($reference);
     }
 
-    private function buildFormRequestName(Controller $controller, string $name)
+    protected function buildFormRequestName(Controller $controller, string $name)
     {
         if (empty($controller->namespace())) {
             return $controller->name() . Str::studly($name) . 'Request';
@@ -572,7 +572,7 @@ class TestGenerator implements Generator
         return $controller->namespace() . '\\' . $controller->name() . Str::studly($name) . 'Request';
     }
 
-    private function buildFormRequestTestCase(string $controller, string $action, string $form_request)
+    protected function buildFormRequestTestCase(string $controller, string $action, string $form_request)
     {
         return <<< END
     /**
@@ -589,25 +589,25 @@ class TestGenerator implements Generator
 END;
     }
 
-    private function addFakerTrait(Controller $controller)
+    protected function addFakerTrait(Controller $controller)
     {
         $this->addImport($controller, 'Illuminate\\Foundation\\Testing\\WithFaker');
         $this->addTrait($controller, 'WithFaker');
     }
 
-    private function addTestAssertionsTrait(Controller $controller)
+    protected function addTestAssertionsTrait(Controller $controller)
     {
         $this->addImport($controller, 'JMac\\Testing\\Traits\AdditionalAssertions');
         $this->addTrait($controller, 'AdditionalAssertions');
     }
 
-    private function addRefreshDatabaseTrait(Controller $controller)
+    protected function addRefreshDatabaseTrait(Controller $controller)
     {
         $this->addImport($controller, 'Illuminate\\Foundation\\Testing\\RefreshDatabase');
         $this->addTrait($controller, 'RefreshDatabase');
     }
 
-    private function httpMethodForAction($action)
+    protected function httpMethodForAction($action)
     {
         switch ($action) {
             case 'store':
@@ -621,7 +621,7 @@ END;
         }
     }
 
-    private function buildTestCaseName(string $name, int $tested_bits)
+    protected function buildTestCaseName(string $name, int $tested_bits)
     {
         $verifications = [];
 
@@ -658,12 +658,12 @@ END;
         return $name . '_' . implode('_', $verifications) . '_and_' . $final_verification;
     }
 
-    private function buildLines($lines)
+    protected function buildLines($lines)
     {
         return str_pad(' ', 8) . implode(PHP_EOL . str_pad(' ', 8), $lines);
     }
 
-    private function splitField($field)
+    protected function splitField($field)
     {
         if (Str::contains($field, '.')) {
             return explode('.', $field, 2);
@@ -672,7 +672,7 @@ END;
         return [null, $field];
     }
 
-    private function uniqueSetupLines(array $setup)
+    protected function uniqueSetupLines(array $setup)
     {
         return collect($setup)->filter()
             ->map(function ($lines) {
@@ -681,7 +681,7 @@ END;
             ->toArray();
     }
 
-    private function generateReferenceFactory(Column $local_column, Controller $controller, string $modelNamespace)
+    protected function generateReferenceFactory(Column $local_column, Controller $controller, string $modelNamespace)
     {
         if (!in_array($local_column->dataType(), ['id', 'uuid']) && !($local_column->attributes() && Str::endsWith($local_column->name(), '_id'))) {
             return null;


### PR DESCRIPTION
Making modifications to file layouts that aren't supported by config changes is benefited by subclassing the core generators and changing methods like "getPath".  Using private for every non-contracted method hurts extensibility.