### PR TITLE
Respect model namespace when guessing

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -222,7 +222,13 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
             return $model->fullyQualifiedClassName();
         }
 
-        return config('blueprint.namespace') . '\\' . ($sub_namespace ? $sub_namespace . '\\' : '') . $model_name;
+        return sprintf(
+            '%s\\%s%s%s',
+            config('blueprint.namespace'),
+            config('blueprint.models_namespace') ? config('blueprint.models_namespace') . '\\' : '',
+            $sub_namespace ? $sub_namespace . '\\' : '',
+            $model_name
+        );
     }
 
     private function determineModel(Controller $controller, ?string $reference): string

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -130,6 +130,7 @@ final class ControllerGeneratorTest extends TestCase
     {
         $this->app['config']->set('blueprint.app_path', 'src/path');
         $this->app['config']->set('blueprint.namespace', 'Some\\App');
+        $this->app['config']->set('blueprint.models_namespace', '');
         $this->app['config']->set('blueprint.controllers_namespace', 'Other\\Http');
 
         $this->filesystem->expects('stub')

--- a/tests/fixtures/controllers/inertia-render.php
+++ b/tests/fixtures/controllers/inertia-render.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Customer;
+use App\Models\Customer;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;

--- a/tests/fixtures/controllers/with-all-policies.php
+++ b/tests/fixtures/controllers/with-all-policies.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\PostStoreRequest;
 use App\Http\Requests\PostUpdateRequest;
-use App\Post;
+use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;

--- a/tests/fixtures/controllers/with-authorize-resource.php
+++ b/tests/fixtures/controllers/with-authorize-resource.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\PostStoreRequest;
 use App\Http\Requests\PostUpdateRequest;
-use App\Post;
+use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;

--- a/tests/fixtures/controllers/with-some-policies.php
+++ b/tests/fixtures/controllers/with-some-policies.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\PostStoreRequest;
 use App\Http\Requests\PostUpdateRequest;
-use App\Post;
+use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;

--- a/tests/fixtures/drafts/controller-configured.yaml
+++ b/tests/fixtures/drafts/controller-configured.yaml
@@ -13,4 +13,5 @@ controllers:
 config:
   app_path: shift
   namespace: Some\App
+  models_namespace: null
   controllers_namespace: Other\Http


### PR DESCRIPTION
There were a few areas where the configured `model_namespace` was not being respected when Blueprint "guessed" model references. This corrects that bug fixing #702.