### PR TITLE
FactoryGenerator: No need to import fqcn foreign keys.

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -97,9 +97,10 @@ class FactoryGenerator extends AbstractClassGenerator implements Generator
                 }
 
                 $class = Str::studly(Str::singular($table));
-                $reference = $this->fullyQualifyModelReference($class) ?? $model;
-
-                $this->addImport($model, $reference->fullyQualifiedNamespace() . '\\' . $class);
+                if (!Str::startsWith($class, '\\')) {
+                    $reference = $this->fullyQualifyModelReference($class) ?? $model;
+                    $this->addImport($model, $reference->fullyQualifiedNamespace() . '\\' . $class);
+                }
 
                 if ($key === 'id') {
                     $definition .= str_repeat(self::INDENT, 3) . "'{$column->name()}' => ";

--- a/tests/Feature/Generators/FactoryGeneratorTest.php
+++ b/tests/Feature/Generators/FactoryGeneratorTest.php
@@ -181,6 +181,7 @@ final class FactoryGeneratorTest extends TestCase
             ['drafts/factory-smallint-and-tinyint.yaml', 'database/factories/ModelFactory.php', 'factories/factory-smallint-and-tinyint.php'],
             ['drafts/all-column-types.yaml', 'database/factories/AllTypeFactory.php', 'factories/all-column-types.php'],
             ['drafts/shorthands.yaml', 'database/factories/NameFactory.php', 'factories/shorthands.php'],
+            ['drafts/fqcn-foreign-key.yaml', 'database/factories/PostFactory.php', 'factories/fqcn-foreign-key.php'],
         ];
     }
 }

--- a/tests/fixtures/drafts/fqcn-foreign-key.yaml
+++ b/tests/fixtures/drafts/fqcn-foreign-key.yaml
@@ -1,0 +1,4 @@
+models:
+  Post:
+    title: string
+    author_id: id foreign:\My\User

--- a/tests/fixtures/factories/fqcn-foreign-key.php
+++ b/tests/fixtures/factories/fqcn-foreign-key.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use App\Models\Post;
+
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Post::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(4),
+            'author_id' => \My\User::factory(),
+        ];
+    }
+}


### PR DESCRIPTION
No need `use App\Models\\Foo\Bar;` for `foreign:\Foo\Bar`.