### PR TITLE
Support new `inertia` controller statement

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -10,6 +10,7 @@ use Blueprint\Models\Policy;
 use Blueprint\Models\Statements\DispatchStatement;
 use Blueprint\Models\Statements\EloquentStatement;
 use Blueprint\Models\Statements\FireStatement;
+use Blueprint\Models\Statements\InertiaStatement;
 use Blueprint\Models\Statements\QueryStatement;
 use Blueprint\Models\Statements\RedirectStatement;
 use Blueprint\Models\Statements\RenderStatement;
@@ -174,6 +175,9 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
                 } elseif ($statement instanceof QueryStatement) {
                     $body .= self::INDENT . $statement->output($controller->prefix()) . PHP_EOL;
                     $this->addImport($controller, $this->determineModel($controller, $statement->model()));
+                } elseif ($statement instanceof InertiaStatement) {
+                    $body .= self::INDENT . $statement->output() . PHP_EOL;
+                    $this->addImport($controller, 'Inertia\Inertia');
                 }
 
                 $body .= PHP_EOL;
@@ -187,6 +191,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
                 $method = str_replace('): Response' . PHP_EOL, ')' . PHP_EOL, $method);
             } else {
                 $returnType = match (true) {
+                    $statement instanceof InertiaStatement => 'Inertia\Response',
                     $statement instanceof RenderStatement => 'Illuminate\View\View',
                     $statement instanceof RedirectStatement => 'Illuminate\Http\RedirectResponse',
                     $statement instanceof ResourceStatement => config('blueprint.namespace') . '\\Http\\Resources\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $statement->name(),

--- a/src/Lexers/StatementLexer.php
+++ b/src/Lexers/StatementLexer.php
@@ -6,6 +6,7 @@ use Blueprint\Contracts\Lexer;
 use Blueprint\Models\Statements\DispatchStatement;
 use Blueprint\Models\Statements\EloquentStatement;
 use Blueprint\Models\Statements\FireStatement;
+use Blueprint\Models\Statements\InertiaStatement;
 use Blueprint\Models\Statements\QueryStatement;
 use Blueprint\Models\Statements\RedirectStatement;
 use Blueprint\Models\Statements\RenderStatement;
@@ -24,24 +25,32 @@ class StatementLexer implements Lexer
 
         foreach ($tokens as $command => $statement) {
             $statements[] = match ($command) {
-                'query' => $this->analyzeQuery($statement),
-                'render' => $this->analyzeRender($statement),
-                'fire' => $this->analyzeEvent($statement),
                 'dispatch' => $this->analyzeDispatch($statement),
-                'send' => $this->analyzeSend($statement),
-                'notify' => $this->analyzeNotify($statement),
-                'validate' => $this->analyzeValidate($statement),
-                'redirect' => $this->analyzeRedirect($statement),
-                'respond' => $this->analyzeRespond($statement),
-                'resource' => $this->analyzeResource($statement),
-                'save', 'delete', 'find' => new EloquentStatement($command, $statement),
-                'update' => $this->analyzeUpdate($statement),
+                'fire' => $this->analyzeEvent($statement),
                 'flash', 'store' => new SessionStatement($command, $statement),
+                'inertia' => $this->analyzeInertia($statement),
+                'notify' => $this->analyzeNotify($statement),
+                'query' => $this->analyzeQuery($statement),
+                'redirect' => $this->analyzeRedirect($statement),
+                'render' => $this->analyzeRender($statement),
+                'resource' => $this->analyzeResource($statement),
+                'respond' => $this->analyzeRespond($statement),
+                'save', 'delete', 'find' => new EloquentStatement($command, $statement),
+                'send' => $this->analyzeSend($statement),
+                'update' => $this->analyzeUpdate($statement),
+                'validate' => $this->analyzeValidate($statement),
                 default => $this->analyzeDefault($command, $statement),
             };
         }
 
         return array_filter($statements);
+    }
+
+    private function analyzeInertia(string $statement): InertiaStatement
+    {
+        [$view, $data] = $this->parseWithStatement($statement);
+
+        return new InertiaStatement($view, $data);
     }
 
     private function analyzeRender(string $statement): RenderStatement

--- a/src/Models/Statements/InertiaStatement.php
+++ b/src/Models/Statements/InertiaStatement.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Blueprint\Models\Statements;
+
+use Blueprint\Concerns\HasParameters;
+
+class InertiaStatement
+{
+    use HasParameters;
+
+    private string $view;
+
+    public function __construct(string $view, array $data = [])
+    {
+        $this->view = $view;
+        $this->data = $data;
+    }
+
+    public function output(): string
+    {
+        $code = "return Inertia::render('" . $this->view() . "'";
+
+        if ($this->data()) {
+            $code .= ', ' . $this->buildParameters();
+        }
+
+        $code .= ');';
+
+        return $code;
+    }
+
+    public function view(): string
+    {
+        return $this->view;
+    }
+
+    private function buildParameters(): string
+    {
+        $parameters = array_map(
+            fn ($parameter) => sprintf(
+                "%s'%s' => \$%s%s,%s",
+                str_pad(' ', 12),
+                $parameter,
+                in_array($parameter, $this->properties()) ? 'this->' : '',
+                $parameter,
+                PHP_EOL
+            ),
+            $this->data()
+        );
+
+        return sprintf(
+            '[%s%s%s]',
+            PHP_EOL,
+            implode($parameters),
+            str_pad(' ', 8)
+        );
+    }
+}

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -241,6 +241,7 @@ final class ControllerGeneratorTest extends TestCase
             ['drafts/nested-components.yaml', 'app/Http/Controllers/Admin/UserController.php', 'controllers/nested-components.php'],
             ['drafts/respond-statements.yaml', 'app/Http/Controllers/Api/PostController.php', 'controllers/respond-statements.php'],
             ['drafts/resource-statements.yaml', 'app/Http/Controllers/UserController.php', 'controllers/resource-statements.php'],
+            ['drafts/inertia-render.yaml', 'app/Http/Controllers/CustomerController.php', 'controllers/inertia-render.php'],
             ['drafts/save-without-validation.yaml', 'app/Http/Controllers/PostController.php', 'controllers/save-without-validation.php'],
             ['drafts/api-resource-pagination.yaml', 'app/Http/Controllers/PostController.php', 'controllers/api-resource-pagination.php'],
             ['drafts/api-routes-example.yaml', 'app/Http/Controllers/Api/CertificateController.php', 'controllers/api-routes-example.php'],

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -6,6 +6,7 @@ use Blueprint\Lexers\StatementLexer;
 use Blueprint\Models\Statements\DispatchStatement;
 use Blueprint\Models\Statements\EloquentStatement;
 use Blueprint\Models\Statements\FireStatement;
+use Blueprint\Models\Statements\InertiaStatement;
 use Blueprint\Models\Statements\QueryStatement;
 use Blueprint\Models\Statements\RedirectStatement;
 use Blueprint\Models\Statements\RenderStatement;
@@ -68,6 +69,22 @@ final class StatementLexerTest extends TestCase
 
         $this->assertCount(1, $actual);
         $this->assertInstanceOf(RenderStatement::class, $actual[0]);
+
+        $this->assertEquals('post.index', $actual[0]->view());
+        $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
+    }
+
+    #[Test]
+    public function it_returns_an_inertia_statement_with_data(): void
+    {
+        $tokens = [
+            'inertia' => 'post.index with:foo,bar,baz',
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertCount(1, $actual);
+        $this->assertInstanceOf(InertiaStatement::class, $actual[0]);
 
         $this->assertEquals('post.index', $actual[0]->view());
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());

--- a/tests/fixtures/controllers/inertia-render.php
+++ b/tests/fixtures/controllers/inertia-render.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Customer;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class CustomerController extends Controller
+{
+    public function show(Request $request, Customer $customer): Response
+    {
+        $customers = Customer::all();
+
+        return Inertia::render('customer.show', [
+            'customer' => $customer,
+            'customers' => $customers,
+        ]);
+    }
+}

--- a/tests/fixtures/drafts/inertia-render.yaml
+++ b/tests/fixtures/drafts/inertia-render.yaml
@@ -1,0 +1,5 @@
+controllers:
+  Customer:
+    show:
+      query: all
+      inertia: customer.show with:customer,customers


### PR DESCRIPTION
As Blueprint now generates Livewire components, it seemed fitting to introduce at least something for Inertia. This adds a new `inertia` controller statement to render a page with data.

```yaml
controllers:
  Event:
    show:
      inertia: example.page with:event
```

Generates:

```php
use Inertia\Inertia;
use Inertia\Response;

class EventController extends Controller
{
    public function show(Event $event): Response
    {
        return Inertia::render('Event/Show', [
            'event' => $event,
        ]);

    // ...
}
```