### PR TITLE
fix: two pass filter to remove softDeletes - issue 546

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -194,9 +194,14 @@ class FactoryGenerator extends AbstractClassGenerator implements Generator
             return $columns;
         }
 
-        return array_filter(
+        $nonNullableColumns = array_filter(
             $columns,
             fn (Column $column) => !in_array('nullable', $column->modifiers())
+        );
+
+        return array_filter(
+            $nonNullableColumns,
+            fn (Column $column) => $column->dataType() !== 'softDeletes'
         );
     }
 


### PR DESCRIPTION
Soft delete columns aren’t ‘fillable’ so shouldn’t be part of the generated factory class.

Second pass at fixing issue #546 

No test changes needed.