### PR TITLE
Parse fake dates into Carbon objects

### DIFF
--- a/src/Generators/PhpUnitTestGenerator.php
+++ b/src/Generators/PhpUnitTestGenerator.php
@@ -97,6 +97,7 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                 'mock' => [],
             ];
             $request_data = [];
+            $model_columns = [];
             $tested_bits = 0;
 
             $model = $controller->prefix();
@@ -227,11 +228,17 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                                 if ($factory) {
                                     [$faker, $variable_name] = $factory;
                                 } else {
-                                    $faker = sprintf('$%s = $this->faker->%s;', $data, FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_model->column($column)->dataType()));
+                                    if ($local_column->isDate()) {
+                                        $this->addImport($controller, 'Illuminate\\Support\\Carbon');
+                                        $faker = sprintf('$%s = Carbon::parse($this->faker->%s);', $data, FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_model->column($column)->dataType()));
+                                    } else {
+                                        $faker = sprintf('$%s = $this->faker->%s;', $data, FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_model->column($column)->dataType()));
+                                    }
                                 }
 
                                 $setup['data'][] = $faker;
                                 $request_data[$data] = '$' . $variable_name;
+                                $model_columns[$data] = '$' . $variable_name;
                             } elseif (!is_null($local_model)) {
                                 foreach ($local_model->columns() as $local_column) {
                                     if (in_array($local_column->name(), ['id', 'softdeletes', 'softdeletestz'])) {
@@ -246,12 +253,27 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                                     if ($factory) {
                                         [$faker, $variable_name] = $factory;
                                     } else {
-                                        $faker = sprintf('$%s = $this->faker->%s;', $local_column->name(), FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_column->dataType()));
+                                        if ($local_column->isDate()) {
+                                            $this->addImport($controller, 'Illuminate\\Support\\Carbon');
+                                            $faker = sprintf('$%s = Carbon::parse($this->faker->%s);', $local_column->name(), FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_column->dataType()));
+                                        } else {
+                                            $faker = sprintf('$%s = $this->faker->%s;', $local_column->name(), FakerRegistry::fakerData($local_column->name()) ?? FakerRegistry::fakerDataType($local_column->dataType()));
+                                        }
                                         $variable_name = $local_column->name();
                                     }
 
                                     $setup['data'][] = $faker;
-                                    $request_data[$local_column->name()] = '$' . $variable_name;
+                                    if ($local_column->isDate()) {
+                                        if ($local_column->dataType() === 'date') {
+                                            $request_data[$local_column->name()] = '$' . $variable_name . '->toDateString()';
+                                        } else {
+                                            $request_data[$local_column->name()] = '$' . $variable_name . '->toDateTimeString()';
+                                        }
+                                    } else {
+                                        $request_data[$local_column->name()] = '$' . $variable_name;
+                                    }
+
+                                    $model_columns[$local_column->name()] = '$' . $variable_name;
                                 }
                             }
                         }
@@ -404,11 +426,11 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                     if ($statement->operation() === 'save') {
                         $tested_bits |= self::TESTS_SAVE;
 
-                        if ($request_data) {
+                        if ($model_columns) {
                             $indent = str_pad(' ', 12);
                             $plural = Str::plural($variable);
                             $assertion = sprintf('$%s = %s::query()', $plural, $model);
-                            foreach ($request_data as $key => $datum) {
+                            foreach ($model_columns as $key => $datum) {
                                 $assertion .= PHP_EOL . sprintf('%s->where(\'%s\', %s)', $indent, $key, $datum);
                             }
                             $assertion .= PHP_EOL . $indent . '->get();';
@@ -435,13 +457,12 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                     } elseif ($statement->operation() === 'update') {
                         $assertions['sanity'][] = sprintf('$%s->refresh();', $variable);
 
-                        if ($request_data) {
+                        if ($model_columns) {
                             /** @var \Blueprint\Models\Model $local_model */
                             $local_model = $this->tree->modelForContext($model);
-                            foreach ($request_data as $key => $datum) {
-                                if (!is_null($local_model) && $local_model->hasColumn($key) && $local_model->column($key)->dataType() === 'date') {
-                                    $this->addImport($controller, 'Carbon\\Carbon');
-                                    $assertions['generic'][] = sprintf('$this->assertEquals(Carbon::parse(%s), $%s->%s);', $datum, $variable, $key);
+                            foreach ($model_columns as $key => $datum) {
+                                if (!is_null($local_model) && $local_model->hasColumn($key) && $local_model->column($key)->dataType() === 'timestamp') {
+                                    $assertions['generic'][] = sprintf('$this->assertEquals(%s->timestamp, $%s->%s);', $datum, $variable, $key);
                                 } else {
                                     $assertions['generic'][] = sprintf('$this->assertEquals(%s, $%s->%s);', $datum, $variable, $key);
                                 }

--- a/src/Models/Column.php
+++ b/src/Models/Column.php
@@ -42,6 +42,15 @@ class Column
         return $this->modifiers;
     }
 
+    public function isDate()
+    {
+        return in_array(strtolower($this->dataType()), [
+            'date',
+            'datetime',
+            'timestamp',
+        ]);
+    }
+
     public function isForeignKey()
     {
         return collect($this->modifiers())->filter(fn ($modifier) => (is_array($modifier) && key($modifier) === 'foreign') || $modifier === 'foreign')->flatten()->first();

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -76,6 +76,9 @@ class Model implements BlueprintModel
         $this->columns[$column->name()] = $column;
     }
 
+    /**
+     * @return Column[]
+     */
     public function columns(): array
     {
         return $this->columns;

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -176,7 +176,7 @@ class Model implements BlueprintModel
         return isset($this->columns[$name]);
     }
 
-    public function column(string $name)
+    public function column(string $name): Column
     {
         return $this->columns[$name];
     }

--- a/tests/Feature/Generators/PestTestGeneratorTest.php
+++ b/tests/Feature/Generators/PestTestGeneratorTest.php
@@ -46,7 +46,7 @@ final class PestTestGeneratorTest extends TestCase
 
     #[Test]
     #[DataProvider('controllerTreeDataProvider')]
-    public function output_generates_test_for_controller_tree_l8($definition, $path, $test): void
+    public function output_generates_test_for_controller_tree($definition, $path, $test): void
     {
         $this->filesystem->expects('stub')
             ->with('pest.test.class.stub')
@@ -78,7 +78,7 @@ final class PestTestGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function output_works_for_pascal_case_definition_l8(): void
+    public function output_works_for_pascal_case_definition(): void
     {
         $this->filesystem->expects('stub')
             ->with('pest.test.class.stub')
@@ -112,7 +112,7 @@ final class PestTestGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function output_generates_test_for_controller_tree_using_cached_model_l8(): void
+    public function output_generates_test_for_controller_tree_using_cached_model(): void
     {
         $this->filesystem->expects('stub')
             ->with('pest.test.class.stub')
@@ -145,7 +145,7 @@ final class PestTestGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function output_generates_tests_with_models_with_custom_namespace_correctly_l8(): void
+    public function output_generates_tests_with_models_with_custom_namespace_correctly(): void
     {
         $definition = 'drafts/models-with-custom-namespace.yaml';
         $path = 'tests/Feature/Http/Controllers/CategoryControllerTest.php';
@@ -224,6 +224,7 @@ final class PestTestGeneratorTest extends TestCase
             ['drafts/crud-show-only.yaml', 'tests/Feature/Http/Controllers/PostControllerTest.php', 'tests/pest/crud-show-only.php'],
             ['drafts/model-reference-validate.yaml', 'tests/Feature/Http/Controllers/CertificateControllerTest.php', 'tests/pest/api-shorthand-validation.php'],
             ['drafts/controllers-only-no-context.yaml', 'tests/Feature/Http/Controllers/ReportControllerTest.php', 'tests/pest/controllers-only-no-context.php'],
+            ['drafts/date-formats.yaml', 'tests/Feature/Http/Controllers/DateControllerTest.php', 'tests/pest/date-formats.php'],
             ['drafts/call-to-a-member-function-columns-on-null.yaml', [
                 'tests/Feature/Http/Controllers/SubscriptionControllerTest.php',
                 'tests/Feature/Http/Controllers/TelegramControllerTest.php',

--- a/tests/Feature/Generators/PhpUnitTestGeneratorTest.php
+++ b/tests/Feature/Generators/PhpUnitTestGeneratorTest.php
@@ -46,7 +46,7 @@ final class PhpUnitTestGeneratorTest extends TestCase
 
     #[Test]
     #[DataProvider('controllerTreeDataProvider')]
-    public function output_generates_test_for_controller_tree_l8($definition, $path, $test): void
+    public function output_generates_test_for_controller_tree($definition, $path, $test): void
     {
         $this->filesystem->expects('stub')
             ->with('phpunit.test.class.stub')
@@ -78,7 +78,7 @@ final class PhpUnitTestGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function output_works_for_pascal_case_definition_l8(): void
+    public function output_works_for_pascal_case_definition(): void
     {
         $this->filesystem->expects('stub')
             ->with('phpunit.test.class.stub')
@@ -112,7 +112,7 @@ final class PhpUnitTestGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function output_generates_test_for_controller_tree_using_cached_model_l8(): void
+    public function output_generates_test_for_controller_tree_using_cached_model(): void
     {
         $this->filesystem->expects('stub')
             ->with('phpunit.test.class.stub')
@@ -145,7 +145,7 @@ final class PhpUnitTestGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function output_generates_tests_with_models_with_custom_namespace_correctly_l8(): void
+    public function output_generates_tests_with_models_with_custom_namespace_correctly(): void
     {
         $definition = 'drafts/models-with-custom-namespace.yaml';
         $path = 'tests/Feature/Http/Controllers/CategoryControllerTest.php';

--- a/tests/Feature/Generators/PhpUnitTestGeneratorTest.php
+++ b/tests/Feature/Generators/PhpUnitTestGeneratorTest.php
@@ -224,6 +224,7 @@ final class PhpUnitTestGeneratorTest extends TestCase
             ['drafts/crud-show-only.yaml', 'tests/Feature/Http/Controllers/PostControllerTest.php', 'tests/phpunit/crud-show-only.php'],
             ['drafts/model-reference-validate.yaml', 'tests/Feature/Http/Controllers/CertificateControllerTest.php', 'tests/phpunit/api-shorthand-validation.php'],
             ['drafts/controllers-only-no-context.yaml', 'tests/Feature/Http/Controllers/ReportControllerTest.php', 'tests/phpunit/controllers-only-no-context.php'],
+            ['drafts/date-formats.yaml', 'tests/Feature/Http/Controllers/DateControllerTest.php', 'tests/phpunit/date-formats.php'],
             ['drafts/call-to-a-member-function-columns-on-null.yaml', [
                 'tests/Feature/Http/Controllers/SubscriptionControllerTest.php',
                 'tests/Feature/Http/Controllers/TelegramControllerTest.php',

--- a/tests/fixtures/drafts/date-formats.yaml
+++ b/tests/fixtures/drafts/date-formats.yaml
@@ -1,0 +1,9 @@
+models:
+  Date:
+    born_at: date
+    expires_at: datetime
+    published_at: timestamp
+
+controllers:
+  Date:
+    resource: web

--- a/tests/fixtures/tests/pest/api-shorthand-validation.php
+++ b/tests/fixtures/tests/pest/api-shorthand-validation.php
@@ -4,7 +4,7 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Certificate;
 use App\Models\CertificateType;
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
@@ -34,14 +34,14 @@ test('store saves', function (): void {
     $certificate_type = CertificateType::factory()->create();
     $reference = fake()->word();
     $document = fake()->word();
-    $expiry_date = fake()->date();
+    $expiry_date = Carbon::parse(fake()->date());
 
     $response = post(route('certificate.store'), [
         'name' => $name,
         'certificate_type_id' => $certificate_type->id,
         'reference' => $reference,
         'document' => $document,
-        'expiry_date' => $expiry_date,
+        'expiry_date' => $expiry_date->toDateString(),
     ]);
 
     $certificates = Certificate::query()
@@ -82,14 +82,14 @@ test('update behaves as expected', function (): void {
     $certificate_type = CertificateType::factory()->create();
     $reference = fake()->word();
     $document = fake()->word();
-    $expiry_date = fake()->date();
+    $expiry_date = Carbon::parse(fake()->date());
 
     $response = put(route('certificate.update', $certificate), [
         'name' => $name,
         'certificate_type_id' => $certificate_type->id,
         'reference' => $reference,
         'document' => $document,
-        'expiry_date' => $expiry_date,
+        'expiry_date' => $expiry_date->toDateString(),
     ]);
 
     $certificate->refresh();
@@ -101,7 +101,7 @@ test('update behaves as expected', function (): void {
     expect($certificate_type->id)->toEqual($certificate->certificate_type_id);
     expect($reference)->toEqual($certificate->reference);
     expect($document)->toEqual($certificate->document);
-    expect(Carbon::parse($expiry_date))->toEqual($certificate->expiry_date);
+    expect($expiry_date)->toEqual($certificate->expiry_date);
 });
 
 

--- a/tests/fixtures/tests/pest/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/pest/certificate-pascal-case-example.php
@@ -4,7 +4,7 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Certificate;
 use App\Models\CertificateType;
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
@@ -34,14 +34,14 @@ test('store saves', function (): void {
     $certificate_type = CertificateType::factory()->create();
     $reference = fake()->word();
     $document = fake()->word();
-    $expiry_date = fake()->date();
+    $expiry_date = Carbon::parse(fake()->date());
 
     $response = post(route('certificate.store'), [
         'name' => $name,
         'certificate_type_id' => $certificate_type->id,
         'reference' => $reference,
         'document' => $document,
-        'expiry_date' => $expiry_date,
+        'expiry_date' => $expiry_date->toDateString(),
     ]);
 
     $certificates = Certificate::query()
@@ -82,14 +82,14 @@ test('update behaves as expected', function (): void {
     $certificate_type = CertificateType::factory()->create();
     $reference = fake()->word();
     $document = fake()->word();
-    $expiry_date = fake()->date();
+    $expiry_date = Carbon::parse(fake()->date());
 
     $response = put(route('certificate.update', $certificate), [
         'name' => $name,
         'certificate_type_id' => $certificate_type->id,
         'reference' => $reference,
         'document' => $document,
-        'expiry_date' => $expiry_date,
+        'expiry_date' => $expiry_date->toDateString(),
     ]);
 
     $certificate->refresh();
@@ -101,7 +101,7 @@ test('update behaves as expected', function (): void {
     expect($certificate_type->id)->toEqual($certificate->certificate_type_id);
     expect($reference)->toEqual($certificate->reference);
     expect($document)->toEqual($certificate->document);
-    expect(Carbon::parse($expiry_date))->toEqual($certificate->expiry_date);
+    expect($expiry_date)->toEqual($certificate->expiry_date);
 });
 
 

--- a/tests/fixtures/tests/pest/date-formats.php
+++ b/tests/fixtures/tests/pest/date-formats.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Date;
+use Illuminate\Support\Carbon;
+use function Pest\Faker\fake;
+use function Pest\Laravel\assertModelMissing;
+use function Pest\Laravel\delete;
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\put;
+
+test('index displays view', function (): void {
+    $dates = Date::factory()->count(3)->create();
+
+    $response = get(route('date.index'));
+
+    $response->assertOk();
+    $response->assertViewIs('date.index');
+    $response->assertViewHas('dates');
+});
+
+
+test('create displays view', function (): void {
+    $response = get(route('date.create'));
+
+    $response->assertOk();
+    $response->assertViewIs('date.create');
+});
+
+
+test('store uses form request validation')
+    ->assertActionUsesFormRequest(
+        \App\Http\Controllers\DateController::class,
+        'store',
+        \App\Http\Requests\DateStoreRequest::class
+    );
+
+test('store saves and redirects', function (): void {
+    $born_at = Carbon::parse(fake()->date());
+    $expires_at = Carbon::parse(fake()->dateTime());
+    $published_at = Carbon::parse(fake()->dateTime());
+
+    $response = post(route('date.store'), [
+        'born_at' => $born_at->toDateString(),
+        'expires_at' => $expires_at->toDateTimeString(),
+        'published_at' => $published_at->toDateTimeString(),
+    ]);
+
+    $dates = Date::query()
+        ->where('born_at', $born_at)
+        ->where('expires_at', $expires_at)
+        ->where('published_at', $published_at)
+        ->get();
+    expect($dates)->toHaveCount(1);
+    $date = $dates->first();
+
+    $response->assertRedirect(route('date.index'));
+    $response->assertSessionHas('date.id', $date->id);
+});
+
+
+test('show displays view', function (): void {
+    $date = Date::factory()->create();
+
+    $response = get(route('date.show', $date));
+
+    $response->assertOk();
+    $response->assertViewIs('date.show');
+    $response->assertViewHas('date');
+});
+
+
+test('edit displays view', function (): void {
+    $date = Date::factory()->create();
+
+    $response = get(route('date.edit', $date));
+
+    $response->assertOk();
+    $response->assertViewIs('date.edit');
+    $response->assertViewHas('date');
+});
+
+
+test('update uses form request validation')
+    ->assertActionUsesFormRequest(
+        \App\Http\Controllers\DateController::class,
+        'update',
+        \App\Http\Requests\DateUpdateRequest::class
+    );
+
+test('update redirects', function (): void {
+    $date = Date::factory()->create();
+    $born_at = Carbon::parse(fake()->date());
+    $expires_at = Carbon::parse(fake()->dateTime());
+    $published_at = Carbon::parse(fake()->dateTime());
+
+    $response = put(route('date.update', $date), [
+        'born_at' => $born_at->toDateString(),
+        'expires_at' => $expires_at->toDateTimeString(),
+        'published_at' => $published_at->toDateTimeString(),
+    ]);
+
+    $date->refresh();
+
+    $response->assertRedirect(route('date.index'));
+    $response->assertSessionHas('date.id', $date->id);
+
+    expect($born_at)->toEqual($date->born_at);
+    expect($expires_at)->toEqual($date->expires_at);
+    expect($published_at->timestamp)->toEqual($date->published_at);
+});
+
+
+test('destroy deletes and redirects', function (): void {
+    $date = Date::factory()->create();
+
+    $response = delete(route('date.destroy', $date));
+
+    $response->assertRedirect(route('date.index'));
+
+    assertModelMissing($date);
+});

--- a/tests/fixtures/tests/phpunit/api-shorthand-validation.php
+++ b/tests/fixtures/tests/phpunit/api-shorthand-validation.php
@@ -4,9 +4,9 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Certificate;
 use App\Models\CertificateType;
-use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Carbon;
 use JMac\Testing\Traits\AdditionalAssertions;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -47,14 +47,14 @@ final class CertificateControllerTest extends TestCase
         $certificate_type = CertificateType::factory()->create();
         $reference = $this->faker->word();
         $document = $this->faker->word();
-        $expiry_date = $this->faker->date();
+        $expiry_date = Carbon::parse($this->faker->date());
 
         $response = $this->post(route('certificate.store'), [
             'name' => $name,
             'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
-            'expiry_date' => $expiry_date,
+            'expiry_date' => $expiry_date->toDateString(),
         ]);
 
         $certificates = Certificate::query()
@@ -102,14 +102,14 @@ final class CertificateControllerTest extends TestCase
         $certificate_type = CertificateType::factory()->create();
         $reference = $this->faker->word();
         $document = $this->faker->word();
-        $expiry_date = $this->faker->date();
+        $expiry_date = Carbon::parse($this->faker->date());
 
         $response = $this->put(route('certificate.update', $certificate), [
             'name' => $name,
             'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
-            'expiry_date' => $expiry_date,
+            'expiry_date' => $expiry_date->toDateString(),
         ]);
 
         $certificate->refresh();
@@ -121,7 +121,7 @@ final class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals(Carbon::parse($expiry_date), $certificate->expiry_date);
+        $this->assertEquals($expiry_date, $certificate->expiry_date);
     }
 
 

--- a/tests/fixtures/tests/phpunit/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/phpunit/certificate-pascal-case-example.php
@@ -4,9 +4,9 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Certificate;
 use App\Models\CertificateType;
-use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Carbon;
 use JMac\Testing\Traits\AdditionalAssertions;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -47,14 +47,14 @@ final class CertificateControllerTest extends TestCase
         $certificate_type = CertificateType::factory()->create();
         $reference = $this->faker->word();
         $document = $this->faker->word();
-        $expiry_date = $this->faker->date();
+        $expiry_date = Carbon::parse($this->faker->date());
 
         $response = $this->post(route('certificate.store'), [
             'name' => $name,
             'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
-            'expiry_date' => $expiry_date,
+            'expiry_date' => $expiry_date->toDateString(),
         ]);
 
         $certificates = Certificate::query()
@@ -102,14 +102,14 @@ final class CertificateControllerTest extends TestCase
         $certificate_type = CertificateType::factory()->create();
         $reference = $this->faker->word();
         $document = $this->faker->word();
-        $expiry_date = $this->faker->date();
+        $expiry_date = Carbon::parse($this->faker->date());
 
         $response = $this->put(route('certificate.update', $certificate), [
             'name' => $name,
             'certificate_type_id' => $certificate_type->id,
             'reference' => $reference,
             'document' => $document,
-            'expiry_date' => $expiry_date,
+            'expiry_date' => $expiry_date->toDateString(),
         ]);
 
         $certificate->refresh();
@@ -121,7 +121,7 @@ final class CertificateControllerTest extends TestCase
         $this->assertEquals($certificate_type->id, $certificate->certificate_type_id);
         $this->assertEquals($reference, $certificate->reference);
         $this->assertEquals($document, $certificate->document);
-        $this->assertEquals(Carbon::parse($expiry_date), $certificate->expiry_date);
+        $this->assertEquals($expiry_date, $certificate->expiry_date);
     }
 
 

--- a/tests/fixtures/tests/phpunit/date-formats.php
+++ b/tests/fixtures/tests/phpunit/date-formats.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Date;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Carbon;
+use JMac\Testing\Traits\AdditionalAssertions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\DateController
+ */
+final class DateControllerTest extends TestCase
+{
+    use AdditionalAssertions, RefreshDatabase, WithFaker;
+
+    #[Test]
+    public function index_displays_view(): void
+    {
+        $dates = Date::factory()->count(3)->create();
+
+        $response = $this->get(route('date.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('date.index');
+        $response->assertViewHas('dates');
+    }
+
+
+    #[Test]
+    public function create_displays_view(): void
+    {
+        $response = $this->get(route('date.create'));
+
+        $response->assertOk();
+        $response->assertViewIs('date.create');
+    }
+
+
+    #[Test]
+    public function store_uses_form_request_validation(): void
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\DateController::class,
+            'store',
+            \App\Http\Requests\DateStoreRequest::class
+        );
+    }
+
+    #[Test]
+    public function store_saves_and_redirects(): void
+    {
+        $born_at = Carbon::parse($this->faker->date());
+        $expires_at = Carbon::parse($this->faker->dateTime());
+        $published_at = Carbon::parse($this->faker->dateTime());
+
+        $response = $this->post(route('date.store'), [
+            'born_at' => $born_at->toDateString(),
+            'expires_at' => $expires_at->toDateTimeString(),
+            'published_at' => $published_at->toDateTimeString(),
+        ]);
+
+        $dates = Date::query()
+            ->where('born_at', $born_at)
+            ->where('expires_at', $expires_at)
+            ->where('published_at', $published_at)
+            ->get();
+        $this->assertCount(1, $dates);
+        $date = $dates->first();
+
+        $response->assertRedirect(route('date.index'));
+        $response->assertSessionHas('date.id', $date->id);
+    }
+
+
+    #[Test]
+    public function show_displays_view(): void
+    {
+        $date = Date::factory()->create();
+
+        $response = $this->get(route('date.show', $date));
+
+        $response->assertOk();
+        $response->assertViewIs('date.show');
+        $response->assertViewHas('date');
+    }
+
+
+    #[Test]
+    public function edit_displays_view(): void
+    {
+        $date = Date::factory()->create();
+
+        $response = $this->get(route('date.edit', $date));
+
+        $response->assertOk();
+        $response->assertViewIs('date.edit');
+        $response->assertViewHas('date');
+    }
+
+
+    #[Test]
+    public function update_uses_form_request_validation(): void
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\DateController::class,
+            'update',
+            \App\Http\Requests\DateUpdateRequest::class
+        );
+    }
+
+    #[Test]
+    public function update_redirects(): void
+    {
+        $date = Date::factory()->create();
+        $born_at = Carbon::parse($this->faker->date());
+        $expires_at = Carbon::parse($this->faker->dateTime());
+        $published_at = Carbon::parse($this->faker->dateTime());
+
+        $response = $this->put(route('date.update', $date), [
+            'born_at' => $born_at->toDateString(),
+            'expires_at' => $expires_at->toDateTimeString(),
+            'published_at' => $published_at->toDateTimeString(),
+        ]);
+
+        $date->refresh();
+
+        $response->assertRedirect(route('date.index'));
+        $response->assertSessionHas('date.id', $date->id);
+
+        $this->assertEquals($born_at, $date->born_at);
+        $this->assertEquals($expires_at, $date->expires_at);
+        $this->assertEquals($published_at->timestamp, $date->published_at);
+    }
+
+
+    #[Test]
+    public function destroy_deletes_and_redirects(): void
+    {
+        $date = Date::factory()->create();
+
+        $response = $this->delete(route('date.destroy', $date));
+
+        $response->assertRedirect(route('date.index'));
+
+        $this->assertModelMissing($date);
+    }
+}


### PR DESCRIPTION
Currently, Blueprint uses Faker dates for columns with a _date_ data type. This either generates you a `string` or a `DateTimeInterface` object. Neither of these are readily useable for testing.

This PR parses the returned faker data into an `Illuminate\Support\Carbon` object. This allows it to be used more readily in tests.