### PR TITLE
Default to plural api route naming, with config to allow plural or singular

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -116,6 +116,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Pluralize base slug for Route::apiResource(...)
+    |--------------------------------------------------------------------------
+    |
+    | By default, Blueprint will pluralize the api resource slug meaning
+    | a model named post will create an api resource route definition with a
+    | the base slug as 'posts'. Previously this was singular. Setting this
+    | to false, will product a singular slug of 'post'
+    |
+    */
+    'plural_api_slug' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Generators
     |--------------------------------------------------------------------------
     |

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -53,7 +53,7 @@ class RouteGenerator extends AbstractClassGenerator implements Generator
         $resource_methods = array_intersect($methods, Controller::$resourceMethods);
         if (count($resource_methods)) {
             $routes .= $controller->isApiResource()
-                ? sprintf("Route::apiResource('%s', %s)", $slug, $className)
+                ? sprintf("Route::apiResource('%s', %s)", config('blueprint.plural_api_slug') ? Str::plural($slug) : Str::singular($slug), $className)
                 : sprintf("Route::resource('%s', %s)", $slug, $className);
 
             $missing_methods = $controller->isApiResource()

--- a/tests/Feature/Generators/RouteGeneratorTest.php
+++ b/tests/Feature/Generators/RouteGeneratorTest.php
@@ -13,9 +13,8 @@ use Tests\TestCase;
  */
 class RouteGeneratorTest extends TestCase
 {
-    private $blueprint;
-
     protected $files;
+    private $blueprint;
 
     /** @var RouteGenerator */
     private $subject;
@@ -64,6 +63,22 @@ class RouteGeneratorTest extends TestCase
     {
         $this->filesystem->expects('append')
             ->with('routes/api.php', $this->fixture('routes/api-routes.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['updated' => ['routes/api.php']], $this->subject->output($tree));
+    }
+
+    /**
+     * @test
+     */
+    public function output_generates_api_routes_singular_slug()
+    {
+        $this->app['config']->set('blueprint.plural_api_slug', false);
+
+        $this->filesystem->expects('append')
+            ->with('routes/api.php', $this->fixture('routes/api-routes-singular.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
         $tree = $this->blueprint->analyze($tokens);

--- a/tests/fixtures/routes/api-routes-singular.php
+++ b/tests/fixtures/routes/api-routes-singular.php
@@ -1,0 +1,3 @@
+
+
+Route::apiResource('certificate', App\Http\Controllers\Api\CertificateController::class);

--- a/tests/fixtures/routes/api-routes.php
+++ b/tests/fixtures/routes/api-routes.php
@@ -1,3 +1,3 @@
 
 
-Route::apiResource('certificate', App\Http\Controllers\Api\CertificateController::class);
+Route::apiResource('certificates', App\Http\Controllers\Api\CertificateController::class);

--- a/tests/fixtures/routes/multiple-resource-controllers-api.php
+++ b/tests/fixtures/routes/multiple-resource-controllers-api.php
@@ -1,5 +1,5 @@
 
 
-Route::apiResource('file', App\Http\Controllers\FileController::class)->except('index', 'destroy');
+Route::apiResource('files', App\Http\Controllers\FileController::class)->except('index', 'destroy');
 
-Route::apiResource('gallery', App\Http\Controllers\GalleryController::class);
+Route::apiResource('galleries', App\Http\Controllers\GalleryController::class);


### PR DESCRIPTION
Fixes #480

Issue created requiring plural api resource slugs. Hopefully this covers the issue as you requested @pktharindu?

This implementation seems very simple, so there may be more needed, so happy to take any pointers @jasonmccreary or @pktharindu