### PR TITLE
Fix exception for variables without context

### DIFF
--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -125,7 +125,7 @@ class TestGenerator extends AbstractClassGenerator implements Generator
                             $assertion .= ', function ($notification)';
 
                             foreach ($statement->data() as $data) {
-                                if (Str::studly(Str::singular($data)) === $context) {
+                                if (Str::studly(Str::singular($data)) === $context || ! Str::contains($data, '.')) {
                                     $variables[] .= '$' . $data;
                                     $conditions[] .= sprintf('$notification->%s->is($%s)', $data, $data);
                                 } else {
@@ -166,7 +166,7 @@ class TestGenerator extends AbstractClassGenerator implements Generator
                             }
 
                             foreach ($statement->data() as $data) {
-                                if (Str::studly(Str::singular($data)) === $context) {
+                                if (Str::studly(Str::singular($data)) === $context || ! Str::contains($data, '.')) {
                                     $variables[] .= '$' . $data;
                                     $conditions[] .= sprintf('$mail->%s->is($%s)', $data, $data);
                                 } else {
@@ -262,7 +262,7 @@ class TestGenerator extends AbstractClassGenerator implements Generator
                         $assertion .= ', function ($job)';
 
                         foreach ($statement->data() as $data) {
-                            if (Str::studly(Str::singular($data)) === $context) {
+                            if (Str::studly(Str::singular($data)) === $context || ! Str::contains($data, '.')) {
                                 $variables[] .= '$' . $data;
                                 $conditions[] .= sprintf('$job->%s->is($%s)', $data, $data);
                             } else {
@@ -305,7 +305,7 @@ class TestGenerator extends AbstractClassGenerator implements Generator
                         $assertion .= ', function ($event)';
 
                         foreach ($statement->data() as $data) {
-                            if (Str::studly(Str::singular($data)) === $context) {
+                            if (Str::studly(Str::singular($data)) === $context || ! Str::contains($data, '.')) {
                                 $variables[] .= '$' . $data;
                                 $conditions[] .= sprintf('$event->%s->is($%s)', $data, $data);
                             } else {

--- a/tests/Feature/Generators/TestGeneratorTest.php
+++ b/tests/Feature/Generators/TestGeneratorTest.php
@@ -220,6 +220,7 @@ class TestGeneratorTest extends TestCase
             ['drafts/respond-statements.yaml', 'tests/Feature/Http/Controllers/Api/PostControllerTest.php', 'tests/respond-statements.php'],
             ['drafts/full-crud-example.yaml', 'tests/Feature/Http/Controllers/PostControllerTest.php', 'tests/full-crud-example.php'],
             ['drafts/model-reference-validate.yaml', 'tests/Feature/Http/Controllers/CertificateControllerTest.php', 'tests/api-shorthand-validation.php'],
+            ['drafts/controllers-only-no-context.yaml', 'tests/Feature/Http/Controllers/ReportControllerTest.php', 'tests/controllers-only-no-context.php'],
             ['drafts/call-to-a-member-function-columns-on-null.yaml', [
                 'tests/Feature/Http/Controllers/SubscriptionControllerTest.php',
                 'tests/Feature/Http/Controllers/TelegramControllerTest.php',

--- a/tests/fixtures/drafts/controllers-only-no-context.yaml
+++ b/tests/fixtures/drafts/controllers-only-no-context.yaml
@@ -1,0 +1,8 @@
+controllers:
+  Report:
+    invokable:
+      dispatch: GenerateReport with:event
+      fire: ExportReport with:event
+      notify: auth.user ReportGenerated with:event
+      send: SendReport with:event
+      render: report

--- a/tests/fixtures/tests/controllers-only-no-context.php
+++ b/tests/fixtures/tests/controllers-only-no-context.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Events\ExportReport;
+use App\Jobs\GenerateReport;
+use App\Mail\SendReport;
+use App\Notification\ReportGenerated;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\ReportController
+ */
+class ReportControllerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function __invoke_displays_view()
+    {
+        Queue::fake();
+        Event::fake();
+        Notification::fake();
+        Mail::fake();
+
+        $response = $this->get(route('report.__invoke'));
+
+        $response->assertOk();
+        $response->assertViewIs('report');
+
+        Queue::assertPushed(GenerateReport::class, function ($job) use ($event) {
+            return $job->event->is($event);
+        });
+        Event::assertDispatched(ExportReport::class, function ($event) use ($event) {
+            return $event->event->is($event);
+        });
+        Notification::assertSentTo($auth->user, ReportGenerated::class, function ($notification) use ($event) {
+            return $notification->event->is($event);
+        });
+        Mail::assertSent(SendReport::class, function ($mail) use ($event) {
+            return $mail->event->is($event);
+        });
+    }
+}


### PR DESCRIPTION
Fixes #549 

Note that the expected test output would fail as we have no context for `$auth` or `$event`.