### PR TITLE
chore: remove old version compare code

### DIFF
--- a/tests/Feature/Generators/FactoryGeneratorTest.php
+++ b/tests/Feature/Generators/FactoryGeneratorTest.php
@@ -24,7 +24,7 @@ class FactoryGeneratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->factoryStub = version_compare(App::version(), '8.0.0', '>=') ? 'factory.stub' : 'factory.closure.stub';
+        $this->factoryStub = 'factory.stub';
         $this->subject = new FactoryGenerator($this->files);
 
         $this->blueprint = new Blueprint();

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -21,7 +21,7 @@ class ModelGeneratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->modelStub = version_compare(App::version(), '8.0.0', '>=') ? 'model.class.stub' : 'model.class.no-factory.stub';
+        $this->modelStub = 'model.class.stub';
         $this->subject = new ModelGenerator($this->files);
 
         $this->blueprint = new Blueprint();

--- a/tests/Feature/Generators/SeederGeneratorTest.php
+++ b/tests/Feature/Generators/SeederGeneratorTest.php
@@ -27,7 +27,7 @@ class SeederGeneratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->seederStub = version_compare(App::version(), '8.0.0', '>=') ? 'seeder.stub' : 'seeder.no-factory.stub';
+        $this->seederStub = 'seeder.stub';
         $this->subject = new SeederGenerator($this->files);
 
         $this->blueprint = new Blueprint();


### PR DESCRIPTION
Given the package is now php 8.0.0 and higher. Also, those alternate stubs no longer exist