### PR TITLE
Explicitly set nullable validation rule

### DIFF
--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -29,9 +29,7 @@ class Rules
     {
         $rules = [];
 
-        if (!in_array('nullable', $column->modifiers())) {
-            array_push($rules, 'required');
-        }
+        array_push($rules, in_array('nullable', $column->modifiers()) ? 'nullable' : 'required');
 
         // hack for tests...
         if (in_array($column->dataType(), ['string', 'char', 'text', 'longText', 'fullText'])) {

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -23,6 +23,16 @@ class RulesTest extends TestCase
 
     /**
      * @test
+     */
+    public function forColumn_returns_nullable_rule()
+    {
+        $column = new Column('test', 'nullable string');
+
+        $this->assertEquals(['required', 'string'], Rules::fromColumn('context', $column));
+    }
+
+    /**
+     * @test
      * @dataProvider stringDataTypesProvider
      */
     public function forColumn_returns_string_rule_for_string_data_types($data_type)
@@ -201,7 +211,7 @@ class RulesTest extends TestCase
     /**
      * @test
      */
-    public function forColumn_does_not_return_between_rule_for_unsigned_decimal_without_precion_and_scale()
+    public function forColumn_does_not_return_between_rule_for_unsigned_decimal_without_precision_and_scale()
     {
         $unsignedBeforeDecimalColumn = new Column('column', 'unsigned decimal');
 
@@ -216,7 +226,7 @@ class RulesTest extends TestCase
      * @test
      * @dataProvider noBetweenRuleDataProvider
      */
-    public function forColumn_does_not_return_between_rule_for_double_without_precion_and_scale($column)
+    public function forColumn_does_not_return_between_rule_for_double_without_precision_and_scale($column)
     {
         $this->assertNotContains('between', Rules::fromColumn('context', $column));
     }

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -26,9 +26,9 @@ class RulesTest extends TestCase
      */
     public function forColumn_returns_nullable_rule()
     {
-        $column = new Column('test', 'nullable string');
+        $column = new Column('test', 'string', ['nullable']);
 
-        $this->assertEquals(['required', 'string'], Rules::fromColumn('context', $column));
+        $this->assertEquals(['nullable', 'string'], Rules::fromColumn('context', $column));
     }
 
     /**

--- a/tests/fixtures/form-requests/certificate-store.php
+++ b/tests/fixtures/form-requests/certificate-store.php
@@ -29,7 +29,7 @@ class CertificateStoreRequest extends FormRequest
             'reference' => ['required', 'string'],
             'document' => ['required', 'string'],
             'expiry_date' => ['required', 'date'],
-            'remarks' => ['string'],
+            'remarks' => ['nullable', 'string'],
         ];
     }
 }

--- a/tests/fixtures/form-requests/certificate-update.php
+++ b/tests/fixtures/form-requests/certificate-update.php
@@ -29,7 +29,7 @@ class CertificateUpdateRequest extends FormRequest
             'reference' => ['required', 'string'],
             'document' => ['required', 'string'],
             'expiry_date' => ['required', 'date'],
-            'remarks' => ['string'],
+            'remarks' => ['nullable', 'string'],
         ];
     }
 }


### PR DESCRIPTION
Currently, Blueprint does not explicitly set the `nullable` validation rule for `nullable` columns. This means the generated form request requires `nullable` columns to be set or not in the request data at all.

For example, a `published_at` date column which is nullable would generate the validation rule `['date']`. As such, attempting to set this `published_at` column to `null` would cause validation to fail. That is not the expected behavior for a nullable column.

Originally, the thought was the columns you passed to a `validate` statement should all be "required". While that is the common case, it's assuming (too fancy).

I now think adding the `nullable` validation rule to database columns which are `nullable` generates an expected set of ready-to-use validation rules. If the developer knows a nullable column is always present in the request or should not be `null` for that form, then it's easy to change to `required`.

---
Closes #431