### PR TITLE
Remove double "for"

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -119,7 +119,7 @@ return [
     | Pluralize route names
     |--------------------------------------------------------------------------
     |
-    | By default, Blueprint will use the `kebab-case` of the controller name for
+    | By default, Blueprint will use the `kebab-case` of the controller name
     | for the route name. If you would like to ensure a plural route name is
     | used, you may set this to `true`.
     |


### PR DESCRIPTION
Hey @jasonmccreary,

just watched your stream from yesterday and noticed you had a double *for* in the comment block :+1: 

Thanks for building Blueprint! :muscle:

Cheers,
Peter