### PR TITLE
Allow multiple dispatch, fire, notify and send statements

### DIFF
--- a/src/Generators/Statements/EventGenerator.php
+++ b/src/Generators/Statements/EventGenerator.php
@@ -6,7 +6,6 @@ use Blueprint\Blueprint;
 use Blueprint\Generators\StatementGenerator;
 use Blueprint\Models\Statements\FireStatement;
 use Blueprint\Tree;
-use Illuminate\Support\Arr;
 
 class EventGenerator extends StatementGenerator
 {
@@ -22,23 +21,21 @@ class EventGenerator extends StatementGenerator
         foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
-                    foreach (Arr::wrap($statement) as $statement) {
-                        if (!$statement instanceof FireStatement) {
-                            continue;
-                        }
-
-                        if ($statement->isNamedEvent()) {
-                            continue;
-                        }
-
-                        $path = $this->getStatementPath($statement->event());
-
-                        if ($this->filesystem->exists($path)) {
-                            continue;
-                        }
-
-                        $this->create($path, $this->populateStub($stub, $statement));
+                    if (!$statement instanceof FireStatement) {
+                        continue;
                     }
+
+                    if ($statement->isNamedEvent()) {
+                        continue;
+                    }
+
+                    $path = $this->getStatementPath($statement->event());
+
+                    if ($this->filesystem->exists($path)) {
+                        continue;
+                    }
+
+                    $this->create($path, $this->populateStub($stub, $statement));
                 }
             }
         }

--- a/src/Generators/Statements/JobGenerator.php
+++ b/src/Generators/Statements/JobGenerator.php
@@ -6,7 +6,6 @@ use Blueprint\Blueprint;
 use Blueprint\Generators\StatementGenerator;
 use Blueprint\Models\Statements\DispatchStatement;
 use Blueprint\Tree;
-use Illuminate\Support\Arr;
 
 class JobGenerator extends StatementGenerator
 {
@@ -22,19 +21,17 @@ class JobGenerator extends StatementGenerator
         foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
-                    foreach (Arr::wrap($statement) as $statement) {
-                        if (!$statement instanceof DispatchStatement) {
-                            continue;
-                        }
-
-                        $path = $this->getStatementPath($statement->job());
-
-                        if ($this->filesystem->exists($path)) {
-                            continue;
-                        }
-
-                        $this->create($path, $this->populateStub($stub, $statement));
+                    if (!$statement instanceof DispatchStatement) {
+                        continue;
                     }
+
+                    $path = $this->getStatementPath($statement->job());
+
+                    if ($this->filesystem->exists($path)) {
+                        continue;
+                    }
+
+                    $this->create($path, $this->populateStub($stub, $statement));
                 }
             }
         }

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -6,7 +6,6 @@ use Blueprint\Blueprint;
 use Blueprint\Generators\StatementGenerator;
 use Blueprint\Models\Statements\SendStatement;
 use Blueprint\Tree;
-use Illuminate\Support\Arr;
 
 class MailGenerator extends StatementGenerator
 {
@@ -23,29 +22,27 @@ class MailGenerator extends StatementGenerator
         foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $statements) {
                 foreach ($statements as $statement) {
-                    foreach (Arr::wrap($statement) as $statement) {
-                        if (!$statement instanceof SendStatement) {
-                            continue;
-                        }
-
-                        if ($statement->type() !== SendStatement::TYPE_MAIL) {
-                            continue;
-                        }
-
-                        $path = $this->getStatementPath($statement->mail());
-                        if ($this->filesystem->exists($path)) {
-                            continue;
-                        }
-
-                        $this->create($path, $this->populateStub($stub, $statement));
-
-                        $path = $this->getViewPath($statement->view());
-                        if ($this->filesystem->exists($path)) {
-                            continue;
-                        }
-
-                        $this->create($path, $this->populateViewStub($view_stub, $statement));
+                    if (!$statement instanceof SendStatement) {
+                        continue;
                     }
+
+                    if ($statement->type() !== SendStatement::TYPE_MAIL) {
+                        continue;
+                    }
+
+                    $path = $this->getStatementPath($statement->mail());
+                    if ($this->filesystem->exists($path)) {
+                        continue;
+                    }
+
+                    $this->create($path, $this->populateStub($stub, $statement));
+
+                    $path = $this->getViewPath($statement->view());
+                    if ($this->filesystem->exists($path)) {
+                        continue;
+                    }
+
+                    $this->create($path, $this->populateViewStub($view_stub, $statement));
                 }
             }
         }

--- a/src/Generators/Statements/NotificationGenerator.php
+++ b/src/Generators/Statements/NotificationGenerator.php
@@ -6,7 +6,6 @@ use Blueprint\Blueprint;
 use Blueprint\Generators\StatementGenerator;
 use Blueprint\Models\Statements\SendStatement;
 use Blueprint\Tree;
-use Illuminate\Support\Arr;
 
 class NotificationGenerator extends StatementGenerator
 {
@@ -22,23 +21,21 @@ class NotificationGenerator extends StatementGenerator
         foreach ($tree->controllers() as $controller) {
             foreach ($controller->methods() as $method => $statements) {
                 foreach ($statements as $statement) {
-                    foreach (Arr::wrap($statement) as $statement) {
-                        if (!$statement instanceof SendStatement) {
-                            continue;
-                        }
-
-                        if (!$statement->isNotification()) {
-                            continue;
-                        }
-
-                        $path = $this->getStatementPath($statement->mail());
-
-                        if ($this->filesystem->exists($path)) {
-                            continue;
-                        }
-
-                        $this->create($path, $this->populateStub($stub, $statement));
+                    if (!$statement instanceof SendStatement) {
+                        continue;
                     }
+
+                    if (!$statement->isNotification()) {
+                        continue;
+                    }
+
+                    $path = $this->getStatementPath($statement->mail());
+
+                    if ($this->filesystem->exists($path)) {
+                        continue;
+                    }
+
+                    $this->create($path, $this->populateStub($stub, $statement));
                 }
             }
         }

--- a/src/Generators/TestGenerator.php
+++ b/src/Generators/TestGenerator.php
@@ -22,7 +22,6 @@ use Blueprint\Models\Statements\SendStatement;
 use Blueprint\Models\Statements\SessionStatement;
 use Blueprint\Models\Statements\ValidateStatement;
 use Blueprint\Tree;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Shift\Faker\Registry as FakerRegistry;
 
@@ -114,347 +113,345 @@ class TestGenerator extends AbstractClassGenerator implements Generator
             }
 
             foreach ($statements as $statement) {
-                foreach (Arr::wrap($statement) as $statement) {
-                    if ($statement instanceof SendStatement) {
-                        if ($statement->isNotification()) {
-                            $this->addImport($controller, 'Illuminate\\Support\\Facades\\Notification');
-                            $this->addImport($controller, config('blueprint.namespace') . '\\Notification\\' . $statement->mail());
+                if ($statement instanceof SendStatement) {
+                    if ($statement->isNotification()) {
+                        $this->addImport($controller, 'Illuminate\\Support\\Facades\\Notification');
+                        $this->addImport($controller, config('blueprint.namespace') . '\\Notification\\' . $statement->mail());
 
-                            $setup['mock'][] = 'Notification::fake();';
-
-                            $assertion = sprintf(
-                                'Notification::assertSentTo($%s, %s::class',
-                                str_replace('.', '->', $statement->to()),
-                                $statement->mail()
-                            );
-
-                            if ($statement->data()) {
-                                $conditions = [];
-                                $variables = [];
-                                $assertion .= ', function ($notification)';
-
-                                foreach ($statement->data() as $data) {
-                                    if (Str::studly(Str::singular($data)) === $context || !Str::contains($data, '.')) {
-                                        $variables[] .= '$' . $data;
-                                        $conditions[] .= sprintf('$notification->%s->is($%s)', $data, $data);
-                                    } else {
-                                        [$model, $property] = explode('.', $data);
-                                        $variables[] .= '$' . $model;
-                                        $conditions[] .= sprintf('$notification->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
-                                    }
-                                }
-
-                                if ($variables) {
-                                    $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
-                                }
-
-                                $assertion .= ' {' . PHP_EOL;
-                                $assertion .= str_pad(' ', 12);
-                                $assertion .= 'return ' . implode(' && ', $conditions) . ';';
-                                $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
-                            }
-
-                            $assertion .= ');';
-
-                            $assertions['mock'][] = $assertion;
-                        } else {
-                            $this->addImport($controller, 'Illuminate\\Support\\Facades\\Mail');
-                            $this->addImport($controller, config('blueprint.namespace') . '\\Mail\\' . $statement->mail());
-
-                            $setup['mock'][] = 'Mail::fake();';
-
-                            $assertion = sprintf('Mail::assertSent(%s::class', $statement->mail());
-
-                            if ($statement->data() || $statement->to()) {
-                                $conditions = [];
-                                $variables = [];
-                                $assertion .= ', function ($mail)';
-
-                                if ($statement->to()) {
-                                    $conditions[] = '$mail->hasTo($' . str_replace('.', '->', $statement->to()) . ')';
-                                }
-
-                                foreach ($statement->data() as $data) {
-                                    if (Str::studly(Str::singular($data)) === $context || !Str::contains($data, '.')) {
-                                        $variables[] .= '$' . $data;
-                                        $conditions[] .= sprintf('$mail->%s->is($%s)', $data, $data);
-                                    } else {
-                                        [$model, $property] = explode('.', $data);
-                                        $variables[] .= '$' . $model;
-                                        $conditions[] .= sprintf('$mail->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
-                                    }
-                                }
-
-                                if ($variables) {
-                                    $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
-                                }
-
-                                $assertion .= ' {' . PHP_EOL;
-                                $assertion .= str_pad(' ', 12);
-                                $assertion .= 'return ' . implode(' && ', $conditions) . ';';
-                                $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
-                            }
-
-                            $assertion .= ');';
-
-                            $assertions['mock'][] = $assertion;
-                        }
-                    } elseif ($statement instanceof ValidateStatement) {
-                        $this->addTestAssertionsTrait($controller);
-
-                        $class = $this->buildFormRequestName($controller, $name);
-                        $test_case = $this->buildFormRequestTestCase($controller->fullyQualifiedClassName(), $name, config('blueprint.namespace') . '\\Http\\Requests\\' . $class) . PHP_EOL . PHP_EOL . $test_case;
-
-                        if ($statement->data()) {
-                            $this->addFakerTrait($controller);
-
-                            foreach ($statement->data() as $data) {
-                                [$qualifier, $column] = $this->splitField($data);
-
-                                if (is_null($qualifier)) {
-                                    $qualifier = $context;
-                                }
-
-                                $variable_name = $data;
-
-                                /** @var \Blueprint\Models\Model $local_model */
-                                $local_model = $this->tree->modelForContext($qualifier);
-
-                                if (!is_null($local_model) && $local_model->hasColumn($column)) {
-                                    $local_column = $local_model->column($column);
-
-                                    $factory = $this->generateReferenceFactory($local_column, $controller, $modelNamespace);
-
-                                    if ($factory) {
-                                        [$faker, $variable_name] = $factory;
-                                    } else {
-                                        $faker = sprintf('$%s = $this->faker->%s;', $data, FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_model->column($column)->dataType()));
-                                    }
-
-                                    $setup['data'][] = $faker;
-                                    $request_data[$data] = '$' . $variable_name;
-                                } elseif (!is_null($local_model)) {
-                                    foreach ($local_model->columns() as $local_column) {
-                                        if (in_array($local_column->name(), ['id', 'softdeletes', 'softdeletestz'])) {
-                                            continue;
-                                        }
-
-                                        if (in_array('nullable', $local_column->modifiers())) {
-                                            continue;
-                                        }
-
-                                        $factory = $this->generateReferenceFactory($local_column, $controller, $modelNamespace);
-                                        if ($factory) {
-                                            [$faker, $variable_name] = $factory;
-                                        } else {
-                                            $faker = sprintf('$%s = $this->faker->%s;', $local_column->name(), FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_column->dataType()));
-                                            $variable_name = $local_column->name();
-                                        }
-
-                                        $setup['data'][] = $faker;
-                                        $request_data[$local_column->name()] = '$' . $variable_name;
-                                    }
-                                }
-                            }
-                        }
-                    } elseif ($statement instanceof DispatchStatement) {
-                        $this->addImport($controller, 'Illuminate\\Support\\Facades\\Queue');
-                        $this->addImport($controller, config('blueprint.namespace') . '\\Jobs\\' . $statement->job());
-
-                        $setup['mock'][] = 'Queue::fake();';
-
-                        $assertion = sprintf('Queue::assertPushed(%s::class', $statement->job());
-
-                        if ($statement->data()) {
-                            $conditions = [];
-                            $variables = [];
-                            $assertion .= ', function ($job)';
-
-                            foreach ($statement->data() as $data) {
-                                if (Str::studly(Str::singular($data)) === $context || !Str::contains($data, '.')) {
-                                    $variables[] .= '$' . $data;
-                                    $conditions[] .= sprintf('$job->%s->is($%s)', $data, $data);
-                                } else {
-                                    [$model, $property] = explode('.', $data);
-                                    $variables[] .= '$' . $model;
-                                    $conditions[] .= sprintf('$job->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
-                                }
-                            }
-
-                            if ($variables) {
-                                $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
-                            }
-
-                            $assertion .= ' {' . PHP_EOL;
-                            $assertion .= str_pad(' ', 12);
-                            $assertion .= 'return ' . implode(' && ', $conditions) . ';';
-                            $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
-                        }
-
-                        $assertion .= ');';
-
-                        $assertions['mock'][] = $assertion;
-                    } elseif ($statement instanceof FireStatement) {
-                        $this->addImport($controller, 'Illuminate\\Support\\Facades\\Event');
-
-                        $setup['mock'][] = 'Event::fake();';
-
-                        $assertion = 'Event::assertDispatched(';
-
-                        if ($statement->isNamedEvent()) {
-                            $assertion .= $statement->event();
-                        } else {
-                            $this->addImport($controller, config('blueprint.namespace') . '\\Events\\' . $statement->event());
-                            $assertion .= $statement->event() . '::class';
-                        }
-
-                        if ($statement->data()) {
-                            $conditions = [];
-                            $variables = [];
-                            $assertion .= ', function ($event)';
-
-                            foreach ($statement->data() as $data) {
-                                if (Str::studly(Str::singular($data)) === $context || !Str::contains($data, '.')) {
-                                    $variables[] .= '$' . $data;
-                                    $conditions[] .= sprintf('$event->%s->is($%s)', $data, $data);
-                                } else {
-                                    [$model, $property] = explode('.', $data);
-                                    $variables[] .= '$' . $model;
-                                    $conditions[] .= sprintf('$event->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
-                                }
-                            }
-
-                            if ($variables) {
-                                $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
-                            }
-
-                            $assertion .= ' {' . PHP_EOL;
-                            $assertion .= str_pad(' ', 12);
-                            $assertion .= 'return ' . implode(' && ', $conditions) . ';';
-                            $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
-                        }
-
-                        $assertion .= ');';
-
-                        $assertions['mock'][] = $assertion;
-                    } elseif ($statement instanceof RenderStatement) {
-                        $tested_bits |= self::TESTS_VIEW;
-
-                        $view_assertions = [];
-                        $view_assertions[] = '$response->assertOk();';
-                        $view_assertions[] = sprintf('$response->assertViewIs(\'%s\');', $statement->view());
-
-                        foreach ($statement->data() as $data) {
-                            // TODO: if data references locally scoped var, strengthen assertion...
-                            $view_assertions[] = sprintf('$response->assertViewHas(\'%s\');', $data);
-                        }
-
-                        array_unshift($assertions['response'], ...$view_assertions);
-                    } elseif ($statement instanceof RedirectStatement) {
-                        $tested_bits |= self::TESTS_REDIRECT;
+                        $setup['mock'][] = 'Notification::fake();';
 
                         $assertion = sprintf(
-                            '$response->assertRedirect(route(\'%s\'',
-                            config('blueprint.plural_routes') ? Str::plural(Str::kebab($statement->route())) : Str::kebab($statement->route())
+                            'Notification::assertSentTo($%s, %s::class',
+                            str_replace('.', '->', $statement->to()),
+                            $statement->mail()
                         );
 
                         if ($statement->data()) {
-                            $parameters = array_map(fn ($parameter) => '$' . $parameter, $statement->data());
+                            $conditions = [];
+                            $variables = [];
+                            $assertion .= ', function ($notification)';
 
-                            $assertion .= ', [' . implode(', ', $parameters) . ']';
-                        } elseif (Str::contains($statement->route(), '.')) {
-                            [$model, $action] = explode('.', $statement->route());
-                            if (in_array($action, ['edit', 'update', 'show', 'destroy'])) {
-                                $assertion .= sprintf(", ['%s' => $%s]", $model, $model);
-                            }
-                        }
-
-                        $assertion .= '));';
-
-                        array_unshift($assertions['response'], $assertion);
-                    } elseif ($statement instanceof ResourceStatement) {
-                        if ($name === 'store') {
-                            $assertions['response'][] = '$response->assertCreated();';
-                        } else {
-                            $assertions['response'][] = '$response->assertOk();';
-                        }
-
-                        $assertions['response'][] = '$response->assertJsonStructure([]);';
-                    } elseif ($statement instanceof RespondStatement) {
-                        $tested_bits |= self::TESTS_RESPONDS;
-
-                        if ($statement->content()) {
-                            array_unshift($assertions['response'], '$response->assertJson($' . $statement->content() . ');');
-                        }
-
-                        if ($statement->status() === 200) {
-                            array_unshift($assertions['response'], '$response->assertOk();');
-                        } elseif ($statement->status() === 204) {
-                            array_unshift($assertions['response'], '$response->assertNoContent();');
-                        } else {
-                            array_unshift($assertions['response'], '$response->assertNoContent(' . $statement->status() . ');');
-                        }
-                    } elseif ($statement instanceof SessionStatement) {
-                        $assertions['response'][] = sprintf('$response->assertSessionHas(\'%s\', %s);', $statement->reference(), '$' . str_replace('.', '->', $statement->reference()));
-                    } elseif ($statement instanceof EloquentStatement) {
-                        $this->addRefreshDatabaseTrait($controller);
-
-                        $model = $this->determineModel($controller->prefix(), $statement->reference());
-                        $this->addImport($controller, $modelNamespace . '\\' . $model);
-
-                        if ($statement->operation() === 'save') {
-                            $tested_bits |= self::TESTS_SAVE;
-
-                            if ($request_data) {
-                                $indent = str_pad(' ', 12);
-                                $plural = Str::plural($variable);
-                                $assertion = sprintf('$%s = %s::query()', $plural, $model);
-                                foreach ($request_data as $key => $datum) {
-                                    $assertion .= PHP_EOL . sprintf('%s->where(\'%s\', %s)', $indent, $key, $datum);
+                            foreach ($statement->data() as $data) {
+                                if (Str::studly(Str::singular($data)) === $context || !Str::contains($data, '.')) {
+                                    $variables[] .= '$' . $data;
+                                    $conditions[] .= sprintf('$notification->%s->is($%s)', $data, $data);
+                                } else {
+                                    [$model, $property] = explode('.', $data);
+                                    $variables[] .= '$' . $model;
+                                    $conditions[] .= sprintf('$notification->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
                                 }
-                                $assertion .= PHP_EOL . $indent . '->get();';
-
-                                $assertions['sanity'][] = $assertion;
-                                $assertions['sanity'][] = '$this->assertCount(1, $' . $plural . ');';
-                                $assertions['sanity'][] = sprintf('$%s = $%s->first();', $variable, $plural);
-                            } else {
-                                $assertions['generic'][] = '$this->assertDatabaseHas(' . Str::camel(Str::plural($model)) . ', [ /* ... */ ]);';
                             }
-                        } elseif ($statement->operation() === 'find') {
-                            $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
-                        } elseif ($statement->operation() === 'delete') {
-                            $tested_bits |= self::TESTS_DELETE;
-                            $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
+
+                            if ($variables) {
+                                $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
+                            }
+
+                            $assertion .= ' {' . PHP_EOL;
+                            $assertion .= str_pad(' ', 12);
+                            $assertion .= 'return ' . implode(' && ', $conditions) . ';';
+                            $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
+                        }
+
+                        $assertion .= ');';
+
+                        $assertions['mock'][] = $assertion;
+                    } else {
+                        $this->addImport($controller, 'Illuminate\\Support\\Facades\\Mail');
+                        $this->addImport($controller, config('blueprint.namespace') . '\\Mail\\' . $statement->mail());
+
+                        $setup['mock'][] = 'Mail::fake();';
+
+                        $assertion = sprintf('Mail::assertSent(%s::class', $statement->mail());
+
+                        if ($statement->data() || $statement->to()) {
+                            $conditions = [];
+                            $variables = [];
+                            $assertion .= ', function ($mail)';
+
+                            if ($statement->to()) {
+                                $conditions[] = '$mail->hasTo($' . str_replace('.', '->', $statement->to()) . ')';
+                            }
+
+                            foreach ($statement->data() as $data) {
+                                if (Str::studly(Str::singular($data)) === $context || !Str::contains($data, '.')) {
+                                    $variables[] .= '$' . $data;
+                                    $conditions[] .= sprintf('$mail->%s->is($%s)', $data, $data);
+                                } else {
+                                    [$model, $property] = explode('.', $data);
+                                    $variables[] .= '$' . $model;
+                                    $conditions[] .= sprintf('$mail->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
+                                }
+                            }
+
+                            if ($variables) {
+                                $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
+                            }
+
+                            $assertion .= ' {' . PHP_EOL;
+                            $assertion .= str_pad(' ', 12);
+                            $assertion .= 'return ' . implode(' && ', $conditions) . ';';
+                            $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
+                        }
+
+                        $assertion .= ');';
+
+                        $assertions['mock'][] = $assertion;
+                    }
+                } elseif ($statement instanceof ValidateStatement) {
+                    $this->addTestAssertionsTrait($controller);
+
+                    $class = $this->buildFormRequestName($controller, $name);
+                    $test_case = $this->buildFormRequestTestCase($controller->fullyQualifiedClassName(), $name, config('blueprint.namespace') . '\\Http\\Requests\\' . $class) . PHP_EOL . PHP_EOL . $test_case;
+
+                    if ($statement->data()) {
+                        $this->addFakerTrait($controller);
+
+                        foreach ($statement->data() as $data) {
+                            [$qualifier, $column] = $this->splitField($data);
+
+                            if (is_null($qualifier)) {
+                                $qualifier = $context;
+                            }
+
+                            $variable_name = $data;
 
                             /** @var \Blueprint\Models\Model $local_model */
-                            $local_model = $this->tree->modelForContext($model);
-                            if (!is_null($local_model) && $local_model->usesSoftDeletes()) {
-                                $assertions['generic'][] = sprintf('$this->assertSoftDeleted($%s);', $variable);
-                            } else {
-                                $assertions['generic'][] = sprintf('$this->assertModelMissing($%s);', $variable);
-                            }
-                        } elseif ($statement->operation() === 'update') {
-                            $assertions['sanity'][] = sprintf('$%s->refresh();', $variable);
+                            $local_model = $this->tree->modelForContext($qualifier);
 
-                            if ($request_data) {
-                                /** @var \Blueprint\Models\Model $local_model */
-                                $local_model = $this->tree->modelForContext($model);
-                                foreach ($request_data as $key => $datum) {
-                                    if (!is_null($local_model) && $local_model->hasColumn($key) && $local_model->column($key)->dataType() === 'date') {
-                                        $this->addImport($controller, 'Carbon\\Carbon');
-                                        $assertions['generic'][] = sprintf('$this->assertEquals(Carbon::parse(%s), $%s->%s);', $datum, $variable, $key);
-                                    } else {
-                                        $assertions['generic'][] = sprintf('$this->assertEquals(%s, $%s->%s);', $datum, $variable, $key);
+                            if (!is_null($local_model) && $local_model->hasColumn($column)) {
+                                $local_column = $local_model->column($column);
+
+                                $factory = $this->generateReferenceFactory($local_column, $controller, $modelNamespace);
+
+                                if ($factory) {
+                                    [$faker, $variable_name] = $factory;
+                                } else {
+                                    $faker = sprintf('$%s = $this->faker->%s;', $data, FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_model->column($column)->dataType()));
+                                }
+
+                                $setup['data'][] = $faker;
+                                $request_data[$data] = '$' . $variable_name;
+                            } elseif (!is_null($local_model)) {
+                                foreach ($local_model->columns() as $local_column) {
+                                    if (in_array($local_column->name(), ['id', 'softdeletes', 'softdeletestz'])) {
+                                        continue;
                                     }
+
+                                    if (in_array('nullable', $local_column->modifiers())) {
+                                        continue;
+                                    }
+
+                                    $factory = $this->generateReferenceFactory($local_column, $controller, $modelNamespace);
+                                    if ($factory) {
+                                        [$faker, $variable_name] = $factory;
+                                    } else {
+                                        $faker = sprintf('$%s = $this->faker->%s;', $local_column->name(), FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_column->dataType()));
+                                        $variable_name = $local_column->name();
+                                    }
+
+                                    $setup['data'][] = $faker;
+                                    $request_data[$local_column->name()] = '$' . $variable_name;
                                 }
                             }
                         }
-                    } elseif ($statement instanceof QueryStatement) {
-                        $this->addRefreshDatabaseTrait($controller);
-                        $setup['data'][] = sprintf('$%s = %s::factory()->count(3)->create();', Str::plural($variable), $model);
-
-                        $this->addImport($controller, $modelNamespace . '\\' . $this->determineModel($controller->prefix(), $statement->model()));
                     }
+                } elseif ($statement instanceof DispatchStatement) {
+                    $this->addImport($controller, 'Illuminate\\Support\\Facades\\Queue');
+                    $this->addImport($controller, config('blueprint.namespace') . '\\Jobs\\' . $statement->job());
+
+                    $setup['mock'][] = 'Queue::fake();';
+
+                    $assertion = sprintf('Queue::assertPushed(%s::class', $statement->job());
+
+                    if ($statement->data()) {
+                        $conditions = [];
+                        $variables = [];
+                        $assertion .= ', function ($job)';
+
+                        foreach ($statement->data() as $data) {
+                            if (Str::studly(Str::singular($data)) === $context || !Str::contains($data, '.')) {
+                                $variables[] .= '$' . $data;
+                                $conditions[] .= sprintf('$job->%s->is($%s)', $data, $data);
+                            } else {
+                                [$model, $property] = explode('.', $data);
+                                $variables[] .= '$' . $model;
+                                $conditions[] .= sprintf('$job->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
+                            }
+                        }
+
+                        if ($variables) {
+                            $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
+                        }
+
+                        $assertion .= ' {' . PHP_EOL;
+                        $assertion .= str_pad(' ', 12);
+                        $assertion .= 'return ' . implode(' && ', $conditions) . ';';
+                        $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
+                    }
+
+                    $assertion .= ');';
+
+                    $assertions['mock'][] = $assertion;
+                } elseif ($statement instanceof FireStatement) {
+                    $this->addImport($controller, 'Illuminate\\Support\\Facades\\Event');
+
+                    $setup['mock'][] = 'Event::fake();';
+
+                    $assertion = 'Event::assertDispatched(';
+
+                    if ($statement->isNamedEvent()) {
+                        $assertion .= $statement->event();
+                    } else {
+                        $this->addImport($controller, config('blueprint.namespace') . '\\Events\\' . $statement->event());
+                        $assertion .= $statement->event() . '::class';
+                    }
+
+                    if ($statement->data()) {
+                        $conditions = [];
+                        $variables = [];
+                        $assertion .= ', function ($event)';
+
+                        foreach ($statement->data() as $data) {
+                            if (Str::studly(Str::singular($data)) === $context || !Str::contains($data, '.')) {
+                                $variables[] .= '$' . $data;
+                                $conditions[] .= sprintf('$event->%s->is($%s)', $data, $data);
+                            } else {
+                                [$model, $property] = explode('.', $data);
+                                $variables[] .= '$' . $model;
+                                $conditions[] .= sprintf('$event->%s == $%s', $property ?? $model, str_replace('.', '->', $data()));
+                            }
+                        }
+
+                        if ($variables) {
+                            $assertion .= ' use (' . implode(', ', array_unique($variables)) . ')';
+                        }
+
+                        $assertion .= ' {' . PHP_EOL;
+                        $assertion .= str_pad(' ', 12);
+                        $assertion .= 'return ' . implode(' && ', $conditions) . ';';
+                        $assertion .= PHP_EOL . str_pad(' ', 8) . '}';
+                    }
+
+                    $assertion .= ');';
+
+                    $assertions['mock'][] = $assertion;
+                } elseif ($statement instanceof RenderStatement) {
+                    $tested_bits |= self::TESTS_VIEW;
+
+                    $view_assertions = [];
+                    $view_assertions[] = '$response->assertOk();';
+                    $view_assertions[] = sprintf('$response->assertViewIs(\'%s\');', $statement->view());
+
+                    foreach ($statement->data() as $data) {
+                        // TODO: if data references locally scoped var, strengthen assertion...
+                        $view_assertions[] = sprintf('$response->assertViewHas(\'%s\');', $data);
+                    }
+
+                    array_unshift($assertions['response'], ...$view_assertions);
+                } elseif ($statement instanceof RedirectStatement) {
+                    $tested_bits |= self::TESTS_REDIRECT;
+
+                    $assertion = sprintf(
+                        '$response->assertRedirect(route(\'%s\'',
+                        config('blueprint.plural_routes') ? Str::plural(Str::kebab($statement->route())) : Str::kebab($statement->route())
+                    );
+
+                    if ($statement->data()) {
+                        $parameters = array_map(fn ($parameter) => '$' . $parameter, $statement->data());
+
+                        $assertion .= ', [' . implode(', ', $parameters) . ']';
+                    } elseif (Str::contains($statement->route(), '.')) {
+                        [$model, $action] = explode('.', $statement->route());
+                        if (in_array($action, ['edit', 'update', 'show', 'destroy'])) {
+                            $assertion .= sprintf(", ['%s' => $%s]", $model, $model);
+                        }
+                    }
+
+                    $assertion .= '));';
+
+                    array_unshift($assertions['response'], $assertion);
+                } elseif ($statement instanceof ResourceStatement) {
+                    if ($name === 'store') {
+                        $assertions['response'][] = '$response->assertCreated();';
+                    } else {
+                        $assertions['response'][] = '$response->assertOk();';
+                    }
+
+                    $assertions['response'][] = '$response->assertJsonStructure([]);';
+                } elseif ($statement instanceof RespondStatement) {
+                    $tested_bits |= self::TESTS_RESPONDS;
+
+                    if ($statement->content()) {
+                        array_unshift($assertions['response'], '$response->assertJson($' . $statement->content() . ');');
+                    }
+
+                    if ($statement->status() === 200) {
+                        array_unshift($assertions['response'], '$response->assertOk();');
+                    } elseif ($statement->status() === 204) {
+                        array_unshift($assertions['response'], '$response->assertNoContent();');
+                    } else {
+                        array_unshift($assertions['response'], '$response->assertNoContent(' . $statement->status() . ');');
+                    }
+                } elseif ($statement instanceof SessionStatement) {
+                    $assertions['response'][] = sprintf('$response->assertSessionHas(\'%s\', %s);', $statement->reference(), '$' . str_replace('.', '->', $statement->reference()));
+                } elseif ($statement instanceof EloquentStatement) {
+                    $this->addRefreshDatabaseTrait($controller);
+
+                    $model = $this->determineModel($controller->prefix(), $statement->reference());
+                    $this->addImport($controller, $modelNamespace . '\\' . $model);
+
+                    if ($statement->operation() === 'save') {
+                        $tested_bits |= self::TESTS_SAVE;
+
+                        if ($request_data) {
+                            $indent = str_pad(' ', 12);
+                            $plural = Str::plural($variable);
+                            $assertion = sprintf('$%s = %s::query()', $plural, $model);
+                            foreach ($request_data as $key => $datum) {
+                                $assertion .= PHP_EOL . sprintf('%s->where(\'%s\', %s)', $indent, $key, $datum);
+                            }
+                            $assertion .= PHP_EOL . $indent . '->get();';
+
+                            $assertions['sanity'][] = $assertion;
+                            $assertions['sanity'][] = '$this->assertCount(1, $' . $plural . ');';
+                            $assertions['sanity'][] = sprintf('$%s = $%s->first();', $variable, $plural);
+                        } else {
+                            $assertions['generic'][] = '$this->assertDatabaseHas(' . Str::camel(Str::plural($model)) . ', [ /* ... */ ]);';
+                        }
+                    } elseif ($statement->operation() === 'find') {
+                        $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
+                    } elseif ($statement->operation() === 'delete') {
+                        $tested_bits |= self::TESTS_DELETE;
+                        $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
+
+                        /** @var \Blueprint\Models\Model $local_model */
+                        $local_model = $this->tree->modelForContext($model);
+                        if (!is_null($local_model) && $local_model->usesSoftDeletes()) {
+                            $assertions['generic'][] = sprintf('$this->assertSoftDeleted($%s);', $variable);
+                        } else {
+                            $assertions['generic'][] = sprintf('$this->assertModelMissing($%s);', $variable);
+                        }
+                    } elseif ($statement->operation() === 'update') {
+                        $assertions['sanity'][] = sprintf('$%s->refresh();', $variable);
+
+                        if ($request_data) {
+                            /** @var \Blueprint\Models\Model $local_model */
+                            $local_model = $this->tree->modelForContext($model);
+                            foreach ($request_data as $key => $datum) {
+                                if (!is_null($local_model) && $local_model->hasColumn($key) && $local_model->column($key)->dataType() === 'date') {
+                                    $this->addImport($controller, 'Carbon\\Carbon');
+                                    $assertions['generic'][] = sprintf('$this->assertEquals(Carbon::parse(%s), $%s->%s);', $datum, $variable, $key);
+                                } else {
+                                    $assertions['generic'][] = sprintf('$this->assertEquals(%s, $%s->%s);', $datum, $variable, $key);
+                                }
+                            }
+                        }
+                    }
+                } elseif ($statement instanceof QueryStatement) {
+                    $this->addRefreshDatabaseTrait($controller);
+                    $setup['data'][] = sprintf('$%s = %s::factory()->count(3)->create();', Str::plural($variable), $model);
+
+                    $this->addImport($controller, $modelNamespace . '\\' . $this->determineModel($controller->prefix(), $statement->model()));
                 }
             }
 

--- a/src/Lexers/StatementLexer.php
+++ b/src/Lexers/StatementLexer.php
@@ -37,7 +37,7 @@ class StatementLexer implements Lexer
                 'save', 'delete', 'find' => new EloquentStatement($command, $statement),
                 'update' => $this->analyzeUpdate($statement),
                 'flash', 'store' => new SessionStatement($command, $statement),
-                default => null,
+                default => $this->analyzeDefault($command, $statement),
             };
         }
 
@@ -189,5 +189,24 @@ class StatementLexer implements Lexer
         $columns = preg_split('/,([ \t]+)?/', $statement);
 
         return new EloquentStatement('update', null, $columns);
+    }
+
+    private function analyzeDefault(string $command, string $statement)
+    {
+        if (fnmatch('fire-*', $command)) {
+            return $this->analyzeEvent($statement);
+        }
+
+        if (fnmatch('dispatch-*', $command)) {
+            return $this->analyzeDispatch($statement);
+        }
+
+        if (fnmatch('send-*', $command)) {
+            return $this->analyzeSend($statement);
+        }
+
+        if (fnmatch('notify-*', $command)) {
+            return $this->analyzeNotify($statement);
+        }
     }
 }

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -297,6 +297,39 @@ final class BlueprintTest extends TestCase
     }
 
     #[Test]
+    public function it_parses_yaml_with_multiple_dispatch_fire_notify_send_keys(): void
+    {
+        $definition = $this->fixture('drafts/multiple-dispatch-fire-notify-send-keys.yaml');
+
+        $expected = [
+            'controllers' => [
+                'Post' => [
+                    'store' => [
+                        'dispatch-4' => 'SyncMedia with:post',
+                        'dispatch-5' => 'SyncMedia with:post',
+                        'dispatch-6' => 'SyncMedia with:post',
+                        'fire-7' => 'NewPost with:post',
+                        'fire-8' => 'NewPost with:post',
+                        'fire-9' => 'NewPost with:post',
+                    ],
+                ],
+                'User' => [
+                    'store' => [
+                        'notify-12' => 'post.author ReviewPost with:post',
+                        'notify-13' => 'post.author ReviewPost with:post',
+                        'notify-14' => 'post.author ReviewPost with:post',
+                        'send-15' => 'ReviewNotification to:post.author with:post',
+                        'send-16' => 'ReviewNotification to:post.author with:post',
+                        'send-17' => 'ReviewNotification to:post.author with:post',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->subject->parse($definition));
+    }
+
+    #[Test]
     public function it_allows_parsing_without_stripping_dashes(): void
     {
         $sequence = [

--- a/tests/fixtures/drafts/multiple-dispatch-fire-notify-send-keys.yaml
+++ b/tests/fixtures/drafts/multiple-dispatch-fire-notify-send-keys.yaml
@@ -1,0 +1,17 @@
+controllers:
+  Post:
+    store:
+      dispatch: SyncMedia with:post
+      dispatch: SyncMedia with:post
+      dispatch: SyncMedia with:post
+      fire: NewPost with:post
+      fire: NewPost with:post
+      fire: NewPost with:post
+  User:
+    store:
+      notify: post.author ReviewPost with:post
+      notify: post.author ReviewPost with:post
+      notify: post.author ReviewPost with:post
+      send: ReviewNotification to:post.author with:post
+      send: ReviewNotification to:post.author with:post
+      send: ReviewNotification to:post.author with:post


### PR DESCRIPTION
> Alternative to https://github.com/laravel-shift/blueprint/pull/612 for https://github.com/laravel-shift/blueprint/issues/611

This new approach preprocesses the YAML content and transforms duplicate keys into keys that are suffixed with their line number to avoid key collisions. This also reverts https://github.com/laravel-shift/blueprint/pull/619.

**Input**
https://github.com/laravel-shift/blueprint/pull/623/files#diff-a4f4e06b3fdb4a8424880f544fca3c75a0ecf2ebb5158feba4963f7066e2d265

**Output**
https://github.com/laravel-shift/blueprint/pull/623/files#diff-72d9e08bf23239b5487ea8767fe78e8f3e9be1b14e5bd64e1ae2c4848da167f1