### PR TITLE
Generate basic Livewire components with Blueprint

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -30,6 +30,8 @@ return [
 
     'controllers_namespace' => 'Http\\Controllers',
 
+    'components_namespace' => 'Livewire',
+
     'policy_namespace' => 'Policies',
 
     /*

--- a/src/BlueprintServiceProvider.php
+++ b/src/BlueprintServiceProvider.php
@@ -48,21 +48,21 @@ class BlueprintServiceProvider extends ServiceProvider implements DeferrableProv
             'blueprint'
         );
 
-        File::mixin(new FileMixins());
+        File::mixin(new FileMixins);
 
         $this->app->bind('command.blueprint.build', fn ($app) => new BuildCommand($app['files'], app(Builder::class)));
         $this->app->bind('command.blueprint.erase', fn ($app) => new EraseCommand($app['files']));
         $this->app->bind('command.blueprint.trace', fn ($app) => new TraceCommand($app['files'], app(Tracer::class)));
         $this->app->bind('command.blueprint.new', fn ($app) => new NewCommand($app['files']));
-        $this->app->bind('command.blueprint.init', fn ($app) => new InitCommand());
-        $this->app->bind('command.blueprint.stubs', fn ($app) => new PublishStubsCommand());
+        $this->app->bind('command.blueprint.init', fn ($app) => new InitCommand);
+        $this->app->bind('command.blueprint.stubs', fn ($app) => new PublishStubsCommand);
 
         $this->app->singleton(Blueprint::class, function ($app) {
-            $blueprint = new Blueprint();
+            $blueprint = new Blueprint;
             $blueprint->registerLexer(new \Blueprint\Lexers\ConfigLexer($app));
-            $blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-            $blueprint->registerLexer(new \Blueprint\Lexers\SeederLexer());
-            $blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new \Blueprint\Lexers\StatementLexer()));
+            $blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+            $blueprint->registerLexer(new \Blueprint\Lexers\SeederLexer);
+            $blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new \Blueprint\Lexers\StatementLexer));
 
             foreach (config('blueprint.generators') as $generator) {
                 $blueprint->registerGenerator(new $generator($app['files']));

--- a/src/Concerns/HasParameters.php
+++ b/src/Concerns/HasParameters.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Blueprint\Concerns;
+
+trait HasParameters
+{
+    protected array $data = [];
+
+    protected array $properties = [];
+
+    public function data(): array
+    {
+        return $this->data;
+    }
+
+    public function properties(): array
+    {
+        return $this->properties;
+    }
+
+    public function withProperties(array $properties): static
+    {
+        $this->properties = $properties;
+
+        return $this;
+    }
+
+    protected function buildParameters(): string
+    {
+        $parameters = array_map(fn ($parameter) => in_array($parameter, $this->properties()) ? '$this->' . $parameter : '$' . $parameter, $this->data());
+
+        return implode(', ', $parameters);
+    }
+}

--- a/src/Generators/ComponentGenerator.php
+++ b/src/Generators/ComponentGenerator.php
@@ -122,7 +122,7 @@ class ComponentGenerator extends AbstractClassGenerator implements Generator
                 } elseif ($statement instanceof RespondStatement) {
                     $body .= self::INDENT . $statement->output() . PHP_EOL;
                 } elseif ($statement instanceof SessionStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT . $statement->output($component->properties(), true) . PHP_EOL;
                 } elseif ($statement instanceof EloquentStatement) {
                     dump($statement->operation());
                     $body .= self::INDENT . $statement->output($component->prefix(), $name, $using_validation) . PHP_EOL;

--- a/src/Generators/ComponentGenerator.php
+++ b/src/Generators/ComponentGenerator.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Blueprint\Generators;
+
+use Blueprint\Concerns\HandlesImports;
+use Blueprint\Concerns\HandlesTraits;
+use Blueprint\Contracts\Generator;
+use Blueprint\Models\Component;
+use Blueprint\Models\Statements\DispatchStatement;
+use Blueprint\Models\Statements\EloquentStatement;
+use Blueprint\Models\Statements\FireStatement;
+use Blueprint\Models\Statements\QueryStatement;
+use Blueprint\Models\Statements\RedirectStatement;
+use Blueprint\Models\Statements\RenderStatement;
+use Blueprint\Models\Statements\ResourceStatement;
+use Blueprint\Models\Statements\RespondStatement;
+use Blueprint\Models\Statements\SendStatement;
+use Blueprint\Models\Statements\SessionStatement;
+use Blueprint\Models\Statements\ValidateStatement;
+use Blueprint\Tree;
+use Illuminate\Support\Str;
+
+class ComponentGenerator extends AbstractClassGenerator implements Generator
+{
+    use HandlesImports, HandlesTraits;
+
+    protected array $types = ['components'];
+
+    public function output(Tree $tree): array
+    {
+        $this->tree = $tree;
+
+        $stub = $this->filesystem->stub('livewire.class.stub');
+
+        foreach ($tree->components() as $component) {
+            $this->addImport($component, 'Livewire\\Component');
+            $path = $this->getPath($component);
+
+            $this->create($path, $this->populateStub($stub, $component));
+            $this->create($this->viewPath($component), $this->filesystem->stub('livewire.view.stub'));
+        }
+
+        return $this->output;
+    }
+
+    protected function populateStub(string $stub, Component $component): string
+    {
+        $stub = str_replace('{{ namespace }}', $component->fullyQualifiedNamespace(), $stub);
+        $stub = str_replace('{{ class }}', $component->className(), $stub);
+        $stub = str_replace('{{ body }}', $this->buildBody($component), $stub);
+        $stub = str_replace('{{ imports }}', $this->buildImports($component), $stub);
+
+        return $stub;
+    }
+
+    protected function buildMethods(Component $component): string
+    {
+        $template = $this->filesystem->stub('livewire.method.stub');
+
+        $methods = '';
+
+        if ($component->properties()) {
+            $methods .= PHP_EOL . $this->buildMountMethod($component->properties(), str_replace('{{ method }}', 'mount', $template));
+        }
+
+        foreach ($component->methods() as $name => $statements) {
+            $method = str_replace('{{ method }}', $name, $template);
+
+            $body = '';
+            $using_validation = false;
+
+            foreach ($statements as $statement) {
+                if ($statement instanceof SendStatement) {
+                    $body .= self::INDENT . $statement->withProperties($component->properties())->output() . PHP_EOL;
+                    if ($statement->type() === SendStatement::TYPE_NOTIFICATION_WITH_FACADE) {
+                        $this->addImport($component, 'Illuminate\\Support\\Facades\\Notification');
+                        $this->addImport($component, config('blueprint.namespace') . '\\Notification\\' . $statement->mail());
+                    } elseif ($statement->type() === SendStatement::TYPE_MAIL) {
+                        $this->addImport($component, 'Illuminate\\Support\\Facades\\Mail');
+                        $this->addImport($component, config('blueprint.namespace') . '\\Mail\\' . $statement->mail());
+                    }
+                } elseif ($statement instanceof ValidateStatement) {
+                    $using_validation = true;
+                    $class_name = $component->name() . Str::studly($name) . 'Request';
+
+                    $fqcn = config('blueprint.namespace') . '\\Http\\Requests\\' . ($component->namespace() ? $component->namespace() . '\\' : '') . $class_name;
+
+                    $method = str_replace('\Illuminate\Http\Request $request', '\\' . $fqcn . ' $request', $method);
+                    $method = str_replace('(Request $request', '(' . $class_name . ' $request', $method);
+
+                    $this->addImport($component, $fqcn);
+                } elseif ($statement instanceof DispatchStatement) {
+                    $body .= self::INDENT . $statement->withProperties($component->properties())->output() . PHP_EOL;
+                    $this->addImport($component, config('blueprint.namespace') . '\\Jobs\\' . $statement->job());
+                } elseif ($statement instanceof FireStatement) {
+                    $body .= self::INDENT . $statement->withProperties($component->properties())->output() . PHP_EOL;
+                    if (!$statement->isNamedEvent()) {
+                        $this->addImport($component, config('blueprint.namespace') . '\\Events\\' . $statement->event());
+                    }
+                } elseif ($statement instanceof RenderStatement) {
+                    $body .= self::INDENT . $statement->withProperties($component->properties())->output() . PHP_EOL;
+                } elseif ($statement instanceof ResourceStatement) {
+                    $fqcn = config('blueprint.namespace') . '\\Http\\Resources\\' . ($component->namespace() ? $component->namespace() . '\\' : '') . $statement->name();
+                    $this->addImport($component, $fqcn);
+                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+
+                    if ($statement->paginate()) {
+                        if (!Str::contains($body, '::all();')) {
+                            $queryStatement = new QueryStatement('all', [$statement->reference()]);
+                            $body = implode(PHP_EOL, [
+                                self::INDENT . $queryStatement->output($statement->reference()),
+                                PHP_EOL . $body,
+                            ]);
+
+                            $this->addImport($component, $this->determineModel($component, $queryStatement->model()));
+                        }
+
+                        $body = str_replace('::all();', '::paginate();', $body);
+                    }
+                } elseif ($statement instanceof RedirectStatement) {
+                    $body .= self::INDENT . $statement->withProperties($component->properties())->output() . PHP_EOL;
+                } elseif ($statement instanceof RespondStatement) {
+                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                } elseif ($statement instanceof SessionStatement) {
+                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                } elseif ($statement instanceof EloquentStatement) {
+                    dump($statement->operation());
+                    $body .= self::INDENT . $statement->output($component->prefix(), $name, $using_validation) . PHP_EOL;
+                    $this->addImport($component, $this->determineModel($component, $statement->reference()));
+                } elseif ($statement instanceof QueryStatement) {
+                    $body .= self::INDENT . $statement->output($component->prefix()) . PHP_EOL;
+                    $this->addImport($component, $this->determineModel($component, $statement->model()));
+                }
+
+                $body .= PHP_EOL;
+            }
+
+            if (!empty($body)) {
+                $method = str_replace('{{ body }}', trim($body), $method);
+            }
+
+            $returnType = match (true) {
+                $statement instanceof RenderStatement => 'Illuminate\View\View',
+                $statement instanceof RedirectStatement => 'Illuminate\Http\RedirectResponse',
+                $statement instanceof ResourceStatement => config('blueprint.namespace') . '\\Http\\Resources\\' . ($component->namespace() ? $component->namespace() . '\\' : '') . $statement->name(),
+                default => null
+            };
+
+            if (!is_null($returnType)) {
+                $method = str_replace($name . '()' . PHP_EOL, $name . '(): ' . Str::afterLast($returnType, '\\') . PHP_EOL, $method);
+                $this->addImport($component, $returnType);
+            }
+
+            $methods .= PHP_EOL . $method;
+        }
+
+        return $methods;
+    }
+
+    private function buildBody(Component $component): string
+    {
+        $properties = $this->buildProperties($component);
+        $methods = $this->buildMethods($component);
+
+        if (empty($properties)) {
+            return trim($methods);
+        }
+
+        return trim($properties) . PHP_EOL . rtrim($methods);
+    }
+
+    private function buildMountMethod(array $properties, string $template): string
+    {
+        ksort($properties);
+
+        $signature = sprintf(
+            'mount(%s): void',
+            implode(', ', array_map(fn ($name) => '$' . $name, $properties))
+        );
+        $output = str_replace('mount()', $signature, $template);
+
+        $body = implode(PHP_EOL, array_map(fn ($name) => '        $this->' . $name . ' = $' . $name . ';', $properties));
+        $output = str_replace('{{ body }}', trim($body), $output);
+
+        return $output;
+    }
+
+    private function buildProperties(Component $component): string
+    {
+        $properties = $component->properties();
+        if (empty($properties)) {
+            return '';
+        }
+
+        ksort($properties);
+
+        $output = '';
+        foreach ($properties as $property) {
+            $output .= <<<PHP
+    #[Locked]
+    public \${$property};
+
+
+PHP;
+        }
+
+        $this->addImport($component, 'Livewire\\Attributes\\Locked');
+
+        return $output;
+    }
+
+    private function viewPath(Component $component): string
+    {
+        $relative = Str::of($component->namespace() . '\\' . $component->className())
+            ->replace('\\', DIRECTORY_SEPARATOR)
+            ->ltrim(DIRECTORY_SEPARATOR)
+            ->snake('-')
+            ->value();
+
+        return 'resources/views/livewire/' . $relative . '.blade.php';
+    }
+}

--- a/src/Generators/ComponentGenerator.php
+++ b/src/Generators/ComponentGenerator.php
@@ -102,7 +102,7 @@ class ComponentGenerator extends AbstractClassGenerator implements Generator
                 } elseif ($statement instanceof ResourceStatement) {
                     $fqcn = config('blueprint.namespace') . '\\Http\\Resources\\' . ($component->namespace() ? $component->namespace() . '\\' : '') . $statement->name();
                     $this->addImport($component, $fqcn);
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT . $statement->output($component->properties()) . PHP_EOL;
 
                     if ($statement->paginate()) {
                         if (!Str::contains($body, '::all();')) {
@@ -120,7 +120,7 @@ class ComponentGenerator extends AbstractClassGenerator implements Generator
                 } elseif ($statement instanceof RedirectStatement) {
                     $body .= self::INDENT . $statement->withProperties($component->properties())->output() . PHP_EOL;
                 } elseif ($statement instanceof RespondStatement) {
-                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $body .= self::INDENT . $statement->output($component->properties()) . PHP_EOL;
                 } elseif ($statement instanceof SessionStatement) {
                     $body .= self::INDENT . $statement->output($component->properties(), true) . PHP_EOL;
                 } elseif ($statement instanceof EloquentStatement) {

--- a/src/Lexers/ComponentLexer.php
+++ b/src/Lexers/ComponentLexer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Blueprint\Lexers;
+
+use Blueprint\Contracts\Lexer;
+use Blueprint\Models\Component;
+use Illuminate\Support\Str;
+
+class ComponentLexer implements Lexer
+{
+    private StatementLexer $statementLexer;
+
+    public function __construct(StatementLexer $statementLexer)
+    {
+        $this->statementLexer = $statementLexer;
+    }
+
+    public function analyze(array $tokens): array
+    {
+        $registry = [
+            'components' => [],
+        ];
+
+        if (empty($tokens['components'])) {
+            return $registry;
+        }
+
+        foreach ($tokens['components'] as $name => $definition) {
+            $component = new Component($name);
+
+            if (isset($definition['mount'])) {
+                foreach (explode(',', $definition['mount']) as $property) {
+                    $component->addProperty(trim($property));
+                }
+
+                unset($definition['mount']);
+            }
+
+            $definition = array_merge($this->defaultRenderTokens($name), $definition);
+
+            foreach ($definition as $method => $body) {
+                $component->addMethod($method, $this->statementLexer->analyze($body));
+            }
+
+            $registry['components'][$name] = $component;
+        }
+
+        return $registry;
+    }
+
+    private function defaultRenderTokens(string $name): array
+    {
+        return [
+            'render' => [
+                'render' => 'livewire.' . Str::snake($name, '-'),
+            ],
+        ];
+    }
+}

--- a/src/Models/Component.php
+++ b/src/Models/Component.php
@@ -3,23 +3,16 @@
 namespace Blueprint\Models;
 
 use Blueprint\Contracts\Model as BlueprintModel;
-use Illuminate\Support\Str;
 
-class Controller implements BlueprintModel
+class Component implements BlueprintModel
 {
-    public static array $resourceMethods = ['index', 'create', 'store', 'edit', 'update', 'show', 'destroy'];
-
-    public static array $apiResourceMethods = ['index', 'store', 'update', 'show', 'destroy'];
-
     private string $name;
 
     private string $namespace;
 
+    private array $properties = [];
+
     private array $methods = [];
-
-    private ?Policy $policy = null;
-
-    private bool $apiResource = false;
 
     public function __construct(string $name)
     {
@@ -34,7 +27,7 @@ class Controller implements BlueprintModel
 
     public function className(): string
     {
-        return $this->name() . (Str::endsWith($this->name(), 'Controller') ? '' : 'Controller');
+        return $this->name();
     }
 
     public function namespace(): string
@@ -50,8 +43,8 @@ class Controller implements BlueprintModel
     {
         $fqn = config('blueprint.namespace');
 
-        if (config('blueprint.controllers_namespace')) {
-            $fqn .= '\\' . config('blueprint.controllers_namespace');
+        if (config('blueprint.components_namespace')) {
+            $fqn .= '\\' . config('blueprint.components_namespace');
         }
 
         if ($this->namespace) {
@@ -76,31 +69,13 @@ class Controller implements BlueprintModel
         $this->methods[$name] = $statements;
     }
 
-    public function policy(?Policy $policy = null): ?Policy
+    public function properties(): array
     {
-        if ($policy) {
-            $this->policy = $policy;
-        }
-
-        return $this->policy;
+        return $this->properties;
     }
 
-    public function prefix(): string
+    public function addProperty(string $name): void
     {
-        if (Str::endsWith($this->name(), 'Controller')) {
-            return Str::substr($this->name(), 0, -10);
-        }
-
-        return $this->name();
-    }
-
-    public function setApiResource(bool $apiResource): void
-    {
-        $this->apiResource = $apiResource;
-    }
-
-    public function isApiResource(): bool
-    {
-        return $this->apiResource;
+        $this->properties[$name] = $name;
     }
 }

--- a/src/Models/Statements/DispatchStatement.php
+++ b/src/Models/Statements/DispatchStatement.php
@@ -2,11 +2,13 @@
 
 namespace Blueprint\Models\Statements;
 
+use Blueprint\Concerns\HasParameters;
+
 class DispatchStatement
 {
-    private string $job;
+    use HasParameters;
 
-    private array $data;
+    private string $job;
 
     public function __construct(string $job, array $data = [])
     {
@@ -19,28 +21,16 @@ class DispatchStatement
         return $this->job;
     }
 
-    public function data(): array
-    {
-        return $this->data;
-    }
-
     public function output(): string
     {
         $code = $this->job() . '::dispatch(';
 
         if ($this->data()) {
-            $code .= $this->buildParameters($this->data());
+            $code .= $this->buildParameters();
         }
 
         $code .= ');';
 
         return $code;
-    }
-
-    private function buildParameters(array $data): string
-    {
-        $parameters = array_map(fn ($parameter) => '$' . $parameter, $data);
-
-        return implode(', ', $parameters);
     }
 }

--- a/src/Models/Statements/FireStatement.php
+++ b/src/Models/Statements/FireStatement.php
@@ -2,11 +2,13 @@
 
 namespace Blueprint\Models\Statements;
 
+use Blueprint\Concerns\HasParameters;
+
 class FireStatement
 {
-    private string $event;
+    use HasParameters;
 
-    private array $data;
+    private string $event;
 
     public function __construct(string $event, array $data = [])
     {
@@ -17,11 +19,6 @@ class FireStatement
     public function event(): string
     {
         return $this->event;
-    }
-
-    public function data(): array
-    {
-        return $this->data;
     }
 
     public function isNamedEvent(): bool
@@ -44,14 +41,7 @@ class FireStatement
         return sprintf(
             $template,
             $this->event(),
-            $this->data() ? $this->buildParameters($this->data()) : ''
+            $this->data() ? $this->buildParameters() : ''
         );
-    }
-
-    private function buildParameters(array $data): string
-    {
-        $parameters = array_map(fn ($parameter) => '$' . $parameter, $data);
-
-        return implode(', ', $parameters);
     }
 }

--- a/src/Models/Statements/HasParameters.php
+++ b/src/Models/Statements/HasParameters.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Blueprint\Models\Statements;
-
-trait HasParameters {}

--- a/src/Models/Statements/HasParameters.php
+++ b/src/Models/Statements/HasParameters.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Blueprint\Models\Statements;
+
+trait HasParameters {}

--- a/src/Models/Statements/RedirectStatement.php
+++ b/src/Models/Statements/RedirectStatement.php
@@ -2,13 +2,14 @@
 
 namespace Blueprint\Models\Statements;
 
+use Blueprint\Concerns\HasParameters;
 use Illuminate\Support\Str;
 
 class RedirectStatement
 {
-    private string $route;
+    use HasParameters;
 
-    private array $data;
+    private string $route;
 
     public function __construct(string $route, array $data = [])
     {
@@ -21,17 +22,12 @@ class RedirectStatement
         return $this->route;
     }
 
-    public function data(): array
-    {
-        return $this->data;
-    }
-
     public function output(): string
     {
         $code = "return redirect()->route('" . $this->route() . "'";
 
         if ($this->data()) {
-            $code .= ', [' . $this->buildParameters($this->data()) . ']';
+            $code .= ', [' . $this->buildParameters() . ']';
         } elseif (Str::contains($this->route(), '.')) {
             [$model, $method] = explode('.', $this->route());
             if (in_array($method, ['edit', 'update', 'show', 'destroy'])) {
@@ -43,12 +39,5 @@ class RedirectStatement
         $code .= ');';
 
         return $code;
-    }
-
-    private function buildParameters(array $data): string
-    {
-        $parameters = array_map(fn ($parameter) => '$' . $parameter, $data);
-
-        return implode(', ', $parameters);
     }
 }

--- a/src/Models/Statements/RenderStatement.php
+++ b/src/Models/Statements/RenderStatement.php
@@ -33,4 +33,11 @@ class RenderStatement
 
         return $code;
     }
+
+    private function buildParameters(): string
+    {
+        $parameters = array_map(fn ($parameter) => "'" . $parameter . "'", $this->data());
+
+        return implode(', ', $parameters);
+    }
 }

--- a/src/Models/Statements/RenderStatement.php
+++ b/src/Models/Statements/RenderStatement.php
@@ -2,11 +2,13 @@
 
 namespace Blueprint\Models\Statements;
 
+use Blueprint\Concerns\HasParameters;
+
 class RenderStatement
 {
-    private string $view;
+    use HasParameters;
 
-    private array $data;
+    private string $view;
 
     public function __construct(string $view, array $data = [])
     {
@@ -19,28 +21,16 @@ class RenderStatement
         return $this->view;
     }
 
-    public function data(): array
-    {
-        return $this->data;
-    }
-
     public function output(): string
     {
         $code = "return view('" . $this->view() . "'";
 
         if ($this->data()) {
-            $code .= ', compact(' . $this->buildParameters($this->data()) . ')';
+            $code .= ', compact(' . $this->buildParameters() . ')';
         }
 
         $code .= ');';
 
         return $code;
-    }
-
-    private function buildParameters(array $data): string
-    {
-        $parameters = array_map(fn ($parameter) => "'" . $parameter . "'", $data);
-
-        return implode(', ', $parameters);
     }
 }

--- a/src/Models/Statements/ResourceStatement.php
+++ b/src/Models/Statements/ResourceStatement.php
@@ -45,6 +45,15 @@ class ResourceStatement
 
     public function output(array $properties = []): string
     {
-        return sprintf('return new %s($%s);', $this->name(), $this->reference());
+        return sprintf('return new %s(%s);', $this->name(), $this->buildArgument($properties));
+    }
+
+    private function buildArgument(array $properties): string
+    {
+        if (in_array($this->reference(), $properties)) {
+            return '$this->' . $this->reference();
+        }
+
+        return '$' . $this->reference();
     }
 }

--- a/src/Models/Statements/ResourceStatement.php
+++ b/src/Models/Statements/ResourceStatement.php
@@ -43,7 +43,7 @@ class ResourceStatement
         return $this->paginate;
     }
 
-    public function output(): string
+    public function output(array $properties = []): string
     {
         return sprintf('return new %s($%s);', $this->name(), $this->reference());
     }

--- a/src/Models/Statements/RespondStatement.php
+++ b/src/Models/Statements/RespondStatement.php
@@ -2,6 +2,8 @@
 
 namespace Blueprint\Models\Statements;
 
+use Illuminate\Support\Str;
+
 class RespondStatement
 {
     private int $status = 200;
@@ -27,12 +29,16 @@ class RespondStatement
         return $this->content;
     }
 
-    public function output(): string
+    public function output(array $properties = []): string
     {
-        if ($this->content()) {
-            return 'return $' . $this->content . ';';
+        if (is_null($this->content())) {
+            return sprintf('return response()->noContent(%s);', $this->status() === 204 ? '' : $this->status());
         }
 
-        return sprintf('return response()->noContent(%s);', $this->status() === 204 ? '' : $this->status());
+        if (in_array(Str::before($this->content(), '.'), $properties)) {
+            return 'return $this->' . $this->content . ';';
+        }
+
+        return 'return $' . $this->content . ';';
     }
 }

--- a/src/Models/Statements/SendStatement.php
+++ b/src/Models/Statements/SendStatement.php
@@ -83,7 +83,7 @@ class SendStatement
         $code = 'Mail::';
 
         if ($this->to()) {
-            $code .= 'to($' . str_replace('.', '->', $this->to()) . ')->';
+            $code .= sprintf('to(%s)->', $this->buildTo());
         }
 
         $code .= 'send(new ' . $this->mail() . '(';
@@ -102,7 +102,7 @@ class SendStatement
         $code = 'Notification::';
 
         if ($this->to()) {
-            $code .= 'send($' . str_replace('.', '->', $this->to()) . ', new ' . $this->mail() . '(';
+            $code .= sprintf('send(%s, new %s(', $this->buildTo(), $this->mail());
         }
 
         if ($this->data()) {
@@ -119,8 +119,7 @@ class SendStatement
         $code = '';
 
         if ($this->to()) {
-            $code .= sprintf('$%s->', str_replace('.', '->', $this->to()));
-            $code .= 'notify(new ' . $this->mail() . '(';
+            $code .= sprintf('%s->notify(new %s(', $this->buildTo(), $this->mail());
         }
 
         if ($this->data()) {
@@ -130,5 +129,16 @@ class SendStatement
         $code .= '));';
 
         return $code;
+    }
+
+    private function buildTo(): string
+    {
+        $variable = str_replace('.', '->', $this->to());
+
+        if (in_array(Str::before($this->to(), '.'), $this->properties())) {
+            $variable = 'this->' . $variable;
+        }
+
+        return '$' . $variable;
     }
 }

--- a/src/Models/Statements/SendStatement.php
+++ b/src/Models/Statements/SendStatement.php
@@ -2,10 +2,13 @@
 
 namespace Blueprint\Models\Statements;
 
+use Blueprint\Concerns\HasParameters;
 use Illuminate\Support\Str;
 
 class SendStatement
 {
+    use HasParameters;
+
     const TYPE_MAIL = 'mail';
 
     const TYPE_NOTIFICATION_WITH_FACADE = 'notification_with_facade';
@@ -15,8 +18,6 @@ class SendStatement
     private string $mail;
 
     private ?string $to;
-
-    private array $data;
 
     private string $type;
 
@@ -54,11 +55,6 @@ class SendStatement
         return $this->type;
     }
 
-    public function data(): array
-    {
-        return $this->data;
-    }
-
     public function output(): string
     {
         if ($this->type() === self::TYPE_NOTIFICATION_WITH_FACADE) {
@@ -93,7 +89,7 @@ class SendStatement
         $code .= 'send(new ' . $this->mail() . '(';
 
         if ($this->data()) {
-            $code .= $this->buildParameters($this->data());
+            $code .= $this->buildParameters();
         }
 
         $code .= '));';
@@ -110,7 +106,7 @@ class SendStatement
         }
 
         if ($this->data()) {
-            $code .= $this->buildParameters($this->data());
+            $code .= $this->buildParameters();
         }
 
         $code .= '));';
@@ -128,18 +124,11 @@ class SendStatement
         }
 
         if ($this->data()) {
-            $code .= $this->buildParameters($this->data());
+            $code .= $this->buildParameters();
         }
 
         $code .= '));';
 
         return $code;
-    }
-
-    private function buildParameters(array $data): string
-    {
-        $parameters = array_map(fn ($parameter) => '$' . $parameter, $data);
-
-        return implode(', ', $parameters);
     }
 }

--- a/src/Models/Statements/SessionStatement.php
+++ b/src/Models/Statements/SessionStatement.php
@@ -2,6 +2,8 @@
 
 namespace Blueprint\Models\Statements;
 
+use Illuminate\Support\Str;
+
 class SessionStatement
 {
     private string $operation;
@@ -24,13 +26,27 @@ class SessionStatement
         return $this->reference;
     }
 
-    public function output(): string
+    public function output(array $properties = [], bool $livewire = false): string
     {
-        $code = '$request->session()->' . $this->operation() . '(';
-        $code .= "'" . $this->reference() . "', ";
-        $code .= '$' . str_replace('.', '->', $this->reference());
-        $code .= ');';
+        $template = "%ssession()->%s('%s', %s);";
 
-        return $code;
+        return sprintf(
+            $template,
+            $livewire ? '' : '$request->',
+            $this->operation(),
+            $this->reference(),
+            $this->buildValue($properties)
+        );
+    }
+
+    private function buildValue(array $properties): string
+    {
+        $variable = str_replace('.', '->', $this->reference());
+
+        if (in_array(Str::before($this->reference(), '.'), $properties)) {
+            $variable = 'this->' . $variable;
+        }
+
+        return '$' . $variable;
     }
 }

--- a/src/Models/Statements/ValidateStatement.php
+++ b/src/Models/Statements/ValidateStatement.php
@@ -2,17 +2,14 @@
 
 namespace Blueprint\Models\Statements;
 
+use Blueprint\Concerns\HasParameters;
+
 class ValidateStatement
 {
-    private array $data;
+    use HasParameters;
 
     public function __construct(array $data)
     {
         $this->data = $data;
-    }
-
-    public function data(): array
-    {
-        return $this->data;
     }
 }

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -2,6 +2,7 @@
 
 namespace Blueprint;
 
+use Blueprint\Models\Component;
 use Illuminate\Support\Str;
 
 class Tree
@@ -17,12 +18,20 @@ class Tree
         $this->registerModels();
     }
 
+    /**
+     * @return Component[]
+     */
+    public function components(): array
+    {
+        return $this->tree['components'];
+    }
+
     private function registerModels(): void
     {
         $this->models = array_merge($this->tree['cache'] ?? [], $this->tree['models'] ?? []);
     }
 
-    public function controllers()
+    public function controllers(): array
     {
         return $this->tree['controllers'];
     }

--- a/stubs/livewire.class.stub
+++ b/stubs/livewire.class.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }};
+
+{{ imports }}
+
+class {{ class }} extends Component
+{
+    {{ body }}
+}

--- a/stubs/livewire.method.stub
+++ b/stubs/livewire.method.stub
@@ -1,0 +1,4 @@
+    public function {{ method }}()
+    {
+        {{ body }}
+    }

--- a/stubs/livewire.view.stub
+++ b/stubs/livewire.view.stub
@@ -1,0 +1,3 @@
+<div>
+    {{-- In work, do what you enjoy. --}}
+</div>

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -25,344 +25,7 @@ final class BlueprintTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = new Blueprint();
-    }
-
-    #[Test]
-    public function it_parses_models(): void
-    {
-        $blueprint = $this->fixture('drafts/models-only.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'ModelOne' => [
-                    'column' => 'datatype modifier',
-                ],
-                'ModelTwo' => [
-                    'column' => 'datatype',
-                    'another_column' => 'datatype modifier',
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    public function it_parses_seeders()
-    {
-        $blueprint = $this->fixture('drafts/seeders.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'Post' => [
-                    'title' => 'string:400',
-                    'content' => 'longtext',
-                    'published_at' => 'nullable timestamp',
-                ],
-                'Comment' => [
-                    'post_id' => 'id',
-                    'content' => 'longtext',
-                    'approved' => 'boolean',
-                    'user_id' => 'id',
-                ],
-            ],
-            'seeders' => 'Post, Comment',
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_controllers(): void
-    {
-        $blueprint = $this->fixture('drafts/controllers-only.yaml');
-
-        $this->assertEquals([
-            'controllers' => [
-                'UserController' => [
-                    'index' => [
-                        'action' => 'detail',
-                    ],
-                    'create' => [
-                        'action' => 'additional detail',
-                    ],
-                ],
-                'RoleController' => [
-                    'index' => [
-                        'action' => 'detail',
-                        'another_action' => 'so much detail',
-                    ],
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_shorthands(): void
-    {
-        $blueprint = $this->fixture('drafts/shorthands.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'Name' => [
-                    'softdeletes' => 'softDeletes',
-                    'id' => 'id',
-                    'timestamps' => 'timestamps',
-                ],
-            ],
-            'controllers' => [
-                'Context' => [
-                    'resource' => 'web',
-                ],
-                'Report' => [
-                    'invokable' => true,
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_ulid_shorthand(): void
-    {
-        $blueprint = $this->fixture('drafts/ulid-shorthand.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'Person' => [
-                    'id' => 'ulid primary',
-                    'timestamps' => 'timestamps',
-                    'company_id' => 'ulid',
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_uuid_shorthand(): void
-    {
-        $blueprint = $this->fixture('drafts/uuid-shorthand.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'Person' => [
-                    'id' => 'uuid primary',
-                    'timestamps' => 'timestamps',
-                    'company_id' => 'uuid',
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_shorthands_with_timezones(): void
-    {
-        $blueprint = $this->fixture('drafts/with-timezones.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'Comment' => [
-                    'softdeletestz' => 'softDeletesTz',
-                    'timestampstz' => 'timestampstz',
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_longhands(): void
-    {
-        $blueprint = $this->fixture('drafts/longhands.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'Proper' => [
-                    'id' => 'id',
-                    'softdeletes' => 'softDeletes',
-                    'timestamps' => 'timestamps',
-                ],
-                'Lower' => [
-                    'id' => 'id',
-                    'softdeletes' => 'softdeletes',
-                    'timestampstz' => 'timestampstz',
-                ],
-                'Timezone' => [
-                    'softdeletestz' => 'softdeletestz',
-                    'timestampstz' => 'timestampsTz',
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_resource_shorthands(): void
-    {
-        $blueprint = $this->fixture('drafts/with-timezones.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'Comment' => [
-                    'softdeletestz' => 'softDeletesTz',
-                    'timestampstz' => 'timestampstz',
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_the_readme_example(): void
-    {
-        $blueprint = $this->fixture('drafts/readme-example.yaml');
-
-        $this->assertEquals([
-            'models' => [
-                'Post' => [
-                    'title' => 'string:400',
-                    'content' => 'longtext',
-                    'published_at' => 'nullable timestamp',
-                    'author_id' => 'id:user',
-                ],
-            ],
-            'controllers' => [
-                'Post' => [
-                    'index' => [
-                        'query' => 'all',
-                        'render' => 'post.index with:posts',
-                    ],
-                    'store' => [
-                        'validate' => 'title, content, author_id',
-                        'save' => 'post',
-                        'send' => 'ReviewPost to:post.author.email with:post',
-                        'dispatch' => 'SyncMedia with:post',
-                        'fire' => 'NewPost with:post',
-                        'flash' => 'post.title',
-                        'redirect' => 'posts.index',
-                    ],
-                ],
-            ],
-        ], $this->subject->parse($blueprint));
-    }
-
-    #[Test]
-    public function it_parses_the_readme_example_with_different_platform_eols(): void
-    {
-        $definition = $this->fixture('drafts/readme-example.yaml');
-
-        $LF = "\n";
-        $CR = "\r";
-        $CRLF = "\r\n";
-
-        $definition_mac_eol = str_replace($LF, $CR, $definition);
-        $definition_windows_eol = str_replace($LF, $CRLF, $definition);
-
-        $expected = [
-            'models' => [
-                'Post' => [
-                    'title' => 'string:400',
-                    'content' => 'longtext',
-                    'published_at' => 'nullable timestamp',
-                    'author_id' => 'id:user',
-                ],
-            ],
-            'controllers' => [
-                'Post' => [
-                    'index' => [
-                        'query' => 'all',
-                        'render' => 'post.index with:posts',
-                    ],
-                    'store' => [
-                        'validate' => 'title, content, author_id',
-                        'save' => 'post',
-                        'send' => 'ReviewPost to:post.author.email with:post',
-                        'dispatch' => 'SyncMedia with:post',
-                        'fire' => 'NewPost with:post',
-                        'flash' => 'post.title',
-                        'redirect' => 'posts.index',
-                    ],
-                ],
-            ],
-        ];
-
-        $this->assertEquals($expected, $this->subject->parse($definition_mac_eol));
-        $this->assertEquals($expected, $this->subject->parse($definition_windows_eol));
-    }
-
-    #[Test]
-    public function it_parses_yaml_with_dashed_syntax(): void
-    {
-        $definition = $this->fixture('drafts/readme-example-dashes.yaml');
-
-        $expected = [
-            'models' => [
-                'Post' => [
-                    'title' => 'string:400',
-                    'content' => 'longtext',
-                ],
-            ],
-            'controllers' => [
-                'Post' => [
-                    'index' => [
-                        'query' => 'all:posts',
-                        'render' => 'post.index with:posts',
-                    ],
-                    'store' => [
-                        'validate' => 'title, content',
-                        'save' => 'post',
-                        'redirect' => 'posts.index',
-                    ],
-                ],
-            ],
-        ];
-
-        $this->assertEquals($expected, $this->subject->parse($definition));
-    }
-
-    #[Test]
-    public function it_parses_yaml_with_multiple_dispatch_fire_notify_send_keys(): void
-    {
-        $definition = $this->fixture('drafts/multiple-dispatch-fire-notify-send-keys.yaml');
-
-        $expected = [
-            'controllers' => [
-                'Post' => [
-                    'store' => [
-                        'dispatch-3' => 'SyncMedia with:post',
-                        'dispatch-4' => 'SyncMedia with:post',
-                        'dispatch-5' => 'SyncMedia with:post',
-                        'fire-6' => 'NewPost with:post',
-                        'fire-7' => 'NewPost with:post',
-                        'fire-8' => 'NewPost with:post',
-                    ],
-                ],
-                'User' => [
-                    'store' => [
-                        'notify-11' => 'post.author ReviewPost with:post',
-                        'notify-12' => 'post.author ReviewPost with:post',
-                        'notify-13' => 'post.author ReviewPost with:post',
-                        'send-14' => 'ReviewNotification to:post.author with:post',
-                        'send-15' => 'ReviewNotification to:post.author with:post',
-                        'send-16' => 'ReviewNotification to:post.author with:post',
-                    ],
-                ],
-            ],
-        ];
-
-        $this->assertEquals($expected, $this->subject->parse($definition));
-    }
-
-    #[Test]
-    public function it_allows_parsing_without_stripping_dashes(): void
-    {
-        $sequence = [
-            'numbers' => range(3, 11),
-        ];
-
-        $this->assertEquals($sequence, $this->subject->parse($this->subject->dump($sequence), false));
-    }
-
-    #[Test]
-    public function it_throws_a_custom_error_when_parsing_fails(): void
-    {
-        $this->expectException(ParseException::class);
-
-        $blueprint = $this->fixture('drafts/invalid.yaml');
-
-        $this->subject->parse($blueprint);
+        $this->subject = new Blueprint;
     }
 
     #[Test]
@@ -395,84 +58,6 @@ final class BlueprintTest extends TestCase
             'controllers' => [],
             'mock' => 'lexer',
         ], $this->subject->analyze($tokens)->toArray());
-    }
-
-    #[Test]
-    public function generate_uses_registered_generators_and_returns_generated_files(): void
-    {
-        $generatorOne = \Mockery::mock(Generator::class);
-        $tree = new Tree(['branch' => ['code', 'attributes']]);
-
-        $generatorOne->expects('output')
-            ->with($tree, false)
-            ->andReturn([
-                'created' => ['one/new.php'],
-                'updated' => ['one/existing.php'],
-                'deleted' => ['one/trashed.php'],
-            ]);
-
-        $generatorOne->expects('types')
-            ->andReturn([
-                'some',
-                'types',
-            ]);
-
-        $generatorTwo = \Mockery::mock(Generator::class);
-        $generatorTwo->expects('output')
-            ->with($tree, false)
-            ->andReturn([
-                'created' => ['two/new.php'],
-                'updated' => ['two/existing.php'],
-                'deleted' => ['two/trashed.php'],
-            ]);
-
-        $generatorTwo->expects('types')
-            ->andReturn([
-                'some',
-                'types',
-            ]);
-
-        $this->subject->registerGenerator($generatorOne);
-        $this->subject->registerGenerator($generatorTwo);
-
-        $this->assertEquals([
-            'created' => ['one/new.php', 'two/new.php'],
-            'updated' => ['one/existing.php', 'two/existing.php'],
-            'deleted' => ['one/trashed.php', 'two/trashed.php'],
-        ], $this->subject->generate($tree));
-    }
-
-    #[Test]
-    public function generate_uses_swapped_generator_and_returns_generated_files(): void
-    {
-        $generatorOne = \Mockery::mock(Generator::class);
-        $tree = new Tree(['branch' => ['code', 'attributes']]);
-
-        $generatorOne->expects('output')->never();
-
-        $generatorSwap = \Mockery::mock(Generator::class);
-        $generatorSwap->expects('output')
-            ->with($tree, false)
-            ->andReturn([
-                'created' => ['swapped/new.php'],
-                'updated' => ['swapped/existing.php'],
-                'deleted' => ['swapped/trashed.php'],
-            ]);
-
-        $generatorSwap->expects('types')
-            ->andReturn([
-                'some',
-                'types',
-            ]);
-
-        $this->subject->registerGenerator($generatorOne);
-        $this->subject->swapGenerator(get_class($generatorOne), $generatorSwap);
-
-        $this->assertEquals([
-            'created' => ['swapped/new.php'],
-            'updated' => ['swapped/existing.php'],
-            'deleted' => ['swapped/trashed.php'],
-        ], $this->subject->generate($tree));
     }
 
     #[Test]
@@ -669,6 +254,447 @@ final class BlueprintTest extends TestCase
         $this->assertEquals([
             'created' => ['foo.php'],
         ], $actual);
+    }
+
+    #[Test]
+    public function generate_uses_registered_generators_and_returns_generated_files(): void
+    {
+        $generatorOne = \Mockery::mock(Generator::class);
+        $tree = new Tree(['branch' => ['code', 'attributes']]);
+
+        $generatorOne->expects('output')
+            ->with($tree, false)
+            ->andReturn([
+                'created' => ['one/new.php'],
+                'updated' => ['one/existing.php'],
+                'deleted' => ['one/trashed.php'],
+            ]);
+
+        $generatorOne->expects('types')
+            ->andReturn([
+                'some',
+                'types',
+            ]);
+
+        $generatorTwo = \Mockery::mock(Generator::class);
+        $generatorTwo->expects('output')
+            ->with($tree, false)
+            ->andReturn([
+                'created' => ['two/new.php'],
+                'updated' => ['two/existing.php'],
+                'deleted' => ['two/trashed.php'],
+            ]);
+
+        $generatorTwo->expects('types')
+            ->andReturn([
+                'some',
+                'types',
+            ]);
+
+        $this->subject->registerGenerator($generatorOne);
+        $this->subject->registerGenerator($generatorTwo);
+
+        $this->assertEquals([
+            'created' => ['one/new.php', 'two/new.php'],
+            'updated' => ['one/existing.php', 'two/existing.php'],
+            'deleted' => ['one/trashed.php', 'two/trashed.php'],
+        ], $this->subject->generate($tree));
+    }
+
+    #[Test]
+    public function generate_uses_swapped_generator_and_returns_generated_files(): void
+    {
+        $generatorOne = \Mockery::mock(Generator::class);
+        $tree = new Tree(['branch' => ['code', 'attributes']]);
+
+        $generatorOne->expects('output')->never();
+
+        $generatorSwap = \Mockery::mock(Generator::class);
+        $generatorSwap->expects('output')
+            ->with($tree, false)
+            ->andReturn([
+                'created' => ['swapped/new.php'],
+                'updated' => ['swapped/existing.php'],
+                'deleted' => ['swapped/trashed.php'],
+            ]);
+
+        $generatorSwap->expects('types')
+            ->andReturn([
+                'some',
+                'types',
+            ]);
+
+        $this->subject->registerGenerator($generatorOne);
+        $this->subject->swapGenerator(get_class($generatorOne), $generatorSwap);
+
+        $this->assertEquals([
+            'created' => ['swapped/new.php'],
+            'updated' => ['swapped/existing.php'],
+            'deleted' => ['swapped/trashed.php'],
+        ], $this->subject->generate($tree));
+    }
+
+    #[Test]
+    public function it_allows_parsing_without_stripping_dashes(): void
+    {
+        $sequence = [
+            'numbers' => range(3, 11),
+        ];
+
+        $this->assertEquals($sequence, $this->subject->parse($this->subject->dump($sequence), false));
+    }
+
+    #[Test]
+    public function it_parses_components(): void
+    {
+        $blueprint = $this->fixture('drafts/components-only.yaml');
+
+        $this->assertEquals([
+            'components' => [
+                'UpdateProfile' => [
+                    'mount' => 'user, dashboard_url',
+                    'update' => [
+                        'action' => 'detail',
+                        'another_action' => 'so much detail',
+                    ],
+                    'another_method' => [
+                        'some' => 'action',
+                    ],
+                ],
+                'AnotherComponent' => [
+                    'main' => [
+                        'action' => 'reaction',
+                    ],
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_controllers(): void
+    {
+        $blueprint = $this->fixture('drafts/controllers-only.yaml');
+
+        $this->assertEquals([
+            'controllers' => [
+                'UserController' => [
+                    'index' => [
+                        'action' => 'detail',
+                    ],
+                    'create' => [
+                        'action' => 'additional detail',
+                    ],
+                ],
+                'RoleController' => [
+                    'index' => [
+                        'action' => 'detail',
+                        'another_action' => 'so much detail',
+                    ],
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_longhands(): void
+    {
+        $blueprint = $this->fixture('drafts/longhands.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'Proper' => [
+                    'id' => 'id',
+                    'softdeletes' => 'softDeletes',
+                    'timestamps' => 'timestamps',
+                ],
+                'Lower' => [
+                    'id' => 'id',
+                    'softdeletes' => 'softdeletes',
+                    'timestampstz' => 'timestampstz',
+                ],
+                'Timezone' => [
+                    'softdeletestz' => 'softdeletestz',
+                    'timestampstz' => 'timestampsTz',
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_models(): void
+    {
+        $blueprint = $this->fixture('drafts/models-only.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'ModelOne' => [
+                    'column' => 'datatype modifier',
+                ],
+                'ModelTwo' => [
+                    'column' => 'datatype',
+                    'another_column' => 'datatype modifier',
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_resource_shorthands(): void
+    {
+        $blueprint = $this->fixture('drafts/with-timezones.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'Comment' => [
+                    'softdeletestz' => 'softDeletesTz',
+                    'timestampstz' => 'timestampstz',
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    public function it_parses_seeders()
+    {
+        $blueprint = $this->fixture('drafts/seeders.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'Post' => [
+                    'title' => 'string:400',
+                    'content' => 'longtext',
+                    'published_at' => 'nullable timestamp',
+                ],
+                'Comment' => [
+                    'post_id' => 'id',
+                    'content' => 'longtext',
+                    'approved' => 'boolean',
+                    'user_id' => 'id',
+                ],
+            ],
+            'seeders' => 'Post, Comment',
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_shorthands(): void
+    {
+        $blueprint = $this->fixture('drafts/shorthands.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'Name' => [
+                    'softdeletes' => 'softDeletes',
+                    'id' => 'id',
+                    'timestamps' => 'timestamps',
+                ],
+            ],
+            'controllers' => [
+                'Context' => [
+                    'resource' => 'web',
+                ],
+                'Report' => [
+                    'invokable' => true,
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_shorthands_with_timezones(): void
+    {
+        $blueprint = $this->fixture('drafts/with-timezones.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'Comment' => [
+                    'softdeletestz' => 'softDeletesTz',
+                    'timestampstz' => 'timestampstz',
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_the_readme_example(): void
+    {
+        $blueprint = $this->fixture('drafts/readme-example.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'Post' => [
+                    'title' => 'string:400',
+                    'content' => 'longtext',
+                    'published_at' => 'nullable timestamp',
+                    'author_id' => 'id:user',
+                ],
+            ],
+            'controllers' => [
+                'Post' => [
+                    'index' => [
+                        'query' => 'all',
+                        'render' => 'post.index with:posts',
+                    ],
+                    'store' => [
+                        'validate' => 'title, content, author_id',
+                        'save' => 'post',
+                        'send' => 'ReviewPost to:post.author.email with:post',
+                        'dispatch' => 'SyncMedia with:post',
+                        'fire' => 'NewPost with:post',
+                        'flash' => 'post.title',
+                        'redirect' => 'posts.index',
+                    ],
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_the_readme_example_with_different_platform_eols(): void
+    {
+        $definition = $this->fixture('drafts/readme-example.yaml');
+
+        $LF = "\n";
+        $CR = "\r";
+        $CRLF = "\r\n";
+
+        $definition_mac_eol = str_replace($LF, $CR, $definition);
+        $definition_windows_eol = str_replace($LF, $CRLF, $definition);
+
+        $expected = [
+            'models' => [
+                'Post' => [
+                    'title' => 'string:400',
+                    'content' => 'longtext',
+                    'published_at' => 'nullable timestamp',
+                    'author_id' => 'id:user',
+                ],
+            ],
+            'controllers' => [
+                'Post' => [
+                    'index' => [
+                        'query' => 'all',
+                        'render' => 'post.index with:posts',
+                    ],
+                    'store' => [
+                        'validate' => 'title, content, author_id',
+                        'save' => 'post',
+                        'send' => 'ReviewPost to:post.author.email with:post',
+                        'dispatch' => 'SyncMedia with:post',
+                        'fire' => 'NewPost with:post',
+                        'flash' => 'post.title',
+                        'redirect' => 'posts.index',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->subject->parse($definition_mac_eol));
+        $this->assertEquals($expected, $this->subject->parse($definition_windows_eol));
+    }
+
+    #[Test]
+    public function it_parses_ulid_shorthand(): void
+    {
+        $blueprint = $this->fixture('drafts/ulid-shorthand.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'Person' => [
+                    'id' => 'ulid primary',
+                    'timestamps' => 'timestamps',
+                    'company_id' => 'ulid',
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_uuid_shorthand(): void
+    {
+        $blueprint = $this->fixture('drafts/uuid-shorthand.yaml');
+
+        $this->assertEquals([
+            'models' => [
+                'Person' => [
+                    'id' => 'uuid primary',
+                    'timestamps' => 'timestamps',
+                    'company_id' => 'uuid',
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
+    public function it_parses_yaml_with_dashed_syntax(): void
+    {
+        $definition = $this->fixture('drafts/readme-example-dashes.yaml');
+
+        $expected = [
+            'models' => [
+                'Post' => [
+                    'title' => 'string:400',
+                    'content' => 'longtext',
+                ],
+            ],
+            'controllers' => [
+                'Post' => [
+                    'index' => [
+                        'query' => 'all:posts',
+                        'render' => 'post.index with:posts',
+                    ],
+                    'store' => [
+                        'validate' => 'title, content',
+                        'save' => 'post',
+                        'redirect' => 'posts.index',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->subject->parse($definition));
+    }
+
+    #[Test]
+    public function it_parses_yaml_with_multiple_dispatch_fire_notify_send_keys(): void
+    {
+        $definition = $this->fixture('drafts/multiple-dispatch-fire-notify-send-keys.yaml');
+
+        $expected = [
+            'controllers' => [
+                'Post' => [
+                    'store' => [
+                        'dispatch-3' => 'SyncMedia with:post',
+                        'dispatch-4' => 'SyncMedia with:post',
+                        'dispatch-5' => 'SyncMedia with:post',
+                        'fire-6' => 'NewPost with:post',
+                        'fire-7' => 'NewPost with:post',
+                        'fire-8' => 'NewPost with:post',
+                    ],
+                ],
+                'User' => [
+                    'store' => [
+                        'notify-11' => 'post.author ReviewPost with:post',
+                        'notify-12' => 'post.author ReviewPost with:post',
+                        'notify-13' => 'post.author ReviewPost with:post',
+                        'send-14' => 'ReviewNotification to:post.author with:post',
+                        'send-15' => 'ReviewNotification to:post.author with:post',
+                        'send-16' => 'ReviewNotification to:post.author with:post',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->subject->parse($definition));
+    }
+
+    #[Test]
+    public function it_throws_a_custom_error_when_parsing_fails(): void
+    {
+        $this->expectException(ParseException::class);
+
+        $blueprint = $this->fixture('drafts/invalid.yaml');
+
+        $this->subject->parse($blueprint);
     }
 
     #[Test]

--- a/tests/Feature/Commands/TraceCommandTest.php
+++ b/tests/Feature/Commands/TraceCommandTest.php
@@ -61,14 +61,14 @@ final class TraceCommandTest extends TestCase
         // App namespace
         config(['blueprint.models_namespace' => '']);
 
-        $this->assertEquals($method->invoke(new Tracer(), app('App\Comment')), 'Comment');
-        $this->assertEquals($method->invoke(new Tracer(), app('App\Something\Tag')), 'Something\Tag');
+        $this->assertEquals($method->invoke(new Tracer, app('App\Comment')), 'Comment');
+        $this->assertEquals($method->invoke(new Tracer, app('App\Something\Tag')), 'Something\Tag');
 
         // Models namespace
         config(['blueprint.models_namespace' => 'Models']);
 
-        $this->assertEquals($method->invoke(new Tracer(), app('App\Models\Comment')), 'Comment');
-        $this->assertEquals($method->invoke(new Tracer(), app('App\Something\Tag')), 'Something\Tag');
+        $this->assertEquals($method->invoke(new Tracer, app('App\Models\Comment')), 'Comment');
+        $this->assertEquals($method->invoke(new Tracer, app('App\Something\Tag')), 'Something\Tag');
     }
 
     public function it_passes_the_command_path_to_tracer()

--- a/tests/Feature/Generators/ComponentGeneratorTest.php
+++ b/tests/Feature/Generators/ComponentGeneratorTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Feature\Generators;
+
+use Blueprint\Blueprint;
+use Blueprint\Generators\ComponentGenerator;
+use Blueprint\Lexers\StatementLexer;
+use Blueprint\Tree;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see ComponentGenerator
+ */
+final class ComponentGeneratorTest extends TestCase
+{
+    private $blueprint;
+
+    /** @var ComponentGenerator */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new ComponentGenerator($this->filesystem);
+
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ComponentLexer(new StatementLexer));
+        $this->blueprint->registerGenerator($this->subject);
+    }
+
+    #[Test]
+    public function output_writes_nothing_for_empty_tree(): void
+    {
+        $this->filesystem->expects('stub')
+            ->with('livewire.class.stub')
+            ->andReturn($this->stub('livewire.class.stub'));
+
+        $this->assertEquals([], $this->subject->output(new Tree(['components' => []])));
+
+        $this->filesystem->shouldNotHaveReceived('put');
+    }
+
+    #[Test]
+    #[DataProvider('componentTreeDataProvider')]
+    public function output_generates_components_for_tree($definition, $paths, $component): void
+    {
+        $this->filesystem->expects('stub')
+            ->with('livewire.class.stub')
+            ->andReturn($this->stub('livewire.class.stub'));
+        $this->filesystem->expects('stub')
+            ->with('livewire.method.stub')
+            ->andReturn($this->stub('livewire.method.stub'));
+
+        $view = $this->stub('livewire.view.stub');
+        $this->filesystem->expects('stub')
+            ->with('livewire.view.stub')
+            ->andReturn($view);
+
+        $this->filesystem->expects('exists')
+            ->with(dirname($paths[0]))
+            ->andReturnTrue();
+        $this->filesystem->expects('put')
+            ->with($paths[0], $this->fixture($component));
+        $this->filesystem->expects('exists')
+            ->with(dirname($paths[1]))
+            ->andReturnTrue();
+        $this->filesystem->expects('put')
+            ->with($paths[1], $view);
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+        $this->assertEquals(['created' => $paths], $this->subject->output($tree));
+    }
+
+    #[Test]
+    public function output_generates_components_with_models_using_custom_namespace(): void
+    {
+        $this->markTestIncomplete('This test has not been implemented yet.');
+
+        $definition = 'drafts/custom-models-namespace.yaml';
+        $path = 'app/Http/Controllers/TagController.php';
+        $component = 'components/custom-models-namespace.php';
+
+        $this->app['config']->set('blueprint.models_namespace', 'Models');
+
+        $this->filesystem->expects('stub')
+            ->with('livewire.class.stub')
+            ->andReturn($this->stub('livewire.class.stub'));
+        $this->filesystem->expects('stub')
+            ->with('livewire.method.stub')
+            ->andReturn($this->stub('livewire.method.stub'));
+
+        $this->filesystem->expects('exists')
+            ->with(dirname($path))
+            ->andReturnTrue();
+        $this->filesystem->expects('put')
+            ->with($path, $this->fixture($component));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
+    #[Test]
+    public function output_respects_configuration(): void
+    {
+        $this->markTestIncomplete('This test has not been implemented yet.');
+
+        $this->app['config']->set('blueprint.app_path', 'src/path');
+        $this->app['config']->set('blueprint.namespace', 'Some\\App');
+        $this->app['config']->set('blueprint.components_namespace', 'Other\\Http');
+
+        $this->filesystem->expects('stub')
+            ->with('livewire.class.stub')
+            ->andReturn($this->stub('livewire.class.stub'));
+        $this->filesystem->expects('stub')
+            ->with('livewire.method.stub')
+            ->andReturn($this->stub('livewire.method.stub'));
+
+        $this->filesystem->expects('exists')
+            ->with('src/path/Other/Http')
+            ->andReturnFalse();
+        $this->filesystem->expects('makeDirectory')
+            ->with('src/path/Other/Http', 0755, true);
+        $this->filesystem->expects('put')
+            ->with('src/path/Other/Http/UserController.php', $this->fixture('components/component-configured.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/simple-component.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['src/path/Other/Http/UserController.php']], $this->subject->output($tree));
+    }
+
+    public static function componentTreeDataProvider(): array
+    {
+        return [
+            ['drafts/livewire-simple.yaml', ['app/Livewire/SimpleComponent.php', 'resources/views/livewire/simple-component.blade.php'], 'components/simple.php'],
+            ['drafts/livewire-with-properties.yaml', ['app/Livewire/UpdateProfile.php', 'resources/views/livewire/update-profile.blade.php'], 'components/with-properties.php'],
+            ['drafts/livewire-properties-statements.yaml', ['app/Livewire/UpdateProfile.php', 'resources/views/livewire/update-profile.blade.php'], 'components/properties-statements.php'],
+        ];
+    }
+}

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -26,9 +26,9 @@ final class ControllerGeneratorTest extends TestCase
 
         $this->subject = new ControllerGenerator($this->filesystem);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/FactoryGeneratorTest.php
+++ b/tests/Feature/Generators/FactoryGeneratorTest.php
@@ -28,8 +28,8 @@ final class FactoryGeneratorTest extends TestCase
         $this->factoryStub = 'factory.stub';
         $this->subject = new FactoryGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -29,8 +29,8 @@ final class MigrationGeneratorTest extends TestCase
 
         $this->subject = new MigrationGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -24,8 +24,8 @@ final class ModelGeneratorTest extends TestCase
 
         $this->subject = new ModelGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/PestTestGeneratorTest.php
+++ b/tests/Feature/Generators/PestTestGeneratorTest.php
@@ -26,9 +26,9 @@ final class PestTestGeneratorTest extends TestCase
 
         $this->subject = new PestTestGenerator($this->filesystem);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/PhpUnitTestGeneratorTest.php
+++ b/tests/Feature/Generators/PhpUnitTestGeneratorTest.php
@@ -26,9 +26,9 @@ final class PhpUnitTestGeneratorTest extends TestCase
 
         $this->subject = new PhpUnitTestGenerator($this->filesystem);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/PolicyGeneratorTest.php
+++ b/tests/Feature/Generators/PolicyGeneratorTest.php
@@ -25,9 +25,9 @@ final class PolicyGeneratorTest extends TestCase
 
         $this->subject = new PolicyGenerator($this->filesystem);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/RouteGeneratorTest.php
+++ b/tests/Feature/Generators/RouteGeneratorTest.php
@@ -28,8 +28,8 @@ final class RouteGeneratorTest extends TestCase
 
         $this->subject = new RouteGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/SeederGeneratorTest.php
+++ b/tests/Feature/Generators/SeederGeneratorTest.php
@@ -30,9 +30,9 @@ final class SeederGeneratorTest extends TestCase
         $this->seederStub = 'seeder.stub';
         $this->subject = new SeederGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\SeederLexer());
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\SeederLexer);
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/Statements/EventGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/EventGeneratorTest.php
@@ -27,8 +27,8 @@ final class EventGeneratorTest extends TestCase
 
         $this->subject = new EventGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/Statements/FormRequestGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/FormRequestGeneratorTest.php
@@ -27,9 +27,9 @@ final class FormRequestGeneratorTest extends TestCase
 
         $this->subject = new FormRequestGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/Statements/JobGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/JobGeneratorTest.php
@@ -27,8 +27,8 @@ final class JobGeneratorTest extends TestCase
 
         $this->subject = new JobGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/Statements/MailGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/MailGeneratorTest.php
@@ -27,8 +27,8 @@ final class MailGeneratorTest extends TestCase
 
         $this->subject = new MailGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/Statements/NotificationGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/NotificationGeneratorTest.php
@@ -28,8 +28,8 @@ final class NotificationGeneratorTest extends TestCase
 
         $this->subject = new NotificationGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/ResourceGeneratorTest.php
@@ -27,9 +27,9 @@ final class ResourceGeneratorTest extends TestCase
 
         $this->subject = new ResourceGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer());
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ModelLexer);
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Generators/Statements/ViewGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/ViewGeneratorTest.php
@@ -27,8 +27,8 @@ final class ViewGeneratorTest extends TestCase
 
         $this->subject = new ViewGenerator($this->files);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new \Blueprint\Lexers\ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->subject);
     }
 

--- a/tests/Feature/Lexers/ComponentLexerTest.php
+++ b/tests/Feature/Lexers/ComponentLexerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Feature\Lexers;
+
+use Blueprint\Lexers\ComponentLexer;
+use Blueprint\Lexers\StatementLexer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see ComponentLexer
+ */
+final class ComponentLexerTest extends TestCase
+{
+    /**
+     * @var ComponentLexer
+     */
+    private $subject;
+
+    /**
+     * @var \Mockery\MockInterface
+     */
+    private $statementLexer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->statementLexer = \Mockery::mock(StatementLexer::class);
+
+        $this->subject = new ComponentLexer($this->statementLexer);
+    }
+
+    #[Test]
+    public function it_returns_nothing_without_components_token(): void
+    {
+        $this->assertEquals([
+            'components' => [],
+        ], $this->subject->analyze([]));
+    }
+
+    #[Test]
+    public function it_returns_components(): void
+    {
+        $tokens = [
+            'components' => [
+                'UpdateProfile' => [
+                    'mount' => 'user, dashboard_url',
+                    'update' => [
+                        'validate' => 'user',
+                        'dispatch' => 'ProfileUpdated with:user',
+                        'redirect' => 'dashboard_url',
+                    ],
+                ],
+                'OverrideComponent' => [
+                    'render' => [
+                        'render' => 'custom.view',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->statementLexer->shouldReceive('analyze')
+            ->with([
+                'validate' => 'user',
+                'dispatch' => 'ProfileUpdated with:user',
+                'redirect' => 'dashboard_url',
+            ])
+            ->andReturn(['validate-statement', 'dispatch-statement', 'redirect-statement']);
+        $this->statementLexer->shouldReceive('analyze')
+            ->with(['render' => 'livewire.update-profile'])
+            ->andReturn(['render-statement']);
+        $this->statementLexer->shouldReceive('analyze')
+            ->with(['render' => 'custom.view'])
+            ->andReturn(['custom-render-statement']);
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertCount(2, $actual['components']);
+
+        $component = $actual['components']['UpdateProfile'];
+        $this->assertEquals('UpdateProfile', $component->name());
+
+        $properties = $component->properties();
+        $this->assertCount(2, $properties);
+        $this->assertArrayHasKey('user', $properties);
+        $this->assertArrayHasKey('dashboard_url', $properties);
+
+        $methods = $component->methods();
+        $this->assertCount(2, $methods);
+
+        $this->assertCount(3, $methods['update']);
+        $this->assertEquals('validate-statement', $methods['update'][0]);
+        $this->assertEquals('dispatch-statement', $methods['update'][1]);
+        $this->assertEquals('redirect-statement', $methods['update'][2]);
+
+        $this->assertCount(1, $methods['render']);
+        $this->assertEquals('render-statement', $methods['render'][0]);
+
+        $component = $actual['components']['OverrideComponent'];
+        $this->assertEquals('OverrideComponent', $component->name());
+
+        $properties = $component->properties();
+        $this->assertCount(0, $properties);
+
+        $methods = $component->methods();
+        $this->assertCount(1, $methods);
+
+        $this->assertCount(1, $methods['render']);
+        $this->assertEquals('custom-render-statement', $methods['render'][0]);
+    }
+}

--- a/tests/Feature/Lexers/ConfigLexerTest.php
+++ b/tests/Feature/Lexers/ConfigLexerTest.php
@@ -28,15 +28,15 @@ final class ConfigLexerTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = new ConfigLexer();
+        $this->subject = new ConfigLexer;
 
         $this->modelGenerator = new ModelGenerator($this->filesystem);
         $this->controllerGenerator = new ControllerGenerator($this->filesystem);
 
-        $this->blueprint = new Blueprint();
-        $this->blueprint->registerLexer(new ModelLexer());
-        $this->blueprint->registerLexer(new ConfigLexer());
-        $this->blueprint->registerLexer(new ControllerLexer(new StatementLexer()));
+        $this->blueprint = new Blueprint;
+        $this->blueprint->registerLexer(new ModelLexer);
+        $this->blueprint->registerLexer(new ConfigLexer);
+        $this->blueprint->registerLexer(new ControllerLexer(new StatementLexer));
         $this->blueprint->registerGenerator($this->modelGenerator);
     }
 

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -15,7 +15,7 @@ final class ModelLexerTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = new ModelLexer();
+        $this->subject = new ModelLexer;
     }
 
     #[Test]

--- a/tests/Feature/Lexers/SeederLexerTest.php
+++ b/tests/Feature/Lexers/SeederLexerTest.php
@@ -20,7 +20,7 @@ final class SeederLexerTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = new SeederLexer();
+        $this->subject = new SeederLexer;
     }
 
     #[Test]

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -32,7 +32,7 @@ final class StatementLexerTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = new StatementLexer();
+        $this->subject = new StatementLexer;
     }
 
     #[Test]

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -43,7 +43,7 @@ final class BuilderTest extends TestCase
         $this->filesystem->expects('put')
             ->with('.blueprint', 'cacheable blueprint content');
 
-        $actual = (new Builder())->execute($blueprint, $this->filesystem, 'draft.yaml');
+        $actual = (new Builder)->execute($blueprint, $this->filesystem, 'draft.yaml');
 
         $this->assertSame($generated, $actual);
     }
@@ -98,7 +98,7 @@ final class BuilderTest extends TestCase
         $this->filesystem->expects('put')
             ->with('.blueprint', 'cacheable blueprint content');
 
-        $actual = (new Builder())->execute($blueprint, $this->filesystem, 'draft.yaml');
+        $actual = (new Builder)->execute($blueprint, $this->filesystem, 'draft.yaml');
 
         $this->assertSame($generated, $actual);
     }
@@ -147,7 +147,7 @@ final class BuilderTest extends TestCase
         $this->filesystem->expects('put')
             ->with('.blueprint', 'cacheable blueprint content');
 
-        $actual = (new Builder())->execute($blueprint, $this->filesystem, 'draft.yaml');
+        $actual = (new Builder)->execute($blueprint, $this->filesystem, 'draft.yaml');
 
         $this->assertSame($generated, $actual);
     }

--- a/tests/fixtures/components/properties-statements.php
+++ b/tests/fixtures/components/properties-statements.php
@@ -38,7 +38,7 @@ class UpdateProfile extends Component
 
         return redirect()->route('user.show', [$this->user]);
 
-        return view('user.show', compact($this->user, $extra));
+        return view('user.show', compact('user', 'extra'));
 
         return new UserResource($this->user);
 

--- a/tests/fixtures/components/properties-statements.php
+++ b/tests/fixtures/components/properties-statements.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Events\ProfileUpdated;
+use App\Http\Resources\UserResource;
+use App\Jobs\UpdateProfile;
+use App\Mail\ReviewProfile;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\View\View;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class UpdateProfile extends Component
+{
+    #[Locked]
+    public $user;
+
+    public function mount($user): void
+    {
+        $this->user = $user;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.update-profile');
+    }
+
+    public function update()
+    {
+        UpdateProfile::dispatch($this->user);
+
+        ProfileUpdated::dispatch($this->user);
+
+        $request->session()->flash('user.name', $user->name);
+
+        $user->notify(new ReviewProfile($this->user));
+
+        return redirect()->route('user.show', [$this->user]);
+
+        return view('user.show', compact($this->user, $extra));
+
+        return new UserResource($user);
+
+        return $user;
+
+        Mail::to($user->email)->send(new ReviewProfile($this->user));
+
+        $request->session()->store('user.id', $user->id);
+    }
+}

--- a/tests/fixtures/components/properties-statements.php
+++ b/tests/fixtures/components/properties-statements.php
@@ -40,9 +40,9 @@ class UpdateProfile extends Component
 
         return view('user.show', compact($this->user, $extra));
 
-        return new UserResource($user);
+        return new UserResource($this->user);
 
-        return $user;
+        return $this->user;
 
         Mail::to($this->user->email)->send(new ReviewProfile($this->user));
 

--- a/tests/fixtures/components/properties-statements.php
+++ b/tests/fixtures/components/properties-statements.php
@@ -32,9 +32,9 @@ class UpdateProfile extends Component
 
         ProfileUpdated::dispatch($this->user);
 
-        $request->session()->flash('user.name', $user->name);
+        session()->flash('user.name', $this->user->name);
 
-        $user->notify(new ReviewProfile($this->user));
+        $this->user->notify(new ReviewProfile($this->user));
 
         return redirect()->route('user.show', [$this->user]);
 
@@ -44,8 +44,8 @@ class UpdateProfile extends Component
 
         return $user;
 
-        Mail::to($user->email)->send(new ReviewProfile($this->user));
+        Mail::to($this->user->email)->send(new ReviewProfile($this->user));
 
-        $request->session()->store('user.id', $user->id);
+        session()->store('user.id', $this->user->id);
     }
 }

--- a/tests/fixtures/components/simple.php
+++ b/tests/fixtures/components/simple.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Livewire;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+use Livewire\Component;
+
+class SimpleComponent extends Component
+{
+    public function render(): View
+    {
+        return view('livewire.simple-component');
+    }
+
+    public function action(): RedirectResponse
+    {
+        return redirect()->route('simple.page');
+    }
+}

--- a/tests/fixtures/components/with-properties.php
+++ b/tests/fixtures/components/with-properties.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Events\ProfileUpdated;
+use Illuminate\View\View;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class UpdateProfile extends Component
+{
+    #[Locked]
+    public $user;
+
+    public function mount($user): void
+    {
+        $this->user = $user;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.update-profile');
+    }
+
+    public function update()
+    {
+        ProfileUpdated::dispatch($this->user);
+    }
+}

--- a/tests/fixtures/drafts/components-only.yaml
+++ b/tests/fixtures/drafts/components-only.yaml
@@ -1,0 +1,11 @@
+components:
+  UpdateProfile:
+    mount: user, dashboard_url
+    update:
+      action: detail
+      another_action: so much detail
+    another_method:
+      some: action
+  AnotherComponent:
+    main:
+      action: reaction

--- a/tests/fixtures/drafts/livewire-properties-statements.yaml
+++ b/tests/fixtures/drafts/livewire-properties-statements.yaml
@@ -2,6 +2,7 @@ components:
   UpdateProfile:
     mount: user
     update:
+#      validate: user
       dispatch: UpdateProfile with:user
 #      find: user
       fire: ProfileUpdated with:user

--- a/tests/fixtures/drafts/livewire-properties-statements.yaml
+++ b/tests/fixtures/drafts/livewire-properties-statements.yaml
@@ -1,0 +1,19 @@
+components:
+  UpdateProfile:
+    mount: user
+    update:
+      dispatch: UpdateProfile with:user
+#      find: user
+      fire: ProfileUpdated with:user
+      flash: user.name
+      notify: user ReviewProfile with:user
+      redirect: user.show with:user
+      render: user.show with:user,extra
+      resource: user
+      respond: user
+#      save: user
+#      delete: user
+      send: ReviewProfile to:user.email with:user
+      store: user.id
+#      update: user
+#      query: where:title where:content order:published_at limit:5

--- a/tests/fixtures/drafts/livewire-simple.yaml
+++ b/tests/fixtures/drafts/livewire-simple.yaml
@@ -1,0 +1,4 @@
+components:
+  SimpleComponent:
+    action:
+      redirect: simple.page

--- a/tests/fixtures/drafts/livewire-with-properties.yaml
+++ b/tests/fixtures/drafts/livewire-with-properties.yaml
@@ -1,0 +1,5 @@
+components:
+  UpdateProfile:
+    mount: user
+    update:
+      fire: ProfileUpdated with:user


### PR DESCRIPTION
This adds basic Livewire component generation to Blueprint.

At the time of merge it supports generating a component with mounted properties and using most of the [controller statements](https://blueprint.laravelshift.com/docs/controller-statements/).

Here's an example `draft.yaml` for generating a Livewire component:
```yaml
components:
  UpdateProfile:
    mount: user
    update:
      fire: ProfileUpdated with:user
```

Here's the generated Livewire component class:
```php
<?php

namespace App\Livewire;

use App\Events\ProfileUpdated;
use Illuminate\View\View;
use Livewire\Attributes\Locked;
use Livewire\Component;

class UpdateProfile extends Component
{
    #[Locked]
    public $user;

    public function mount($user): void
    {
        $this->user = $user;
    }

    public function render(): View
    {
        return view('livewire.update-profile');
    }

    public function update()
    {
        ProfileUpdated::dispatch($this->user);
    }
}
```

Just like generating a controller with Blueprint, the Blade template (`livewire/update-profile.blade.php`) and associated classes for any statements are generated. In this case, the `ProfileUpdated` event.

Again, this is _basic_ generation. Generating the corresponding test and several controller statements (`validate`, `find`, `save`, `delete`, `update`, `query`) are still _todo_. However, I figured some generation is better than nothing.

This additional generation will be completed before the next release is tagged. If you want to generate Livewire components with Blueprint, you may set your constraint to `dev-master`.