### PR TITLE
Correct form request name

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -128,7 +128,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
                     }
                 } elseif ($statement instanceof ValidateStatement) {
                     $using_validation = true;
-                    $class_name = $controller->name() . Str::studly($name) . 'Request';
+                    $class_name = Str::singular($controller->prefix()) . Str::studly($name) . 'Request';
 
                     $fqcn = config('blueprint.namespace') . '\\Http\\Requests\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $class_name;
 

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -239,6 +239,7 @@ final class ControllerGeneratorTest extends TestCase
             ['drafts/readme-example-notification-facade.yaml', 'app/Http/Controllers/PostController.php', 'controllers/readme-example-notification-facade.php'],
             ['drafts/readme-example-notification-model.yaml', 'app/Http/Controllers/PostController.php', 'controllers/readme-example-notification-model.php'],
             ['drafts/crazy-eloquent.yaml', 'app/Http/Controllers/PostController.php', 'controllers/crazy-eloquent.php'],
+            ['drafts/longhand-controller-name.yaml', 'app/Http/Controllers/UserController.php', 'controllers/longhand-controller-name.php'],
             ['drafts/nested-components.yaml', 'app/Http/Controllers/Admin/UserController.php', 'controllers/nested-components.php'],
             ['drafts/respond-statements.yaml', 'app/Http/Controllers/Api/PostController.php', 'controllers/respond-statements.php'],
             ['drafts/resource-statements.yaml', 'app/Http/Controllers/UserController.php', 'controllers/resource-statements.php'],

--- a/tests/fixtures/controllers/longhand-controller-name.php
+++ b/tests/fixtures/controllers/longhand-controller-name.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UserStoreRequest;
+use App\Http\Requests\UserUpdateRequest;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function store(UserStoreRequest $request): RedirectResponse
+    {
+        $user = User::create($request->validated());
+
+        return redirect()->route('backend.users.show');
+    }
+
+    public function update(UserUpdateRequest $request, User $user): RedirectResponse
+    {
+        $user->update($request->validated());
+
+        $request->session()->flash('user.id', $user->id);
+
+        return redirect()->route('user.index');
+    }
+}

--- a/tests/fixtures/drafts/longhand-controller-name.yaml
+++ b/tests/fixtures/drafts/longhand-controller-name.yaml
@@ -1,0 +1,11 @@
+controllers:
+  UserController:
+    store:
+      validate: user
+      save: user
+      redirect: backend.users.show
+    update:
+      validate: user
+      update: user
+      flash: user.id
+      redirect: user.index


### PR DESCRIPTION
Blueprint would generate an incorrect reference to the generated form request when the defining a _longhand_ controller name. For example, `UserController` instead of simply `User`.

Closes #703