### PR TITLE
Output new Laravel 11 geo column types

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -152,6 +152,10 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
             if (!empty($columnAttributes) && !$this->isIdColumnType($column->dataType())) {
                 $column_definition .= ', ';
 
+                if (in_array($column->dataType(), ['geography', 'geometry'])) {
+                    $columnAttributes[0] = Str::wrap($columnAttributes[0], "'");
+                }
+
                 if (in_array($column->dataType(), ['set', 'enum'])) {
                     $column_definition .= json_encode($columnAttributes);
                 } else {

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -36,6 +36,7 @@ class ModelLexer implements Lexer
         'enum' => 'enum',
         'float' => 'float',
         'fulltext' => 'fullText',
+        'geography' => 'geography',
         'geometry' => 'geometry',
         'geometrycollection' => 'geometryCollection',
         'increments' => 'increments',

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -646,6 +646,7 @@ final class MigrationGeneratorTest extends TestCase
             ['drafts/foreign-key-on-delete.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/foreign-key-on-delete.php'],
             ['drafts/nullable-columns-with-foreign.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/nullable-columns-with-foreign.php'],
             ['drafts/omits-length-for-integers.yaml', 'database/migrations/timestamp_create_omits_table.php', 'migrations/omits-length-for-integers.php'],
+            ['drafts/geometry-columns.yaml', 'database/migrations/timestamp_create_locations_table.php', 'migrations/geometry-columns.php'],
         ];
     }
 }

--- a/tests/fixtures/drafts/geometry-columns.yaml
+++ b/tests/fixtures/drafts/geometry-columns.yaml
@@ -1,0 +1,7 @@
+models:
+  Location:
+    name:  string:100
+    description: text nullable
+    coordinates: geography:point,4326
+    positions: geometry:point,0
+

--- a/tests/fixtures/migrations/geometry-columns.php
+++ b/tests/fixtures/migrations/geometry-columns.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('locations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->text('description')->nullable();
+            $table->geography('coordinates', 'point', 4326);
+            $table->geometry('positions', 'point', 0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('locations');
+    }
+};


### PR DESCRIPTION
This adds support to properly generate the migrations using `geometry` and `geography` types in Laravel 11 applications.

```yaml
models:
  Example:
    coordinates: geography:point,4326
    positions: geometry:point,0
```

**Note**: while Blueprint will generate code using these types for a Laravel 10 application Laravel may no recognize them. You should use the [old data types](https://laravel.com/docs/10.x/migrations#available-column-types) in your Laravel 10 applications.