### PR TITLE
Improvement: show skipped views in the output of build command

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -96,7 +96,7 @@ class BuildCommand extends Command
     {
         if ($action === 'deleted') {
             return 'error';
-        } elseif ($action === 'updated') {
+        } elseif ($action === 'updated' || $action === 'skipped') {
             return 'comment';
         }
 

--- a/src/Generators/Statements/ViewGenerator.php
+++ b/src/Generators/Statements/ViewGenerator.php
@@ -38,7 +38,7 @@ class ViewGenerator implements Generator
                     $path = $this->getPath($statement->view());
 
                     if ($this->filesystem->exists($path)) {
-                        // TODO: mark skipped...
+                        $output['skipped'][] = $path;
                         continue;
                     }
 

--- a/tests/Feature/Generators/Statements/ViewGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/ViewGeneratorTest.php
@@ -107,7 +107,7 @@ class ViewGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function it_only_outputs_new_views()
+    public function it_outputs_skipped_views()
     {
         $this->filesystem->expects('stub')
             ->with('view.stub')
@@ -126,6 +126,12 @@ class ViewGeneratorTest extends TestCase
         $tokens = $this->blueprint->parse($this->fixture('drafts/render-statements.yaml'));
         $tree = $this->blueprint->analyze($tokens);
 
-        $this->assertEquals([], $this->subject->output($tree));
+        $this->assertEquals([
+            "skipped" => [
+                "resources/views/user/index.blade.php",
+                "resources/views/user/create.blade.php",
+                "resources/views/post/show.blade.php",
+            ],
+        ], $this->subject->output($tree));
     }
 }


### PR DESCRIPTION
Hello,

This update will print the list of the skipped views while executing `blueprint:build` command. This PR implements the TODO comment in `ViewGenerator:41`.

Before the update:
![image](https://user-images.githubusercontent.com/16087389/148015278-a997d653-4036-4262-86f4-6e3b01491f00.png)

After the update:
![image](https://user-images.githubusercontent.com/16087389/148015306-e711a05d-3e90-467b-96c5-3d75859c61e7.png)

