### PR TITLE
Use `foreignId` for consistency

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -165,12 +165,7 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
             if ($column->name() === 'id' && $dataType === 'id') {
                 $dataType = 'bigIncrements';
             } elseif ($dataType === 'id') {
-                if ($model->isPivot()) {
-                    // TODO: what if constraints are enabled?
-                    $dataType = 'foreignId';
-                } else {
-                    $dataType = 'unsignedBigInteger';
-                }
+                $dataType = 'foreignId';
             }
 
             if (in_array($dataType, self::UNSIGNABLE_TYPES) && in_array('unsigned', $column->modifiers())) {

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -681,7 +681,7 @@ final class ModelLexerTest extends TestCase
         $this->assertEquals([], $columns['id']->modifiers());
         $this->assertEquals('venue_id', $columns['venue_id']->name());
         $this->assertEquals('id', $columns['venue_id']->dataType());
-        $this->assertEquals(['unsigned'], $columns['venue_id']->modifiers());
+        $this->assertEquals([], $columns['venue_id']->modifiers());
         $this->assertEquals(['Venue'], $columns['venue_id']->attributes());
         $this->assertEquals('region_id', $columns['region_id']->name());
         $this->assertEquals('id', $columns['region_id']->dataType());

--- a/tests/fixtures/migrations/belongs-to-many.php
+++ b/tests/fixtures/migrations/belongs-to-many.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('journeys', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->unsignedBigInteger('user_id');
+            $table->foreignId('user_id');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/identity-columns-big-increments.php
+++ b/tests/fixtures/migrations/identity-columns-big-increments.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('relationships', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('post_id');
-            $table->unsignedBigInteger('another');
+            $table->foreignId('post_id');
+            $table->foreignId('another');
         });
     }
 

--- a/tests/fixtures/migrations/identity-columns.php
+++ b/tests/fixtures/migrations/identity-columns.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('relationships', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('post_id');
-            $table->unsignedBigInteger('another');
+            $table->foreignId('post_id');
+            $table->foreignId('another');
         });
     }
 

--- a/tests/fixtures/migrations/indexes.php
+++ b/tests/fixtures/migrations/indexes.php
@@ -14,8 +14,8 @@ return new class extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->unsignedInteger('id');
             $table->string('title');
-            $table->unsignedBigInteger('parent_post_id');
-            $table->unsignedBigInteger('author_id');
+            $table->foreignId('parent_post_id');
+            $table->foreignId('author_id');
             $table->timestamp('published_at')->nullable();
             $table->unsignedInteger('word_count');
             $table->geometry('location');

--- a/tests/fixtures/migrations/infer-belongsto.php
+++ b/tests/fixtures/migrations/infer-belongsto.php
@@ -14,8 +14,8 @@ return new class extends Migration
         Schema::create('conferences', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->unsignedBigInteger('venue_id');
-            $table->unsignedBigInteger('region_id');
+            $table->foreignId('venue_id');
+            $table->foreignId('region_id');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/models-with-custom-namespace.php
+++ b/tests/fixtures/migrations/models-with-custom-namespace.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('name', 30);
             $table->string('image');
-            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->foreignId('parent_id')->nullable();
             $table->boolean('active')->default(true);
             $table->timestamps();
             $table->softDeletes();

--- a/tests/fixtures/migrations/readme-example.php
+++ b/tests/fixtures/migrations/readme-example.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->string('title', 400);
             $table->longText('content');
             $table->timestamp('published_at')->nullable();
-            $table->unsignedBigInteger('author_id');
+            $table->foreignId('author_id');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/relationships.php
+++ b/tests/fixtures/migrations/relationships.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('post_id');
-            $table->unsignedBigInteger('author_id');
+            $table->foreignId('post_id');
+            $table->foreignId('author_id');
             $table->timestamps();
         });
     }

--- a/tests/fixtures/migrations/soft-deletes.php
+++ b/tests/fixtures/migrations/soft-deletes.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('post_id');
+            $table->foreignId('post_id');
             $table->timestamps();
             $table->softDeletes();
         });

--- a/tests/fixtures/migrations/unconventional.php
+++ b/tests/fixtures/migrations/unconventional.php
@@ -14,8 +14,8 @@ return new class extends Migration
         Schema::create('teams', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->unsignedBigInteger('owner');
-            $table->unsignedBigInteger('manager');
+            $table->foreignId('owner');
+            $table->foreignId('manager');
             $table->json('options');
             $table->timestamps();
         });


### PR DESCRIPTION
It seems recent code uses `foreignId` when setting the column data type for many and polymorphic relationship foreign keys. However, the standard `belongsTo` relationship still uses `unsignedBigInteger` as the data type. For consistency within Blueprint and to align with whatever data type Laravel uses for "id" columns `foreignId` is now used.

Given the following draft file:

```yaml
models:
    Post:
        author_id: id
```

**Before:**
```php
Schema::create('posts', function (Blueprint $table) {
    $table->unsignedBigInteger('author_id');
}
```

**After:**
```php
Schema::create('posts', function (Blueprint $table) {
    $table->foreignId('author_id');
}
```

