### PR TITLE
Update $tree visibility from private to protected. Closes #479

### DIFF
--- a/src/Generators/AbstractClassGenerator.php
+++ b/src/Generators/AbstractClassGenerator.php
@@ -8,11 +8,11 @@ use Illuminate\Filesystem\Filesystem;
 
 class AbstractClassGenerator
 {
-    const INDENT = '        ';
+    public const INDENT = '        ';
 
     protected $filesystem;
 
-    private $tree;
+    protected $tree;
 
     protected $output = [];
 


### PR DESCRIPTION
This pull request closes #479 by having the $tree variable as a protected property instead of a private property as he requested. It does then keep it inline with the other variables in the abstract method.