### PR TITLE
Ability to set model connection

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -94,6 +94,16 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
             $stub = $this->disableForeignKeyConstraints($stub);
         }
 
+        if ($model->usesCustomDatabaseConnection()) {
+            $property = str_replace(
+                ['{{ name }}', 'by the model.'],
+                [$model->databaseConnection(), 'by the migration.'],
+                $this->filesystem->stub('model.connection.stub')
+            );
+
+            $stub = Str::replaceFirst('{', '{' . PHP_EOL . $property, $stub);
+        }
+
         return $stub;
     }
 

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -171,6 +171,10 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
     {
         $properties = [];
 
+        if ($model->usesCustomDatabaseConnection()) {
+            $properties[] = str_replace('{{ name }}', $model->databaseConnection(), $this->filesystem->stub('model.connection.stub'));
+        }
+
         if ($model->usesCustomTableName() || $model->isPivot()) {
             $properties[] = str_replace('{{ name }}', $model->tableName(), $this->filesystem->stub('model.table.stub'));
         }

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -132,6 +132,10 @@ class ModelLexer implements Lexer
         $model = new Model($name);
 
         if (isset($columns['meta']) && is_array($columns['meta'])) {
+            if (isset($columns['meta']['connection'])) {
+                $model->setDatabaseConnection($columns['meta']['connection']);
+            }
+
             if (isset($columns['meta']['table'])) {
                 $model->setTableName($columns['meta']['table']);
             }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -19,6 +19,8 @@ class Model implements BlueprintModel
 
     private string|bool $softDeletes = false;
 
+    private ?string $connection;
+
     private string $table;
 
     private array $columns = [];
@@ -122,6 +124,21 @@ class Model implements BlueprintModel
     public function setPivot(): void
     {
         $this->pivot = true;
+    }
+
+    public function usesCustomDatabaseConnection(): bool
+    {
+        return isset($this->connection);
+    }
+
+    public function databaseConnection(): ?string
+    {
+        return $this->connection;
+    }
+
+    public function setDatabaseConnection(string $connection)
+    {
+        $this->connection = $connection;
     }
 
     public function usesCustomTableName(): bool

--- a/stubs/model.connection.stub
+++ b/stubs/model.connection.stub
@@ -1,0 +1,6 @@
+    /**
+     * The database connection that should be used by the model.
+     *
+     * @var string
+     */
+    protected $connection = '{{ name }}';

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -54,6 +54,12 @@ final class MigrationGeneratorTest extends TestCase
             ->with('migration.stub')
             ->andReturn($this->stub('migration.stub'));
 
+        if ($definition === 'drafts/model-with-meta.yaml') {
+            $this->filesystem->expects('stub')
+                ->with('model.connection.stub')
+                ->andReturn($this->stub('model.connection.stub'));
+        }
+
         $now = Carbon::now();
         Carbon::setTestNow($now);
 

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -61,6 +61,10 @@ final class ModelGeneratorTest extends TestCase
 
         if ($definition === 'drafts/model-with-meta.yaml') {
             $this->filesystem->expects('stub')
+                ->with('model.connection.stub')
+                ->andReturn($this->stub('model.connection.stub'));
+
+            $this->filesystem->expects('stub')
                 ->with('model.table.stub')
                 ->andReturn($this->stub('model.table.stub'));
         }

--- a/tests/fixtures/drafts/model-with-meta.yaml
+++ b/tests/fixtures/drafts/model-with-meta.yaml
@@ -1,6 +1,7 @@
 models:
   Post:
     meta:
+      connection: read-only
       pivot: true
       table: post
     title: string:400

--- a/tests/fixtures/migrations/model-with-meta.php
+++ b/tests/fixtures/migrations/model-with-meta.php
@@ -7,6 +7,13 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
+     * The database connection that should be used by the migration.
+     *
+     * @var string
+     */
+    protected $connection = 'read-only';
+
+    /**
      * Run the migrations.
      */
     public function up(): void

--- a/tests/fixtures/models/model-with-meta.php
+++ b/tests/fixtures/models/model-with-meta.php
@@ -10,6 +10,13 @@ class Post extends Pivot
     use HasFactory;
 
     /**
+     * The database connection that should be used by the model.
+     *
+     * @var string
+     */
+    protected $connection = 'read-only';
+
+    /**
      * The table associated with the model.
      *
      * @var string


### PR DESCRIPTION
This adds a `connection` option to the `meta` section of a model, which will generate a model and any migration with the `$connection` property set to that value.

For example:

```yaml
models:
  Example:
    meta:
      connection: readonly
    # ...
```

---
Closes #639