### PR TITLE
Request and Response class name replacement fixed to handle environment differences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 /.phpunit.cache
 composer.lock
+/.idea/

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -126,7 +126,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
                     }
                 } elseif ($statement instanceof ValidateStatement) {
                     $using_validation = true;
-                    $class_name = $controller->name() . Str::studly($name) . 'Request';
+                    $class_name = $controller->prefix() . Str::studly($name) . 'Request';
 
                     $fqcn = config('blueprint.namespace') . '\\Http\\Requests\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $class_name;
 

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -184,7 +184,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
             }
 
             if ($statement instanceof RespondStatement && $statement->content()) {
-                $method = str_replace('): Response' . PHP_EOL, ')' . PHP_EOL, $method);
+                $method = str_replace('): Response', ')', $method);
             } else {
                 $returnType = match (true) {
                     $statement instanceof RenderStatement => 'Illuminate\View\View',
@@ -193,7 +193,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
                     default => 'Illuminate\Http\Response'
                 };
 
-                $method = str_replace('): Response' . PHP_EOL, '): ' . Str::afterLast($returnType, '\\') . PHP_EOL, $method);
+                $method = str_replace('): Response', '): ' . Str::afterLast($returnType, '\\'), $method);
                 $this->addImport($controller, $returnType);
             }
 


### PR DESCRIPTION
**Request class name is now generated correctly.**
**Response class name is now replaced correctly.**

**PHP_EOL** could cause problems in different environments like based on OS and Platform.

**Example:**
Windows terminal with Apache would evaluate PHP_EOL as \r\n at runtime while the stub only has \n causing the str_replace function to fail.

Furthermore tests use \r\n in the files opposit to \n within the stubs causing false negatives.