### PR TITLE
Infer `belongsTo` relationships

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -308,7 +308,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         );
     }
 
-    private function castableColumns(array $columns)
+    private function castableColumns(array $columns): array
     {
         return array_filter(
             array_map(
@@ -331,7 +331,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         );
     }
 
-    private function castForColumn(Column $column)
+    private function castForColumn(Column $column): ?string
     {
         if ($column->dataType() === 'date') {
             return 'date';
@@ -345,7 +345,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
             return 'timestamp';
         }
 
-        if (stripos($column->dataType(), 'integer') || $column->dataType() === 'id') {
+        if (stripos($column->dataType(), 'integer') || in_array($column->dataType(), ['id', 'foreign'])) {
             return 'integer';
         }
 
@@ -364,6 +364,8 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         if ($column->dataType() === 'json') {
             return 'array';
         }
+
+        return null;
     }
 
     private function pretty_print_array(array $data, $assoc = true)

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -68,7 +68,6 @@ final class MigrationGeneratorTest extends TestCase
         $tree = $this->blueprint->analyze($tokens);
 
         $this->assertEquals(['created' => [$timestamp_path]], $this->subject->output($tree));
-
     }
 
     #[Test]

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -609,6 +609,7 @@ final class ModelGeneratorTest extends TestCase
             ['drafts/alias-relationships.yaml', 'app/Models/Salesman.php', 'models/alias-relationships.php'],
             ['drafts/uuid-shorthand-invalid-relationship.yaml', 'app/Models/AgeCohort.php', 'models/uuid-shorthand-invalid-relationship.php'],
             ['drafts/model-with-meta.yaml', 'app/Models/Post.php', 'models/model-with-meta.php'],
+            ['drafts/infer-belongsto.yaml', 'app/Models/Conference.php', 'models/infer-belongsto.php'],
         ];
     }
 

--- a/tests/Feature/Generators/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/ResourceGeneratorTest.php
@@ -136,7 +136,8 @@ final class ResourceGeneratorTest extends TestCase
             ->with('resource.stub')
             ->andReturn(file_get_contents('stubs/resource.stub'));
 
-        $this->filesystem->shouldReceive('exists')
+        $this->filesystem->expects('exists')
+            ->twice()
             ->with('app/Http/Resources/Api')
             ->andReturns(false, true);
         $this->filesystem->expects('makeDirectory')
@@ -170,7 +171,8 @@ final class ResourceGeneratorTest extends TestCase
             ->with('resource.stub')
             ->andReturn(file_get_contents('stubs/resource.stub'));
 
-        $this->files->shouldReceive('exists')
+        $this->files->expects('exists')
+            ->twice()
             ->with('app/Http/Resources')
             ->andReturns(false, true);
         $this->files->expects('makeDirectory')

--- a/tests/fixtures/drafts/alias-relationships.yaml
+++ b/tests/fixtures/drafts/alias-relationships.yaml
@@ -3,5 +3,5 @@ models:
     name: string
     relationships:
       hasOne: User:Lead
-      hasMany: class_name:method_name
-      belongsTo: class_name:method_name
+      hasMany: ManyModel:ManyAlias
+      belongsTo: BelongsModel:BelongsAlias

--- a/tests/fixtures/drafts/infer-belongsto.yaml
+++ b/tests/fixtures/drafts/infer-belongsto.yaml
@@ -1,0 +1,6 @@
+models:
+  Conference:
+    name: string
+    venue_id: unsigned bigInteger
+    relationships:
+      belongsTo: Venue, Region

--- a/tests/fixtures/migrations/infer-belongsto.php
+++ b/tests/fixtures/migrations/infer-belongsto.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conferences', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->unsignedBigInteger('venue_id');
+            $table->unsignedBigInteger('region_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('conferences');
+    }
+};

--- a/tests/fixtures/migrations/models-with-custom-namespace.php
+++ b/tests/fixtures/migrations/models-with-custom-namespace.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 30);
+            $table->string('image');
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/tests/fixtures/models/infer-belongsto.php
+++ b/tests/fixtures/models/infer-belongsto.php
@@ -5,10 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 
-class Salesman extends Model
+class Conference extends Model
 {
     use HasFactory;
 
@@ -19,7 +17,8 @@ class Salesman extends Model
      */
     protected $fillable = [
         'name',
-        'belongs_alias_id',
+        'venue_id',
+        'region_id',
     ];
 
     /**
@@ -29,21 +28,17 @@ class Salesman extends Model
      */
     protected $casts = [
         'id' => 'integer',
-        'belongs_alias_id' => 'integer',
+        'venue_id' => 'integer',
+        'region_id' => 'integer',
     ];
 
-    public function lead(): HasOne
+    public function venue(): BelongsTo
     {
-        return $this->hasOne(User::class);
+        return $this->belongsTo(Venue::class);
     }
 
-    public function manyAliases(): HasMany
+    public function region(): BelongsTo
     {
-        return $this->hasMany(ManyModel::class);
-    }
-
-    public function belongsAlias(): BelongsTo
-    {
-        return $this->belongsTo(BelongsModel::class);
+        return $this->belongsTo(Region::class);
     }
 }

--- a/tests/fixtures/resources/certificate-with-nested-resource.php
+++ b/tests/fixtures/resources/certificate-with-nested-resource.php
@@ -19,6 +19,7 @@ class CertificateResource extends JsonResource
             'document' => $this->document,
             'expiry_date' => $this->expiry_date,
             'remarks' => $this->remarks,
+            'certificate_id' => $this->certificate_id,
             'certificate' => CertificateResource::make($this->whenLoaded('certificate')),
             'certificates' => CertificateCollection::make($this->whenLoaded('certificates')),
         ];


### PR DESCRIPTION
After watching Blueprint in action on a [Laracast Series](https://laracasts.com/series/rapid-laravel-development-with-filament/episodes/1), I realized a use case that could be optimized. Blueprint is all about conventions and rapid development, but this video demonstrated some confusion on when to define model `columns` as well as `relationships`. Particularly in the case of `belongsTo`.

Consider the following draft file:

```yaml
models:
  Conference:
    name: string
    venue_id: unsigned bigInteger
    relationships:
      belongsTo: Venue, Region
```

In this case a user has defined what they believe to be a foreign key column, but also the `belongsTo` relationship to `Venue`. While there are a few ways you may write this, ideally you would do one or the other. Personally, I would not define a `belongsTo` relationship as simply defining the column is faster (less to type).

For example:

```yaml
models:
  Conference:
    name: string
    venue_id: id
    region_id: id
```

However, with this PR, you may also write the following and the foreign key columns will be inferred:

```yaml
models:
  Conference:
    name: string
    relationships:
      belongsTo: Venue, Region
```

As a bonus, if you were to write the original draft file, Blueprint will assume the `venue_id` is meant to be a data type of `id`.

---
As a development note to myself and future contributors, these types of adjustments should be done in the _lexer_. Doing these kinds of things higher up avoid having to do it in several of the underlying _generators_.