### PR TITLE
Plural routes by default

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -106,15 +106,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Pluralize route names
+    | Singular route names
     |--------------------------------------------------------------------------
     |
     | By default, Blueprint will use the `kebab-case` of the controller name
-    | for the route name. If you would like to ensure a plural route name
+    | for the route name. If you would like to ensure a singular route name
     | is used, you may set this to `true`.
     |
     */
-    'plural_routes' => null,
+    'singular_routes' => null,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -320,9 +320,9 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
      * pivot table segment, it defaults to appending `$table->foreignId(\'' . $foreignKeyColumnName . '\');`
      * to the `$definition` string. The function then returns the `$definition` string.
      *
-     * @param  string  $pivotTableSegment The segment of the pivot table. e.g 'dive_job' it would be 'Dive' or 'Job'.
-     * @param  string  $foreignKeyColumnName The name of the foreign key column. e.g 'dive_id' or 'job_id'.
-     * @param  array  $models An array of models. e.g ['Dive' => $diveModel, 'Job' => $jobModel].
+     * @param  string  $pivotTableSegment  The segment of the pivot table. e.g 'dive_job' it would be 'Dive' or 'Job'.
+     * @param  string  $foreignKeyColumnName  The name of the foreign key column. e.g 'dive_id' or 'job_id'.
+     * @param  array  $models  An array of models. e.g ['Dive' => $diveModel, 'Job' => $jobModel].
      * @return string The foreign key definition. e.g '$table->foreignUlid('dive_id');'
      */
     protected function generateForeignKeyDefinition(string $pivotTableSegment, string $foreignKeyColumnName, array $models = []): string

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -43,7 +43,7 @@ class RouteGenerator extends AbstractClassGenerator implements Generator
         $routes = '';
         $methods = array_keys($controller->methods());
         $className = $this->getClassName($controller);
-        $slug = config('blueprint.plural_routes') ? Str::plural(Str::kebab($controller->prefix())) : Str::kebab($controller->prefix());
+        $slug = config('blueprint.singular_routes') ? Str::kebab($controller->prefix()) : Str::plural(Str::kebab($controller->prefix()));
 
         foreach (array_diff($methods, Controller::$resourceMethods) as $method) {
             $routes .= $this->buildRouteLine($className, $slug, $method);

--- a/tests/Feature/Generators/RouteGeneratorTest.php
+++ b/tests/Feature/Generators/RouteGeneratorTest.php
@@ -68,12 +68,12 @@ final class RouteGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function output_generates_routes_with_plural_slug(): void
+    public function output_generates_routes_with_singular_slug(): void
     {
-        $this->app['config']->set('blueprint.plural_routes', true);
+        $this->app['config']->set('blueprint.singular_routes', true);
 
         $this->filesystem->expects('append')
-            ->with('routes/web.php', $this->fixture('routes/readme-example-plural.php'));
+            ->with('routes/web.php', $this->fixture('routes/readme-example-singular.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/readme-example.yaml'));
         $tree = $this->blueprint->analyze($tokens);
@@ -82,12 +82,12 @@ final class RouteGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function output_generates_api_routes_with_plural_slug(): void
+    public function output_generates_api_routes_with_singular_slug(): void
     {
-        $this->app['config']->set('blueprint.plural_routes', true);
+        $this->app['config']->set('blueprint.singular_routes', true);
 
         $this->filesystem->expects('append')
-            ->with('routes/api.php', $this->fixture('routes/api-routes-plural.php'));
+            ->with('routes/api.php', $this->fixture('routes/api-routes-singular.php'));
 
         $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
         $tree = $this->blueprint->analyze($tokens);

--- a/tests/fixtures/routes/api-routes-plural.php
+++ b/tests/fixtures/routes/api-routes-plural.php
@@ -1,3 +1,0 @@
-
-
-Route::apiResource('certificates', App\Http\Controllers\Api\CertificateController::class);

--- a/tests/fixtures/routes/api-routes-singular.php
+++ b/tests/fixtures/routes/api-routes-singular.php
@@ -1,0 +1,3 @@
+
+
+Route::apiResource('certificate', App\Http\Controllers\Api\CertificateController::class);

--- a/tests/fixtures/routes/api-routes.php
+++ b/tests/fixtures/routes/api-routes.php
@@ -1,3 +1,3 @@
 
 
-Route::apiResource('certificate', App\Http\Controllers\Api\CertificateController::class);
+Route::apiResource('certificates', App\Http\Controllers\Api\CertificateController::class);

--- a/tests/fixtures/routes/cruddy.php
+++ b/tests/fixtures/routes/cruddy.php
@@ -1,5 +1,5 @@
 
 
-Route::resource('crud', App\Http\Controllers\CrudController::class);
+Route::resource('cruds', App\Http\Controllers\CrudController::class);
 
 Route::resource('users', App\Http\Controllers\UsersController::class)->except('create', 'store');

--- a/tests/fixtures/routes/invokable-controller.php
+++ b/tests/fixtures/routes/invokable-controller.php
@@ -1,3 +1,3 @@
 
 
-Route::get('report', App\Http\Controllers\ReportController::class);
+Route::get('reports', App\Http\Controllers\ReportController::class);

--- a/tests/fixtures/routes/multiple-resource-controllers-api.php
+++ b/tests/fixtures/routes/multiple-resource-controllers-api.php
@@ -1,5 +1,5 @@
 
 
-Route::apiResource('file', App\Http\Controllers\FileController::class)->except('index', 'destroy');
+Route::apiResource('files', App\Http\Controllers\FileController::class)->except('index', 'destroy');
 
-Route::apiResource('gallery', App\Http\Controllers\GalleryController::class);
+Route::apiResource('galleries', App\Http\Controllers\GalleryController::class);

--- a/tests/fixtures/routes/multiple-resource-controllers-web.php
+++ b/tests/fixtures/routes/multiple-resource-controllers-web.php
@@ -1,5 +1,5 @@
 
 
-Route::resource('page', App\Http\Controllers\PageController::class);
+Route::resource('pages', App\Http\Controllers\PageController::class);
 
-Route::resource('category', App\Http\Controllers\CategoryController::class)->only('index', 'destroy');
+Route::resource('categories', App\Http\Controllers\CategoryController::class)->only('index', 'destroy');

--- a/tests/fixtures/routes/non-cruddy.php
+++ b/tests/fixtures/routes/non-cruddy.php
@@ -1,9 +1,9 @@
 
 
-Route::get('some/whatever', [App\Http\Controllers\SomeController::class, 'whatever']);
-Route::get('some/slug-name', [App\Http\Controllers\SomeController::class, 'slugName']);
-Route::resource('some', App\Http\Controllers\SomeController::class)->only('index', 'show');
+Route::get('somes/whatever', [App\Http\Controllers\SomeController::class, 'whatever']);
+Route::get('somes/slug-name', [App\Http\Controllers\SomeController::class, 'slugName']);
+Route::resource('somes', App\Http\Controllers\SomeController::class)->only('index', 'show');
 
 Route::get('subscriptions/resume', [App\Http\Controllers\SubscriptionsController::class, 'resume']);
 
-Route::get('report', App\Http\Controllers\ReportController::class);
+Route::get('reports', App\Http\Controllers\ReportController::class);

--- a/tests/fixtures/routes/readme-example-plural.php
+++ b/tests/fixtures/routes/readme-example-plural.php
@@ -1,3 +1,0 @@
-
-
-Route::resource('posts', App\Http\Controllers\PostController::class)->only('index', 'store');

--- a/tests/fixtures/routes/readme-example-singular.php
+++ b/tests/fixtures/routes/readme-example-singular.php
@@ -1,0 +1,3 @@
+
+
+Route::resource('post', App\Http\Controllers\PostController::class)->only('index', 'store');

--- a/tests/fixtures/routes/readme-example.php
+++ b/tests/fixtures/routes/readme-example.php
@@ -1,3 +1,3 @@
 
 
-Route::resource('post', App\Http\Controllers\PostController::class)->only('index', 'store');
+Route::resource('posts', App\Http\Controllers\PostController::class)->only('index', 'store');

--- a/tests/fixtures/routes/respond-statements.php
+++ b/tests/fixtures/routes/respond-statements.php
@@ -1,4 +1,4 @@
 
 
-Route::get('post/error', [App\Http\Controllers\Api\PostController::class, 'error']);
-Route::resource('post', App\Http\Controllers\Api\PostController::class)->only('index', 'store');
+Route::get('posts/error', [App\Http\Controllers\Api\PostController::class, 'error']);
+Route::resource('posts', App\Http\Controllers\Api\PostController::class)->only('index', 'store');

--- a/tests/fixtures/routes/routes-mixed.php
+++ b/tests/fixtures/routes/routes-mixed.php
@@ -1,7 +1,7 @@
 
 
-Route::resource('foo', App\Http\Controllers\FooController::class);
+Route::resource('foos', App\Http\Controllers\FooController::class);
 
-Route::get('some/whatever', [App\Http\Controllers\SomeController::class, 'whatever']);
+Route::get('somes/whatever', [App\Http\Controllers\SomeController::class, 'whatever']);
 
-Route::get('report', App\Http\Controllers\ReportController::class);
+Route::get('reports', App\Http\Controllers\ReportController::class);


### PR DESCRIPTION
This uses the plural of a modal for resource controllers by default to match the examples in the Laravel docs as discussed in #662 . Singular still remains possible via a config setting.

I checked the docs and could not find any references to the singular ones, so no need for changes there as far as I could see.
