### PR TITLE
Throw an exception when a required model is missing

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -229,7 +229,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
                         $relationship .= sprintf('%s->using(%s::class)', PHP_EOL . str_pad(' ', 12), $column_name);
                         $relationship .= sprintf('%s->as(\'%s\')', PHP_EOL . str_pad(' ', 12), Str::snake($column_name));
 
-                        $foreign = $this->tree->modelForContext($column_name);
+                        $foreign = $this->tree->modelForContext($column_name, true);
                         $columns = $this->pivotColumns($foreign->columns(), $foreign->relationships());
                         if ($columns) {
                             $relationship .= sprintf('%s->withPivot(\'%s\')', PHP_EOL . str_pad(' ', 12), implode("', '", $columns));

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -80,7 +80,7 @@ class ResourceGenerator extends StatementGenerator implements Generator
         /**
          * @var \Blueprint\Models\Model $model
          */
-        $model = $this->tree->modelForContext($context);
+        $model = $this->tree->modelForContext($context, true);
 
         $data = [];
         if ($resource->collection()) {

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -35,7 +35,7 @@ class Tree
         return $this->tree['seeders'];
     }
 
-    public function modelForContext(string $context)
+    public function modelForContext(string $context, bool $throwWhenMissing = false)
     {
         if (isset($this->models[Str::studly($context)])) {
             return $this->models[Str::studly($context)];
@@ -49,6 +49,15 @@ class Tree
 
         if (count($matches) === 1) {
             return $this->models[current($matches)];
+        }
+
+        if ($throwWhenMissing) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'The [%s] model class could not be found or autoloaded. Please ensure that the model class name is correctly spelled, adheres to the appropriate namespace, and that the file containing the class is properly located within the "app/Models" directory or another relevant directory as configured.',
+                    $this->fqcnForContext($context),
+                )
+            );
         }
     }
 

--- a/tests/Unit/TreeTest.php
+++ b/tests/Unit/TreeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use Blueprint\Tree;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[CoversClass(\Blueprint\Tree::class)]
+final class TreeTest extends TestCase
+{
+    #[Test]
+    public function it_throws_when_a_referenced_model_cannot_be_found(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [App\Models\Unknown] model class could not be found or autoloaded. Please ensure that the model class name is correctly spelled, adheres to the appropriate namespace, and that the file containing the class is properly located within the "app/Models" directory or another relevant directory as configured.');
+
+        $tree = new Tree(['models' => []]);
+        $tree->modelForContext('Unknown', true);
+    }
+}


### PR DESCRIPTION
> Resolves https://github.com/laravel-shift/blueprint/issues/340

Currently it only throws in two places, based on the cases I could track down where `modelForContext` is called and afterwards a `Model` instance is expected or unhandled exceptions will be encountered.