### PR TITLE
Generate mail views

### DIFF
--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -42,7 +42,7 @@ class MailGenerator extends StatementGenerator
                         continue;
                     }
 
-                    $this->create($path, $this->createView($view_stub, $statement));
+                    $this->create($path, $this->populateViewStub($view_stub, $statement));
                 }
             }
         }
@@ -50,7 +50,7 @@ class MailGenerator extends StatementGenerator
         return $this->output;
     }
 
-    private function createView(string $stub, SendStatement $statement)
+    private function populateViewStub(string $stub, SendStatement $statement)
     {
         return str_replace('{{ class }}', $statement->mail(), $stub);
     }

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -14,12 +14,13 @@ class MailGenerator extends StatementGenerator
     public function output(Tree $tree): array
     {
         $stub = $this->filesystem->stub('mail.stub');
+        $view_stub = $this->filesystem->stub('mail.view.stub');
 
         /**
          * @var \Blueprint\Models\Controller $controller
          */
         foreach ($tree->controllers() as $controller) {
-            foreach ($controller->methods() as $method => $statements) {
+            foreach ($controller->methods() as $statements) {
                 foreach ($statements as $statement) {
                     if (!$statement instanceof SendStatement) {
                         continue;
@@ -30,17 +31,34 @@ class MailGenerator extends StatementGenerator
                     }
 
                     $path = $this->getStatementPath($statement->mail());
-
                     if ($this->filesystem->exists($path)) {
                         continue;
                     }
 
                     $this->create($path, $this->populateStub($stub, $statement));
+
+                    $path = $this->getViewPath($statement->view());
+                    if ($this->filesystem->exists($path)) {
+                        continue;
+                    }
+
+                    $this->create($path, $this->createView($view_stub, $statement));
                 }
             }
         }
 
         return $this->output;
+    }
+
+    private function createView(string $stub, SendStatement $statement)
+    {
+        return str_replace('{{ class }}', $statement->mail(), $stub);
+
+    }
+
+    private function getViewPath($view)
+    {
+        return 'resources/views/' . str_replace('.', '/', $view) . '.blade.php';
     }
 
     protected function getStatementPath(string $name)
@@ -52,6 +70,7 @@ class MailGenerator extends StatementGenerator
     {
         $stub = str_replace('{{ namespace }}', config('blueprint.namespace') . '\\Mail', $stub);
         $stub = str_replace('{{ class }}', $sendStatement->mail(), $stub);
+        $stub = str_replace('{{ view }}', $sendStatement->view(), $stub);
         $stub = str_replace('{{ properties }}', $this->populateConstructor('message', $sendStatement), $stub);
 
         if (Blueprint::useReturnTypeHints()) {

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -53,7 +53,6 @@ class MailGenerator extends StatementGenerator
     private function createView(string $stub, SendStatement $statement)
     {
         return str_replace('{{ class }}', $statement->mail(), $stub);
-
     }
 
     private function getViewPath($view)

--- a/src/Lexers/StatementLexer.php
+++ b/src/Lexers/StatementLexer.php
@@ -80,10 +80,17 @@ class StatementLexer implements Lexer
     private function analyzeSend($statement)
     {
         $to = null;
+        $view = null;
 
         $found = preg_match('/\\s+to:(\\S+)/', $statement, $matches);
         if ($found) {
             $to = $matches[1];
+            $statement = str_replace($matches[0], '', $statement);
+        }
+
+        $found = preg_match('/\\s+view:(\\S+)/', $statement, $matches);
+        if ($found) {
+            $view = $matches[1];
             $statement = str_replace($matches[0], '', $statement);
         }
 
@@ -99,7 +106,7 @@ class StatementLexer implements Lexer
             $type = SendStatement::TYPE_NOTIFICATION_WITH_FACADE;
         }
 
-        return new SendStatement($object, $to, $data, $type);
+        return new SendStatement($object, $to, $data, $type, $view);
     }
 
     private function analyzeNotify($statement)

--- a/src/Models/Statements/SendStatement.php
+++ b/src/Models/Statements/SendStatement.php
@@ -2,6 +2,8 @@
 
 namespace Blueprint\Models\Statements;
 
+use Illuminate\Support\Str;
+
 class SendStatement
 {
     const TYPE_MAIL = 'mail';
@@ -30,12 +32,18 @@ class SendStatement
      */
     private $type;
 
-    public function __construct(string $mail, string $to = null, array $data, string $type)
+    /**
+     * @var string
+     */
+    private $view;
+
+    public function __construct(string $mail, ?string $to, array $data, string $type, string $view = null)
     {
         $this->mail = $mail;
         $this->data = $data;
         $this->to = $to;
         $this->type = $type;
+        $this->view = $view ?? 'emails.' . Str::kebab($this->mail);
     }
 
     public function mail()
@@ -77,6 +85,11 @@ class SendStatement
     public function isNotification()
     {
         return $this->type() === SendStatement::TYPE_NOTIFICATION_WITH_FACADE || $this->type() === SendStatement::TYPE_NOTIFICATION_WITH_MODEL;
+    }
+
+    public function view()
+    {
+        return $this->view;
     }
 
     private function mailOutput()

--- a/stubs/mail.stub
+++ b/stubs/mail.stub
@@ -20,6 +20,6 @@ class {{ class }} extends Mailable
      */
     public function build()
     {
-        return $this->view('view.name');
+        return $this->view('{{ view }}');
     }
 }

--- a/stubs/mail.view.stub
+++ b/stubs/mail.view.stub
@@ -1,0 +1,1 @@
+{{-- Template for {{ class }} --}}

--- a/tests/Feature/Generators/Statements/MailGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/MailGeneratorTest.php
@@ -180,11 +180,23 @@ class MailGeneratorTest extends TestCase
             ->with('src/path/Mail', 0755, true);
         $this->filesystem->expects('put')
             ->with('src/path/Mail/ReviewPost.php', $this->fixture('mailables/mail-configured.php'));
+        $this->filesystem->expects('exists')
+            ->with('resources/views/emails/review-post.blade.php')
+            ->andReturnFalse();
+        $this->filesystem->expects('makeDirectory')
+            ->with('resources/views/emails', 0755, true);
+        $this->filesystem->expects('put')
+            ->with('resources/views/emails/review-post.blade.php', $this->fixture('mailables/review-post-view.blade.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/readme-example.yaml'));
         $tree = $this->blueprint->analyze($tokens);
 
-        $this->assertEquals(['created' => ['src/path/Mail/ReviewPost.php']], $this->subject->output($tree));
+        $this->assertEquals([
+            'created' => [
+                'src/path/Mail/ReviewPost.php',
+                'resources/views/emails/review-post.blade.php',
+            ],
+        ], $this->subject->output($tree));
     }
 
     /**
@@ -215,17 +227,29 @@ class MailGeneratorTest extends TestCase
             ->with('src/path/Mail', 0755, true);
         $this->filesystem->expects('put')
             ->with('src/path/Mail/ReviewPost.php', $this->fixture('mailables/return-type-declarations.php'));
+        $this->filesystem->expects('exists')
+            ->with('resources/views/emails/review-post.blade.php')
+            ->andReturnFalse();
+        $this->filesystem->expects('makeDirectory')
+            ->with('resources/views/emails', 0755, true);
+        $this->filesystem->expects('put')
+            ->with('resources/views/emails/review-post.blade.php', $this->fixture('mailables/review-post-view.blade.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/readme-example.yaml'));
         $tree = $this->blueprint->analyze($tokens);
 
-        $this->assertEquals(['created' => ['src/path/Mail/ReviewPost.php']], $this->subject->output($tree));
+        $this->assertEquals([
+            'created' => [
+                'src/path/Mail/ReviewPost.php',
+                'resources/views/emails/review-post.blade.php',
+            ],
+        ], $this->subject->output($tree));
     }
 
     /**
      * @test
      */
-    public function output_writes_mails_but_not_template()
+    public function output_writes_mails_but_not_existing_templates()
     {
         $this->filesystem->expects('stub')
             ->with('mail.stub')
@@ -268,7 +292,6 @@ class MailGeneratorTest extends TestCase
             ],
         ], $this->subject->output($tree));
     }
-
 
     /**
      * @test

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -166,6 +166,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals('ReviewPost', $actual[0]->mail());
         $this->assertNull($actual[0]->to());
         $this->assertSame([], $actual[0]->data());
+        $this->assertEquals('emails.review-post', $actual[0]->view());
         $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
     }
 
@@ -186,6 +187,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals('ReviewPost', $actual[0]->mail());
         $this->assertEquals('post.author', $actual[0]->to());
         $this->assertSame([], $actual[0]->data());
+        $this->assertEquals('emails.review-post', $actual[0]->view());
         $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
     }
 
@@ -206,6 +208,7 @@ class StatementLexerTest extends TestCase
         $this->assertEquals('ReviewPost', $actual[0]->mail());
         $this->assertNull($actual[0]->to());
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
+        $this->assertEquals('emails.review-post', $actual[0]->view());
         $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
     }
 
@@ -226,6 +229,28 @@ class StatementLexerTest extends TestCase
         $this->assertEquals('ReviewPost', $actual[0]->mail());
         $this->assertEquals('post.author', $actual[0]->to());
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
+        $this->assertEquals('emails.review-post', $actual[0]->view());
+        $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_send_statement_to_with_and_view()
+    {
+        $tokens = [
+            'send' => 'ReviewPost to:post.author with:foo, bar, baz view:email.review-post',
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertCount(1, $actual);
+        $this->assertInstanceOf(SendStatement::class, $actual[0]);
+
+        $this->assertEquals('ReviewPost', $actual[0]->mail());
+        $this->assertEquals('post.author', $actual[0]->to());
+        $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
+        $this->assertEquals('email.review-post', $actual[0]->view());
         $this->assertEquals(SendStatement::TYPE_MAIL, $actual[0]->type());
     }
 

--- a/tests/fixtures/drafts/send-statement-with-view.yaml
+++ b/tests/fixtures/drafts/send-statement-with-view.yaml
@@ -1,0 +1,5 @@
+controllers:
+  User:
+    store:
+      send: AddedAdmin to:user.email with:user view:emails.admin.added
+      redirect: user.show with:user.id

--- a/tests/fixtures/mailables/added-admin-view.blade.php
+++ b/tests/fixtures/mailables/added-admin-view.blade.php
@@ -1,0 +1,1 @@
+{{-- Template for AddedAdmin --}}

--- a/tests/fixtures/mailables/added-admin.php
+++ b/tests/fixtures/mailables/added-admin.php
@@ -7,20 +7,20 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 
-class ReviewPost extends Mailable
+class AddedAdmin extends Mailable
 {
     use Queueable, SerializesModels;
 
-    public $post;
+    public $user;
 
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($post)
+    public function __construct($user)
     {
-        $this->post = $post;
+        $this->user = $user;
     }
 
     /**
@@ -30,6 +30,6 @@ class ReviewPost extends Mailable
      */
     public function build()
     {
-        return $this->view('emails.review-post');
+        return $this->view('emails.admin.added');
     }
 }

--- a/tests/fixtures/mailables/mail-configured.php
+++ b/tests/fixtures/mailables/mail-configured.php
@@ -30,6 +30,6 @@ class ReviewPost extends Mailable
      */
     public function build()
     {
-        return $this->view('view.name');
+        return $this->view('emails.review-post');
     }
 }

--- a/tests/fixtures/mailables/published-post-view.blade.php
+++ b/tests/fixtures/mailables/published-post-view.blade.php
@@ -1,0 +1,1 @@
+{{-- Template for PublishedPost --}}

--- a/tests/fixtures/mailables/published-post.php
+++ b/tests/fixtures/mailables/published-post.php
@@ -28,6 +28,6 @@ class PublishedPost extends Mailable
      */
     public function build()
     {
-        return $this->view('view.name');
+        return $this->view('emails.published-post');
     }
 }

--- a/tests/fixtures/mailables/return-type-declarations.php
+++ b/tests/fixtures/mailables/return-type-declarations.php
@@ -30,6 +30,6 @@ class ReviewPost extends Mailable
      */
     public function build(): ReviewPost
     {
-        return $this->view('view.name');
+        return $this->view('emails.review-post');
     }
 }

--- a/tests/fixtures/mailables/review-post-view.blade.php
+++ b/tests/fixtures/mailables/review-post-view.blade.php
@@ -1,0 +1,1 @@
+{{-- Template for ReviewPost --}}


### PR DESCRIPTION
This updates Blueprint to generate an empty Blade template for any generated Mailable. By default, the kebab case of the Mailable name is used and stored under the `resources/views/emails` folder. You may customize the template name (and path) by passing an optional `view` argument to the `send` statement.

Example:
```yaml
    send: ReviewPost to:post.author with:foo, bar, baz view:emails.posts.review
```

Note: This also contains a change to the `SendStatement` constructor to add the new argument as well as fix a PHP 8 warning about the order of optional arguments.

---
Closes #506