### PR TITLE
Laravel 9, Scout fullText index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 .phpunit.result.cache
 composer.lock
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .env
 .phpunit.result.cache
 composer.lock
-/.idea

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -184,6 +184,8 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
                 $column_definition .= '$table->softDeletes(';
             } elseif ($dataType === 'softDeletesTz') {
                 $column_definition .= '$table->softDeletesTz(';
+            } elseif ($dataType === 'fullText') {
+                $column_definition .= '$table->fullText(';
             } else {
                 $column_definition .= '$table->' . $dataType . "('{$column->name()}'";
             }

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -35,6 +35,7 @@ class ModelLexer implements Lexer
         'double' => 'double',
         'enum' => 'enum',
         'float' => 'float',
+        'fulltext' => 'fullText',
         'geometry' => 'geometry',
         'geometrycollection' => 'geometryCollection',
         'increments' => 'increments',

--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -34,7 +34,7 @@ class Rules
         }
 
         // hack for tests...
-        if (in_array($column->dataType(), ['string', 'char', 'text', 'longText'])) {
+        if (in_array($column->dataType(), ['string', 'char', 'text', 'longText', 'fullText'])) {
             array_push($rules, self::overrideStringRuleForSpecialNames($column->name()));
         }
 

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -225,6 +225,7 @@ class ModelLexerTest extends TestCase
                 'Model' => [
                     'sequence' => 'unsignedbiginteger autoincrement',
                     'content' => 'longtext',
+                    'search' => 'fulltext',
                     'saved_at' => 'timestamptz usecurrent',
                     'updated_at' => 'timestamptz usecurrent usecurrentOnUpdate',
                 ],
@@ -255,6 +256,7 @@ class ModelLexerTest extends TestCase
         $this->assertEquals('longText', $columns['content']->dataType());
         $this->assertEquals([], $columns['content']->attributes());
         $this->assertEquals([], $columns['content']->modifiers());
+        $this->assertEquals('fullText', $columns['search']->dataType());
         $this->assertEquals('saved_at', $columns['saved_at']->name());
         $this->assertEquals('timestampTz', $columns['saved_at']->dataType());
         $this->assertEquals([], $columns['saved_at']->attributes());

--- a/tests/fixtures/drafts/all-column-types.yaml
+++ b/tests/fixtures/drafts/all-column-types.yaml
@@ -12,6 +12,7 @@ models:
     double: double
     enum: enum:1,2,3
     float: float
+    fullText: fullText
     geometry: geometry
     geometryCollection: geometryCollection
     integer: integer

--- a/tests/fixtures/factories/post.php
+++ b/tests/fixtures/factories/post.php
@@ -28,6 +28,7 @@ class PostFactory extends Factory
             'author_id' => Author::factory(),
             'author_bio' => $this->faker->text,
             'content' => $this->faker->paragraphs(3, true),
+            'search' => $this->faker->text,
             'published_at' => $this->faker->dateTime(),
             'updated_at' => $this->faker->dateTime(),
             'word_count' => $this->faker->randomNumber(),

--- a/tests/fixtures/migrations/full-text.php
+++ b/tests/fixtures/migrations/full-text.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->fullText('search');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/tests/fixtures/models/all-column-types.php
+++ b/tests/fixtures/models/all-column-types.php
@@ -26,6 +26,7 @@ class AllType extends Model
         'double',
         'enum',
         'float',
+        'fullText',
         'geometry',
         'geometryCollection',
         'integer',


### PR DESCRIPTION
As discussed in #548 I am trying to add support for fullText indexes.

### Synopsis:
Laravel 9 comes with a database driver for Laravel Scout. It would be great if we could add support for `fullText` indexes which is one of the recommended data types.

### Proposed Syntax:

`foo: fullText` should output `$table->fullText('foo')` in migrations

I don't know which files to change but I tried :)