### PR TITLE
Use `Gate` facade directly

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -108,9 +108,10 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
                             '$' . Str::camel($controllerModelName),
                         ],
                         in_array($name, ['index', 'create', 'store'])
-                            ? "\$this->authorize('{{ method }}', {{ modelClass }}::class);"
-                            : "\$this->authorize('{{ method }}', {{ modelVariable }});"
+                            ? "Gate::authorize('{{ method }}', {{ modelClass }}::class);"
+                            : "Gate::authorize('{{ method }}', {{ modelVariable }});"
                     ) . PHP_EOL . PHP_EOL;
+                    $this->addImport($controller, 'Illuminate\Support\Facades\Gate');
                 }
             }
 

--- a/tests/fixtures/controllers/with-all-policies.php
+++ b/tests/fixtures/controllers/with-all-policies.php
@@ -7,13 +7,14 @@ use App\Http\Requests\PostUpdateRequest;
 use App\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 
 class PostController extends Controller
 {
     public function index(Request $request): View
     {
-        $this->authorize('index', Post::class);
+        Gate::authorize('index', Post::class);
 
         $posts = Post::all();
 
@@ -24,14 +25,14 @@ class PostController extends Controller
 
     public function create(Request $request): View
     {
-        $this->authorize('create', Post::class);
+        Gate::authorize('create', Post::class);
 
         return view('post.create');
     }
 
     public function store(PostStoreRequest $request): RedirectResponse
     {
-        $this->authorize('store', Post::class);
+        Gate::authorize('store', Post::class);
 
 
         $post = Post::create($request->validated());
@@ -43,7 +44,7 @@ class PostController extends Controller
 
     public function show(Request $request, Post $post): View
     {
-        $this->authorize('show', $post);
+        Gate::authorize('show', $post);
 
         return view('post.show', [
             'post' => $post,
@@ -52,7 +53,7 @@ class PostController extends Controller
 
     public function edit(Request $request, Post $post): View
     {
-        $this->authorize('edit', $post);
+        Gate::authorize('edit', $post);
 
         return view('post.edit', [
             'post' => $post,
@@ -61,7 +62,7 @@ class PostController extends Controller
 
     public function update(PostUpdateRequest $request, Post $post): RedirectResponse
     {
-        $this->authorize('update', $post);
+        Gate::authorize('update', $post);
 
 
         $post->update($request->validated());
@@ -73,7 +74,7 @@ class PostController extends Controller
 
     public function destroy(Request $request, Post $post): RedirectResponse
     {
-        $this->authorize('destroy', $post);
+        Gate::authorize('destroy', $post);
 
         $post->delete();
 

--- a/tests/fixtures/controllers/with-some-policies.php
+++ b/tests/fixtures/controllers/with-some-policies.php
@@ -7,13 +7,14 @@ use App\Http\Requests\PostUpdateRequest;
 use App\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 
 class PostController extends Controller
 {
     public function index(Request $request): View
     {
-        $this->authorize('index', Post::class);
+        Gate::authorize('index', Post::class);
 
         $posts = Post::all();
 
@@ -38,7 +39,7 @@ class PostController extends Controller
 
     public function show(Request $request, Post $post): View
     {
-        $this->authorize('show', $post);
+        Gate::authorize('show', $post);
 
         return view('post.show', [
             'post' => $post,


### PR DESCRIPTION
Laravel 11 has marked the "base controller" as `abstract` and no longer includes the previous traits. As such, methods like `middleware`, 'validate`, `authorize`, etc are no longer available.

Currently, Blueprint only uses `authorize` and `authorizeResource` methods. This PR updates the former to use the `Gate` facade directly to avoid errors in Laravel 11 (#701).

**Note**: There does not seem to be an equivalent for `authorizeResource` on `Gate`. For now, this is left as `$this->authorizeResource` for compatibility with Laravel 10. If you require this method in a Laravel 11 app, you may import the `AuthorizeResource` trait in your controller. However, this trait and method do not appear to be use within Laravel and may be removed in future versions of Laravel and Blueprint.