### PR TITLE
Feature: Inline configuration 

### DIFF
--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -75,6 +75,7 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
 
         $this->app->singleton(Blueprint::class, function ($app) {
             $blueprint = new Blueprint();
+            $blueprint->registerLexer(new \Blueprint\Lexers\ConfigLexer($app));
             $blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
             $blueprint->registerLexer(new \Blueprint\Lexers\SeederLexer());
             $blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new \Blueprint\Lexers\StatementLexer()));

--- a/src/Lexers/ConfigLexer.php
+++ b/src/Lexers/ConfigLexer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Blueprint\Lexers;
+
+use Blueprint\Contracts\Lexer;
+use Illuminate\Container\Container;
+
+class ConfigLexer implements Lexer
+{
+    private $app;
+
+    public function __construct(Container $app = null)
+    {
+        $this->app = $app ?? Container::getInstance();
+    }
+
+    public function analyze(array $tokens): array
+    {
+        if (array_key_exists('config', $tokens) && is_array($tokens['config'])) {
+            $this->analyzeValue($tokens['config']);
+        }
+        return [];
+    }
+
+    private function analyzeValue(array $config): void
+    {
+        $this->app['config']->set(
+            'blueprint',
+            array_merge(
+                $this->app['config']->get('blueprint'),
+                $config
+            )
+        );
+    }
+}

--- a/src/Lexers/ConfigLexer.php
+++ b/src/Lexers/ConfigLexer.php
@@ -19,6 +19,7 @@ class ConfigLexer implements Lexer
         if (array_key_exists('config', $tokens) && is_array($tokens['config'])) {
             $this->analyzeValue($tokens['config']);
         }
+
         return [];
     }
 

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -233,6 +233,10 @@ class BlueprintTest extends TestCase
                     ],
                 ],
             ],
+            'config' => [
+                'namespace' => 'MyAppNamespace',
+                'models_namespace' => 'MyAppModels'
+            ]
         ], $this->subject->parse($blueprint));
     }
 
@@ -276,6 +280,10 @@ class BlueprintTest extends TestCase
                     ],
                 ],
             ],
+            'config' => [
+                'namespace' => 'MyAppNamespace',
+                'models_namespace' => 'MyAppModels'
+            ]
         ];
 
         $this->assertEquals($expected, $this->subject->parse($definition_mac_eol));

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -205,6 +205,7 @@ class MigrationGeneratorTest extends TestCase
      */
     public function output_creates_constraints_for_unconventional_foreign_reference_migration()
     {
+        $this->app->config->set('blueprint.use_constraints', true);
         $this->filesystem->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));
@@ -220,7 +221,7 @@ class MigrationGeneratorTest extends TestCase
             ->with($model_migration, $this->fixture('migrations/relationships-constraints.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/relationships.yaml'));
-        $tree = $this->blueprint->analyze($tokens + ['config' => ['use_constraints' => true]]);
+        $tree = $this->blueprint->analyze($tokens);
         $this->assertEquals(['created' => [$model_migration]], $this->subject->output($tree));
     }
 

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -28,6 +28,7 @@ class MigrationGeneratorTest extends TestCase
         $this->subject = new MigrationGenerator($this->files);
 
         $this->blueprint = new Blueprint();
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ConfigLexer());
         $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
         $this->blueprint->registerGenerator($this->subject);
     }
@@ -204,8 +205,6 @@ class MigrationGeneratorTest extends TestCase
      */
     public function output_creates_constraints_for_unconventional_foreign_reference_migration()
     {
-        $this->app->config->set('blueprint.use_constraints', true);
-
         $this->filesystem->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));
@@ -221,8 +220,7 @@ class MigrationGeneratorTest extends TestCase
             ->with($model_migration, $this->fixture('migrations/relationships-constraints.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/relationships.yaml'));
-        $tree = $this->blueprint->analyze($tokens);
-
+        $tree = $this->blueprint->analyze($tokens + ['config' => ['use_constraints' => true]]);
         $this->assertEquals(['created' => [$model_migration]], $this->subject->output($tree));
     }
 

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -205,7 +205,6 @@ class MigrationGeneratorTest extends TestCase
      */
     public function output_creates_constraints_for_unconventional_foreign_reference_migration()
     {
-        $this->app->config->set('blueprint.use_constraints', true);
         $this->filesystem->expects('stub')
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));

--- a/tests/Feature/Lexers/ConfigLexerTest.php
+++ b/tests/Feature/Lexers/ConfigLexerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Lexers;
+
+use Blueprint\Lexers\ConfigLexer;
+use Tests\TestCase;
+
+/**
+ * @see ConfigLexer
+ */
+class ConfigLexerTest extends TestCase
+{
+    /**
+     * @var ConfigLexer
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new ConfigLexer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_updates_config(): void
+    {
+        $tokens = ['config' => ['key' => 'value']];
+
+        $this->subject->analyze($tokens);
+
+        $this->assertSame($tokens['config']['key'], config('blueprint.key'));
+    }
+}

--- a/tests/fixtures/drafts/readme-example.yaml
+++ b/tests/fixtures/drafts/readme-example.yaml
@@ -19,3 +19,7 @@ controllers:
       fire: NewPost with:post
       flash: post.title
       redirect: post.index
+
+config:
+    namespace: MyAppNamespace
+    models_namespace: MyAppModels

--- a/tests/fixtures/drafts/relationships.yaml
+++ b/tests/fixtures/drafts/relationships.yaml
@@ -2,3 +2,6 @@ models:
   Comment:
     post_id: id
     author_id: id:user
+
+config:
+  use_constraints: true

--- a/tests/fixtures/migrations/relationships.php
+++ b/tests/fixtures/migrations/relationships.php
@@ -13,12 +13,16 @@ class CreateCommentsTable extends Migration
      */
     public function up()
     {
+        Schema::disableForeignKeyConstraints();
+
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('post_id');
-            $table->unsignedBigInteger('author_id');
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('author_id')->constrained('users')->cascadeOnDelete()->cascadeOnUpdate();
             $table->timestamps();
         });
+
+        Schema::enableForeignKeyConstraints();
     }
 
     /**


### PR DESCRIPTION
This patch resolves #529 , via the following changes:

- Add tests 
- Create `ConfigLexer` 
- Register `ConfigLexer` in `BlueprintServiceProvider`

#### Note: config keys are case-sensitive.
Default `config/blueprint.php` values.
```yml
config:
    namespace: App
    models_namespace: Models
    controllers_namespace: Http\Controllers
    app_path: app
    generate_phpdocs: false
    use_constraints: false
    on_delete: cascade
    on_update: cascade
    fake_nullables: true
    use_return_types: false
    use_guarded: false
    generators:
      controller: Blueprint\Generators\ControllerGenerator
      factory: Blueprint\Generators\FactoryGenerator
      migration: Blueprint\Generators\MigrationGenerator
      model: Blueprint\Generators\ModelGenerator
      route: Blueprint\Generators\RouteGenerator
      seeder: Blueprint\Generators\SeederGenerator
      test: Blueprint\Generators\TestGenerator
      event: Blueprint\Generators\Statements\EventGenerator
      form_request: Blueprint\Generators\Statements\FormRequestGenerator
      job: Blueprint\Generators\Statements\JobGenerator
      mail: Blueprint\Generators\Statements\MailGenerator
      notification: Blueprint\Generators\Statements\NotificationGenerator
      resource: Blueprint\Generators\Statements\ResourceGenerator
      view: Blueprint\Generators\Statements\ViewGenerator
```