### PR TITLE
use table name for belongsToMany()

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -225,11 +225,12 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
                     $relationship = sprintf('$this->%s(%s::class, \'%s\', \'%s\')', $type, $fqcn, $column_name, $key);
                 } elseif (!is_null($class) && $type === 'belongsToMany') {
                     if ($is_pivot) {
-                        $relationship = sprintf('$this->%s(%s::class)', $type, $fqcn);
+                        $foreign = $this->tree->modelForContext($column_name, true);
+
+                        $relationship = sprintf('$this->%s(%s::class, \'%s\')', $type, $fqcn, $foreign->tableName());
                         $relationship .= sprintf('%s->using(%s::class)', PHP_EOL . str_pad(' ', 12), $column_name);
                         $relationship .= sprintf('%s->as(\'%s\')', PHP_EOL . str_pad(' ', 12), Str::snake($column_name));
 
-                        $foreign = $this->tree->modelForContext($column_name, true);
                         $columns = $this->pivotColumns($foreign->columns(), $foreign->relationships());
                         if ($columns) {
                             $relationship .= sprintf('%s->withPivot(\'%s\')', PHP_EOL . str_pad(' ', 12), implode("', '", $columns));

--- a/tests/fixtures/drafts/custom-pivot.yaml
+++ b/tests/fixtures/drafts/custom-pivot.yaml
@@ -12,6 +12,6 @@ models:
   Membership:
     meta:
       pivot: true
-      table: team_user
+      table: another_table_name
     user_id: id
     team_id: id

--- a/tests/fixtures/models/custom-pivot-membership.php
+++ b/tests/fixtures/models/custom-pivot-membership.php
@@ -15,7 +15,7 @@ class Membership extends Pivot
      *
      * @var string
      */
-    protected $table = 'team_user';
+    protected $table = 'another_table_name';
 
     /**
      * Indicates if the IDs are auto-incrementing.

--- a/tests/fixtures/models/custom-pivot-team.php
+++ b/tests/fixtures/models/custom-pivot-team.php
@@ -30,7 +30,7 @@ class Team extends Model
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class)
+        return $this->belongsToMany(User::class, 'another_table_name')
             ->using(Membership::class)
             ->as('membership')
             ->withPivot('id')

--- a/tests/fixtures/models/custom-pivot-user.php
+++ b/tests/fixtures/models/custom-pivot-user.php
@@ -30,7 +30,7 @@ class User extends Model
 
     public function teams(): BelongsToMany
     {
-        return $this->belongsToMany(Team::class)
+        return $this->belongsToMany(Team::class, 'another_table_name')
             ->using(Membership::class)
             ->as('membership')
             ->withPivot('id')


### PR DESCRIPTION
belongsToMany() needs a table name always.

```php
if ($is_pivot) {
    ...
    $relationship = sprintf('$this->%s(%s::class, \'%s\')', $type, $fqcn, $foreign->tableName());
    ...
}
else {
    $relationship = sprintf('$this->%s(%s::class, \'%s\')', $type, $fqcn, $column_name);
}
```