### PR TITLE
use decimal precision for model casting

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -295,7 +295,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
 
         if (in_array($column->dataType(), ['decimal', 'unsignedDecimal'])) {
             if ($column->attributes()) {
-                return 'decimal:' . $column->attributes()[1];
+                return 'decimal:' . $column->attributes()[0];
             }
 
             return 'decimal';

--- a/tests/fixtures/models/model-with-ulid-trait.php
+++ b/tests/fixtures/models/model-with-ulid-trait.php
@@ -26,6 +26,6 @@ class User extends Model
      * @var array
      */
     protected $casts = [
-        'base_pay' => 'decimal:2',
+        'base_pay' => 'decimal:10',
     ];
 }

--- a/tests/fixtures/models/model-with-uuid-trait.php
+++ b/tests/fixtures/models/model-with-uuid-trait.php
@@ -26,6 +26,6 @@ class User extends Model
      * @var array
      */
     protected $casts = [
-        'base_pay' => 'decimal:2',
+        'base_pay' => 'decimal:10',
     ];
 }


### PR DESCRIPTION
Hey @jasonmccreary hope to find you well. I maybe missing something obvious here, so forgive me if that's the case. 🙏 

The idea I got from the docs is that the definition for a `decimal` column is `decimal:precision,scale`. https://blueprint.laravelshift.com/docs/model-data-types/

On Laravel Docs for casts, the allowed configuration is `precision` https://laravel.com/docs/11.x/eloquent-mutators#attribute-casting. 

From my understanding the `attributes` array is: `[0 => precision, 1 => scale]`, so I assume we are passing the `scale` to the casts instead of the `precision`.

Let me know what you think. 👍 

Cheers

**Edit:** tests are failing probably due to asserting against the "scale" value and not the "precision" value, if you think this approach is correct I will update the tests accordingly.
