### PR TITLE
Modernize view data syntax

### DIFF
--- a/src/Models/Statements/RenderStatement.php
+++ b/src/Models/Statements/RenderStatement.php
@@ -45,7 +45,8 @@ class RenderStatement
                 $parameter,
                 PHP_EOL
             ),
-            $this->data());
+            $this->data()
+        );
 
         return sprintf(
             '[%s%s%s]',

--- a/src/Models/Statements/RenderStatement.php
+++ b/src/Models/Statements/RenderStatement.php
@@ -16,17 +16,12 @@ class RenderStatement
         $this->data = $data;
     }
 
-    public function view(): string
-    {
-        return $this->view;
-    }
-
     public function output(): string
     {
         $code = "return view('" . $this->view() . "'";
 
         if ($this->data()) {
-            $code .= ', compact(' . $this->buildParameters() . ')';
+            $code .= ', ' . $this->buildParameters();
         }
 
         $code .= ');';
@@ -34,10 +29,29 @@ class RenderStatement
         return $code;
     }
 
+    public function view(): string
+    {
+        return $this->view;
+    }
+
     private function buildParameters(): string
     {
-        $parameters = array_map(fn ($parameter) => "'" . $parameter . "'", $this->data());
+        $parameters = array_map(
+            fn ($parameter) => sprintf(
+                "%s'%s' => \$%s%s,%s",
+                str_pad(' ', 12),
+                $parameter,
+                in_array($parameter, $this->properties()) ? 'this->' : '',
+                $parameter,
+                PHP_EOL
+            ),
+            $this->data());
 
-        return implode(', ', $parameters);
+        return sprintf(
+            '[%s%s%s]',
+            PHP_EOL,
+            implode($parameters),
+            str_pad(' ', 8)
+        );
     }
 }

--- a/tests/fixtures/components/properties-statements.php
+++ b/tests/fixtures/components/properties-statements.php
@@ -38,7 +38,10 @@ class UpdateProfile extends Component
 
         return redirect()->route('user.show', [$this->user]);
 
-        return view('user.show', compact('user', 'extra'));
+        return view('user.show', [
+            'user' => $this->user,
+            'extra' => $extra,
+        ]);
 
         return new UserResource($this->user);
 

--- a/tests/fixtures/controllers/controller-configured.php
+++ b/tests/fixtures/controllers/controller-configured.php
@@ -15,7 +15,9 @@ class UserController extends Controller
     {
         $users = User::all();
 
-        return view('user.index', compact('users'));
+        return view('user.index', [
+            'users' => $users,
+        ]);
     }
 
     public function store(UserStoreRequest $request): RedirectResponse

--- a/tests/fixtures/controllers/crazy-eloquent.php
+++ b/tests/fixtures/controllers/crazy-eloquent.php
@@ -13,14 +13,18 @@ class PostController extends Controller
     {
         $posts = Post::where('title', $title)->where('content', $content)->orderBy('published_at')->limit(5)->get();
 
-        return view('post.index', compact('posts'));
+        return view('post.index', [
+            'posts' => $posts,
+        ]);
     }
 
     public function edit(Request $request, Post $post): View
     {
         $post = Post::find($id);
 
-        return view('post.edit', compact('post'));
+        return view('post.edit', [
+            'post' => $post,
+        ]);
     }
 
     public function update(Request $request, Post $post): RedirectResponse

--- a/tests/fixtures/controllers/nested-components.php
+++ b/tests/fixtures/controllers/nested-components.php
@@ -19,7 +19,9 @@ class UserController extends Controller
     {
         $users = User::all();
 
-        return view('admin.user.index', compact('users'));
+        return view('admin.user.index', [
+            'users' => $users,
+        ]);
     }
 
     public function store(UserStoreRequest $request): RedirectResponse

--- a/tests/fixtures/controllers/readme-example-notification-facade.php
+++ b/tests/fixtures/controllers/readme-example-notification-facade.php
@@ -18,7 +18,9 @@ class PostController extends Controller
     {
         $posts = Post::all();
 
-        return view('post.index', compact('posts'));
+        return view('post.index', [
+            'posts' => $posts,
+        ]);
     }
 
     public function store(PostStoreRequest $request): RedirectResponse

--- a/tests/fixtures/controllers/readme-example-notification-model.php
+++ b/tests/fixtures/controllers/readme-example-notification-model.php
@@ -16,7 +16,9 @@ class PostController extends Controller
     {
         $posts = Post::all();
 
-        return view('post.index', compact('posts'));
+        return view('post.index', [
+            'posts' => $posts,
+        ]);
     }
 
     public function store(PostStoreRequest $request): RedirectResponse

--- a/tests/fixtures/controllers/readme-example.php
+++ b/tests/fixtures/controllers/readme-example.php
@@ -18,7 +18,9 @@ class PostController extends Controller
     {
         $posts = Post::all();
 
-        return view('post.index', compact('posts'));
+        return view('post.index', [
+            'posts' => $posts,
+        ]);
     }
 
     public function store(PostStoreRequest $request): RedirectResponse

--- a/tests/fixtures/controllers/with-all-policies.php
+++ b/tests/fixtures/controllers/with-all-policies.php
@@ -17,7 +17,9 @@ class PostController extends Controller
 
         $posts = Post::all();
 
-        return view('post.index', compact('posts'));
+        return view('post.index', [
+            'posts' => $posts,
+        ]);
     }
 
     public function create(Request $request): View
@@ -43,14 +45,18 @@ class PostController extends Controller
     {
         $this->authorize('show', $post);
 
-        return view('post.show', compact('post'));
+        return view('post.show', [
+            'post' => $post,
+        ]);
     }
 
     public function edit(Request $request, Post $post): View
     {
         $this->authorize('edit', $post);
 
-        return view('post.edit', compact('post'));
+        return view('post.edit', [
+            'post' => $post,
+        ]);
     }
 
     public function update(PostUpdateRequest $request, Post $post): RedirectResponse

--- a/tests/fixtures/controllers/with-authorize-resource.php
+++ b/tests/fixtures/controllers/with-authorize-resource.php
@@ -20,7 +20,9 @@ class PostController extends Controller
     {
         $posts = Post::all();
 
-        return view('post.index', compact('posts'));
+        return view('post.index', [
+            'posts' => $posts,
+        ]);
     }
 
     public function create(Request $request): View
@@ -39,12 +41,16 @@ class PostController extends Controller
 
     public function show(Request $request, Post $post): View
     {
-        return view('post.show', compact('post'));
+        return view('post.show', [
+            'post' => $post,
+        ]);
     }
 
     public function edit(Request $request, Post $post): View
     {
-        return view('post.edit', compact('post'));
+        return view('post.edit', [
+            'post' => $post,
+        ]);
     }
 
     public function update(PostUpdateRequest $request, Post $post): RedirectResponse

--- a/tests/fixtures/controllers/with-some-policies.php
+++ b/tests/fixtures/controllers/with-some-policies.php
@@ -17,7 +17,9 @@ class PostController extends Controller
 
         $posts = Post::all();
 
-        return view('post.index', compact('posts'));
+        return view('post.index', [
+            'posts' => $posts,
+        ]);
     }
 
     public function create(Request $request): View
@@ -38,12 +40,16 @@ class PostController extends Controller
     {
         $this->authorize('show', $post);
 
-        return view('post.show', compact('post'));
+        return view('post.show', [
+            'post' => $post,
+        ]);
     }
 
     public function edit(Request $request, Post $post): View
     {
-        return view('post.edit', compact('post'));
+        return view('post.edit', [
+            'post' => $post,
+        ]);
     }
 
     public function update(PostUpdateRequest $request, Post $post): RedirectResponse


### PR DESCRIPTION
Blueprint used `compact` when generating code to pass `view` data. This was really for ease of output and not necessarily convention. In fact, when it comes to view data, Laravel has no documented examples using `compact`. So its use is really just a legacy convention likely from the broader PHP community.

Splitting this out into the full array allows this statement to do more. For example, inline statements or support new code generation for Livewire.