### PR TITLE
Bug/remove double white space first relationship method

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -164,6 +164,7 @@ class ModelGenerator implements Generator
 
     protected function buildRelationships(Model $model)
     {
+        $newLine = null;
         $methods = '';
         $template = $this->filesystem->stub('model.method.stub');
         $commentTemplate = '';
@@ -242,7 +243,8 @@ class ModelGenerator implements Generator
 
                 $phpDoc = str_replace('{{ namespacedReturnClass }}', '\Illuminate\Database\Eloquent\Relations\\' . Str::ucfirst($type), $commentTemplate);
 
-                $methods .= PHP_EOL . $phpDoc . $method;
+                $methods .= ($newLine ?? '') . $phpDoc . $method;
+                $newLine = PHP_EOL;
             }
         }
 

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -164,7 +164,6 @@ class ModelGenerator implements Generator
 
     protected function buildRelationships(Model $model)
     {
-        $newLine = null;
         $methods = '';
         $template = $this->filesystem->stub('model.method.stub');
         $commentTemplate = '';
@@ -243,8 +242,7 @@ class ModelGenerator implements Generator
 
                 $phpDoc = str_replace('{{ namespacedReturnClass }}', '\Illuminate\Database\Eloquent\Relations\\' . Str::ucfirst($type), $commentTemplate);
 
-                $methods .= ($newLine ?? '') . $phpDoc . $method;
-                $newLine = PHP_EOL;
+                $methods .= $phpDoc . $method. PHP_EOL;
             }
         }
 

--- a/tests/fixtures/models/alias-relationships.php
+++ b/tests/fixtures/models/alias-relationships.php
@@ -27,7 +27,6 @@ class Salesman extends Model
         'id' => 'integer',
     ];
 
-
     public function lead()
     {
         return $this->hasOne(\App\User::class);

--- a/tests/fixtures/models/certificate-pascal-case-example.php
+++ b/tests/fixtures/models/certificate-pascal-case-example.php
@@ -34,7 +34,6 @@ class Certificate extends Model
         'expiry_date' => 'date',
     ];
 
-
     public function certificateType()
     {
         return $this->belongsTo(\App\CertificateType::class);

--- a/tests/fixtures/models/certificate-type-pascal-case-example.php
+++ b/tests/fixtures/models/certificate-type-pascal-case-example.php
@@ -27,7 +27,6 @@ class CertificateType extends Model
         'id' => 'integer',
     ];
 
-
     public function certificates()
     {
         return $this->hasMany(\App\Certificate::class);

--- a/tests/fixtures/models/custom-pivot-table-name.php
+++ b/tests/fixtures/models/custom-pivot-table-name.php
@@ -36,7 +36,6 @@ class User extends Model
         'id' => 'integer',
     ];
 
-
     public function accounts()
     {
         return $this->belongsToMany(\App\Account::class, 'test');

--- a/tests/fixtures/models/foreign-key-shorthand-phpdoc.php
+++ b/tests/fixtures/models/foreign-key-shorthand-phpdoc.php
@@ -40,7 +40,6 @@ class Comment extends Model
         'ccid' => 'integer',
     ];
 
-
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */

--- a/tests/fixtures/models/image-polymorphic-relationship.php
+++ b/tests/fixtures/models/image-polymorphic-relationship.php
@@ -27,7 +27,6 @@ class Image extends Model
         'id' => 'integer',
     ];
 
-
     public function imageable()
     {
         return $this->morphTo();

--- a/tests/fixtures/models/model-configured.php
+++ b/tests/fixtures/models/model-configured.php
@@ -30,7 +30,6 @@ class Comment extends Model
         'author_id' => 'integer',
     ];
 
-
     public function post()
     {
         return $this->belongsTo(\Some\App\Models\Post::class);

--- a/tests/fixtures/models/model-relationships-morphone-morphmany-with-fqn.php
+++ b/tests/fixtures/models/model-relationships-morphone-morphmany-with-fqn.php
@@ -28,7 +28,6 @@ class Flag extends Model
         'user_id' => 'integer',
     ];
 
-
     public function stars()
     {
         return $this->morphOne(\Other\Package\Order::class, 'starable');

--- a/tests/fixtures/models/model-relationships-with-full-namespace.php
+++ b/tests/fixtures/models/model-relationships-with-full-namespace.php
@@ -29,7 +29,6 @@ class Recurrency extends Model
         'user_id' => 'integer',
     ];
 
-
     public function teams()
     {
         return $this->belongsToMany(\Some\Package\Team::class);

--- a/tests/fixtures/models/model-relationships.php
+++ b/tests/fixtures/models/model-relationships.php
@@ -29,7 +29,6 @@ class Subscription extends Model
         'user_id' => 'integer',
     ];
 
-
     public function teams()
     {
         return $this->belongsToMany(\App\Team::class);

--- a/tests/fixtures/models/nested-models.php
+++ b/tests/fixtures/models/nested-models.php
@@ -32,7 +32,6 @@ class ScreeningQuestion extends Model
         'question_type_id' => 'integer',
     ];
 
-
     public function report()
     {
         return $this->belongsTo(\App\Models\Screening\Report::class);

--- a/tests/fixtures/models/post-polymorphic-relationship.php
+++ b/tests/fixtures/models/post-polymorphic-relationship.php
@@ -27,7 +27,6 @@ class Post extends Model
         'id' => 'integer',
     ];
 
-
     public function images()
     {
         return $this->morphMany(\App\Image::class, 'imageable');

--- a/tests/fixtures/models/readme-example-phpdoc.php
+++ b/tests/fixtures/models/readme-example-phpdoc.php
@@ -41,7 +41,6 @@ class Post extends Model
         'author_id' => 'integer',
     ];
 
-
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */

--- a/tests/fixtures/models/readme-example.php
+++ b/tests/fixtures/models/readme-example.php
@@ -32,7 +32,6 @@ class Post extends Model
         'author_id' => 'integer',
     ];
 
-
     public function author()
     {
         return $this->belongsTo(\App\User::class);

--- a/tests/fixtures/models/relationships-phpdoc.php
+++ b/tests/fixtures/models/relationships-phpdoc.php
@@ -37,7 +37,6 @@ class Comment extends Model
         'author_id' => 'integer',
     ];
 
-
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */

--- a/tests/fixtures/models/relationships.php
+++ b/tests/fixtures/models/relationships.php
@@ -30,7 +30,6 @@ class Comment extends Model
         'author_id' => 'integer',
     ];
 
-
     public function post()
     {
         return $this->belongsTo(\App\Post::class);

--- a/tests/fixtures/models/return-type-declarations.php
+++ b/tests/fixtures/models/return-type-declarations.php
@@ -41,7 +41,6 @@ class Term extends Model
         'published' => 'boolean',
     ];
 
-
     public function organizers(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
         return $this->belongsToMany(\App\Organizer::class);

--- a/tests/fixtures/models/soft-deletes-phpdoc.php
+++ b/tests/fixtures/models/soft-deletes-phpdoc.php
@@ -36,7 +36,6 @@ class Comment extends Model
         'post_id' => 'integer',
     ];
 
-
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */

--- a/tests/fixtures/models/soft-deletes.php
+++ b/tests/fixtures/models/soft-deletes.php
@@ -29,7 +29,6 @@ class Comment extends Model
         'post_id' => 'integer',
     ];
 
-
     public function post()
     {
         return $this->belongsTo(\App\Post::class);

--- a/tests/fixtures/models/unconventional.php
+++ b/tests/fixtures/models/unconventional.php
@@ -33,7 +33,6 @@ class Team extends Model
         'options' => 'array',
     ];
 
-
     public function owner()
     {
         return $this->belongsTo(\App\Owner::class);

--- a/tests/fixtures/models/user-polymorphic-relationship.php
+++ b/tests/fixtures/models/user-polymorphic-relationship.php
@@ -27,7 +27,6 @@ class User extends Model
         'id' => 'integer',
     ];
 
-
     public function images()
     {
         return $this->morphMany(\App\Image::class, 'imageable');


### PR DESCRIPTION
When working on a different pull request, I kept hitting an issue, only to discover my auto code cleanup was removing double spaces from my fixtures, which would then prevent the fixture matching the output.

Separated into two commits. One for the fixture cleanup, and another for the solution, incase you want the solution to be carried out in a different way.

Solves #520 