### PR TITLE
Protected methods for generators

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -203,7 +203,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
         return trim($methods);
     }
 
-    private function determineModel(Controller $controller, ?string $reference): string
+    protected function determineModel(Controller $controller, ?string $reference): string
     {
         if (empty($reference) || $reference === 'id') {
             return $this->fullyQualifyModelReference($controller->namespace(), Str::studly(Str::singular($controller->prefix())));
@@ -216,7 +216,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
         return $this->fullyQualifyModelReference($controller->namespace(), Str::studly($reference));
     }
 
-    private function fullyQualifyModelReference(string $sub_namespace, string $model_name): string
+    protected function fullyQualifyModelReference(string $sub_namespace, string $model_name): string
     {
         // TODO: get model_name from tree.
         // If not found, assume parallel namespace as controller.

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -190,7 +190,7 @@ class FactoryGenerator extends AbstractClassGenerator implements Generator
         return trim($definition);
     }
 
-    private function fillableColumns(array $columns): array
+    protected function fillableColumns(array $columns): array
     {
         if (config('blueprint.fake_nullables')) {
             return $columns;
@@ -207,7 +207,7 @@ class FactoryGenerator extends AbstractClassGenerator implements Generator
         );
     }
 
-    private function fullyQualifyModelReference(string $model_name)
+    protected function fullyQualifyModelReference(string $model_name)
     {
         return $this->tree->modelForContext($model_name);
     }

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -492,7 +492,7 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
         return Str::plural(Str::lower(Str::singular($parentTable) . 'able'));
     }
 
-    private function shouldAddForeignKeyConstraint(\Blueprint\Models\Column $column): bool
+    protected function shouldAddForeignKeyConstraint(\Blueprint\Models\Column $column): bool
     {
         if ($column->name() === 'id') {
             return false;

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -32,7 +32,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         return $this->output;
     }
 
-    private function pivotColumns(array $columns, array $relationships): array
+    protected function pivotColumns(array $columns, array $relationships): array
     {
         // TODO: ideally restrict to only "belongsTo" columns used for pivot relationship
         return collect($columns)
@@ -303,7 +303,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         return Str::replaceFirst('use HasFactory', 'use ' . implode(', ', $traits), $stub);
     }
 
-    private function fillableColumns(array $columns): array
+    protected function fillableColumns(array $columns): array
     {
         return array_diff(
             array_keys($columns),
@@ -319,7 +319,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         );
     }
 
-    private function hiddenColumns(array $columns): array
+    protected function hiddenColumns(array $columns): array
     {
         return array_intersect(
             array_keys($columns),
@@ -330,7 +330,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         );
     }
 
-    private function castableColumns(array $columns): array
+    protected function castableColumns(array $columns): array
     {
         return array_filter(
             array_map(
@@ -340,7 +340,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         );
     }
 
-    private function dateColumns(array $columns)
+    protected function dateColumns(array $columns)
     {
         return array_map(
             fn (Column $column) => $column->name(),
@@ -353,7 +353,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         );
     }
 
-    private function castForColumn(Column $column): ?string
+    protected function castForColumn(Column $column): ?string
     {
         if ($column->dataType() === 'date') {
             return 'date';
@@ -390,7 +390,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         return null;
     }
 
-    private function pretty_print_array(array $data, bool $assoc = true): string
+    protected function pretty_print_array(array $data, bool $assoc = true): string
     {
         $output = var_export($data, true);
         $output = preg_replace('/^\s+/m', '        ', $output);
@@ -403,7 +403,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         return trim(str_replace("\n", PHP_EOL, $output));
     }
 
-    private function phpDataType(string $dataType): string
+    protected function phpDataType(string $dataType): string
     {
         static $php_data_types = [
             'id' => 'int',
@@ -446,7 +446,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
         return $php_data_types[strtolower($dataType)] ?? 'string';
     }
 
-    private function fullyQualifyModelReference(string $model_name): ?string
+    protected function fullyQualifyModelReference(string $model_name): ?string
     {
         // TODO: get model_name from tree.
         // If not found, assume parallel namespace as controller.

--- a/src/Generators/PestTestGenerator.php
+++ b/src/Generators/PestTestGenerator.php
@@ -505,7 +505,7 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
         return trim($this->buildTraits($controller) . PHP_EOL . $test_cases);
     }
 
-    private function testCaseStub()
+    protected function testCaseStub()
     {
         if (empty($this->stubs['test-case'])) {
             $this->stubs['test-case'] = $this->filesystem->stub('pest.test.case.stub');
@@ -514,7 +514,7 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
         return $this->stubs['test-case'];
     }
 
-    private function determineModel(string $prefix, ?string $reference): string
+    protected function determineModel(string $prefix, ?string $reference): string
     {
         if (empty($reference) || $reference === 'id') {
             return Str::studly(Str::singular($prefix));
@@ -527,7 +527,7 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
         return Str::studly($reference);
     }
 
-    private function buildFormRequestName(Controller $controller, string $name): string
+    protected function buildFormRequestName(Controller $controller, string $name): string
     {
         if (empty($controller->namespace())) {
             return $controller->name() . Str::studly($name) . 'Request';
@@ -536,7 +536,7 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
         return $controller->namespace() . '\\' . $controller->name() . Str::studly($name) . 'Request';
     }
 
-    private function buildFormRequestTestCase(string $controller, string $action, string $form_request): string
+    protected function buildFormRequestTestCase(string $controller, string $action, string $form_request): string
     {
         return <<<END
 test('{$action} uses form request validation')
@@ -548,7 +548,7 @@ test('{$action} uses form request validation')
 END;
     }
 
-    private function httpMethodForAction(string $action): string
+    protected function httpMethodForAction(string $action): string
     {
         return match ($action) {
             'store' => 'post',
@@ -558,7 +558,7 @@ END;
         };
     }
 
-    private function buildTestCaseName(string $name, int $tested_bits): string
+    protected function buildTestCaseName(string $name, int $tested_bits): string
     {
         $verifications = [];
 
@@ -595,12 +595,12 @@ END;
         return $name . '_' . implode('_', $verifications) . '_and_' . $final_verification;
     }
 
-    private function buildLines($lines): string
+    protected function buildLines($lines): string
     {
         return str_pad(' ', 4) . implode(PHP_EOL . str_pad(' ', 4), $lines);
     }
 
-    private function splitField($field): array
+    protected function splitField($field): array
     {
         if (Str::contains($field, '.')) {
             return explode('.', $field, 2);
@@ -609,14 +609,14 @@ END;
         return [null, $field];
     }
 
-    private function uniqueSetupLines(array $setup)
+    protected function uniqueSetupLines(array $setup)
     {
         return collect($setup)->filter()
             ->map(fn ($lines) => array_unique($lines))
             ->toArray();
     }
 
-    private function generateReferenceFactory(Column $local_column, Controller $controller, string $modelNamespace): ?array
+    protected function generateReferenceFactory(Column $local_column, Controller $controller, string $modelNamespace): ?array
     {
         if (!in_array($local_column->dataType(), ['id', 'uuid']) && !($local_column->attributes() && Str::endsWith($local_column->name(), '_id'))) {
             return null;

--- a/src/Generators/PhpUnitTestGenerator.php
+++ b/src/Generators/PhpUnitTestGenerator.php
@@ -497,7 +497,7 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
         return trim($this->buildTraits($controller) . PHP_EOL . $test_cases);
     }
 
-    private function testCaseStub()
+    protected function testCaseStub()
     {
         if (empty($this->stubs['test-case'])) {
             $this->stubs['test-case'] = $this->filesystem->stub('phpunit.test.case.stub');
@@ -506,7 +506,7 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
         return $this->stubs['test-case'];
     }
 
-    private function determineModel(string $prefix, ?string $reference): string
+    protected function determineModel(string $prefix, ?string $reference): string
     {
         if (empty($reference) || $reference === 'id') {
             return Str::studly(Str::singular($prefix));
@@ -519,7 +519,7 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
         return Str::studly($reference);
     }
 
-    private function buildFormRequestName(Controller $controller, string $name): string
+    protected function buildFormRequestName(Controller $controller, string $name): string
     {
         if (empty($controller->namespace())) {
             return $controller->name() . Str::studly($name) . 'Request';
@@ -528,7 +528,7 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
         return $controller->namespace() . '\\' . $controller->name() . Str::studly($name) . 'Request';
     }
 
-    private function buildFormRequestTestCase(string $controller, string $action, string $form_request): string
+    protected function buildFormRequestTestCase(string $controller, string $action, string $form_request): string
     {
         return <<<END
     #[Test]
@@ -543,25 +543,25 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
 END;
     }
 
-    private function addFakerTrait(Controller $controller): void
+    protected function addFakerTrait(Controller $controller): void
     {
         $this->addImport($controller, 'Illuminate\\Foundation\\Testing\\WithFaker');
         $this->addTrait($controller, 'WithFaker');
     }
 
-    private function addTestAssertionsTrait(Controller $controller): void
+    protected function addTestAssertionsTrait(Controller $controller): void
     {
         $this->addImport($controller, 'JMac\\Testing\\Traits\AdditionalAssertions');
         $this->addTrait($controller, 'AdditionalAssertions');
     }
 
-    private function addRefreshDatabaseTrait(Controller $controller): void
+    protected function addRefreshDatabaseTrait(Controller $controller): void
     {
         $this->addImport($controller, 'Illuminate\\Foundation\\Testing\\RefreshDatabase');
         $this->addTrait($controller, 'RefreshDatabase');
     }
 
-    private function httpMethodForAction(string $action): string
+    protected function httpMethodForAction(string $action): string
     {
         return match ($action) {
             'store' => 'post',
@@ -571,7 +571,7 @@ END;
         };
     }
 
-    private function buildTestCaseName(string $name, int $tested_bits): string
+    protected function buildTestCaseName(string $name, int $tested_bits): string
     {
         $verifications = [];
 
@@ -608,12 +608,12 @@ END;
         return $name . '_' . implode('_', $verifications) . '_and_' . $final_verification;
     }
 
-    private function buildLines($lines): string
+    protected function buildLines($lines): string
     {
         return str_pad(' ', 8) . implode(PHP_EOL . str_pad(' ', 8), $lines);
     }
 
-    private function splitField($field): array
+    protected function splitField($field): array
     {
         if (Str::contains($field, '.')) {
             return explode('.', $field, 2);
@@ -622,14 +622,14 @@ END;
         return [null, $field];
     }
 
-    private function uniqueSetupLines(array $setup)
+    protected function uniqueSetupLines(array $setup)
     {
         return collect($setup)->filter()
             ->map(fn ($lines) => array_unique($lines))
             ->toArray();
     }
 
-    private function generateReferenceFactory(Column $local_column, Controller $controller, string $modelNamespace): ?array
+    protected function generateReferenceFactory(Column $local_column, Controller $controller, string $modelNamespace): ?array
     {
         if (!in_array($local_column->dataType(), ['id', 'uuid']) && !($local_column->attributes() && Str::endsWith($local_column->name(), '_id'))) {
             return null;

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -90,12 +90,12 @@ class FormRequestGenerator extends AbstractClassGenerator implements Generator
         );
     }
 
-    private function getName(string $context, string $method): string
+    protected function getName(string $context, string $method): string
     {
         return $context . Str::studly($method) . 'Request';
     }
 
-    private function splitField($field): array
+    protected function splitField($field): array
     {
         if (Str::contains($field, '.')) {
             return explode('.', $field, 2);
@@ -104,7 +104,7 @@ class FormRequestGenerator extends AbstractClassGenerator implements Generator
         return [null, $field];
     }
 
-    private function validationRules(string $qualifier, string $column): array
+    protected function validationRules(string $qualifier, string $column): array
     {
         /**
          * @var \Blueprint\Models\Model $model

--- a/src/Generators/Statements/MailGenerator.php
+++ b/src/Generators/Statements/MailGenerator.php
@@ -50,12 +50,12 @@ class MailGenerator extends StatementGenerator
         return $this->output;
     }
 
-    private function populateViewStub(string $stub, SendStatement $statement): string
+    protected function populateViewStub(string $stub, SendStatement $statement): string
     {
         return str_replace('{{ class }}', $statement->mail(), $stub);
     }
 
-    private function getViewPath($view): string
+    protected function getViewPath($view): string
     {
         return 'resources/views/' . str_replace('.', '/', $view) . '.blade.php';
     }

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -120,7 +120,7 @@ class ResourceGenerator extends StatementGenerator implements Generator
         return implode(PHP_EOL, $data);
     }
 
-    private function visibleColumns(Model $model): array
+    protected function visibleColumns(Model $model): array
     {
         return array_diff(
             array_keys($model->columns()),


### PR DESCRIPTION
This PR changes the visibility of generator methods to at least protected to allow for easier customisation.
Based on the request in [this issue](https://github.com/laravel-shift/blueprint/issues/658).