### PR TITLE
Update new Inertia tests to follow naming convention

### DIFF
--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -78,7 +78,7 @@ final class StatementLexerTest extends TestCase
     public function it_returns_an_inertia_statement_with_data(): void
     {
         $tokens = [
-            'inertia' => 'post.index with:foo,bar,baz',
+            'inertia' => 'Post/Index with:foo,bar,baz',
         ];
 
         $actual = $this->subject->analyze($tokens);
@@ -86,7 +86,7 @@ final class StatementLexerTest extends TestCase
         $this->assertCount(1, $actual);
         $this->assertInstanceOf(InertiaStatement::class, $actual[0]);
 
-        $this->assertEquals('post.index', $actual[0]->view());
+        $this->assertEquals('Post/Index', $actual[0]->view());
         $this->assertEquals(['foo', 'bar', 'baz'], $actual[0]->data());
     }
 

--- a/tests/fixtures/controllers/inertia-render.php
+++ b/tests/fixtures/controllers/inertia-render.php
@@ -13,7 +13,7 @@ class CustomerController extends Controller
     {
         $customers = Customer::all();
 
-        return Inertia::render('customer.show', [
+        return Inertia::render('Customer/Show', [
             'customer' => $customer,
             'customers' => $customers,
         ]);

--- a/tests/fixtures/drafts/inertia-render.yaml
+++ b/tests/fixtures/drafts/inertia-render.yaml
@@ -2,4 +2,4 @@ controllers:
   Customer:
     show:
       query: all
-      inertia: customer.show with:customer,customers
+      inertia: Customer/Show with:customer,customers


### PR DESCRIPTION
When I'm going through a project, I like to read the tests as a form of documentation.  This PR updates the tests that were created for the new Inertia support to follow the Inertia naming convention to make it clearer how to use the new feature in that specific context.