### PR TITLE
Fix `exists` rule for foreign key column indicating table name

### DIFF
--- a/src/Translators/Rules.php
+++ b/src/Translators/Rules.php
@@ -37,8 +37,8 @@ class Rules
         }
 
         if ($column->dataType() === 'id' && ($column->attributes() || Str::endsWith($column->name(), '_id'))) {
-            $reference = $column->attributes()[0] ?? Str::beforeLast($column->name(), '_id');
-            $rules = array_merge($rules, ['integer', 'exists:' . Str::plural($reference) . ',id']);
+            $table = $column->modifiers()[0]['foreign'] ?? Str::plural($column->attributes()[0] ?? Str::beforeLast($column->name(), '_id'));
+            $rules = array_merge($rules, ['integer', 'exists:' . $table . ',id']);
         }
 
         if (in_array($column->dataType(), self::INTEGER_TYPES)) {

--- a/tests/Feature/Translators/RulesTest.php
+++ b/tests/Feature/Translators/RulesTest.php
@@ -129,6 +129,17 @@ final class RulesTest extends TestCase
     }
 
     #[Test]
+    public function forColumn_returns_exists_rule_for_foreign_keys_with_foreign_table_name(): void
+    {
+        $column = new Column('author_id', 'id', [['foreign' => 'users']]);
+
+        $actual = Rules::fromColumn('context', $column);
+
+        $this->assertContains('integer', $actual);
+        $this->assertContains('exists:users,id', $actual);
+    }
+
+    #[Test]
     public function forColumn_returns_gt0_rule_for_unsigned_numeric_types(): void
     {
         $column = new Column('test', 'integer');


### PR DESCRIPTION
# Issue Description

On a clean installation, a foreign key column specifying the name of the related table generates an incorrect `exists` rule in the form request. For instance, the following YAML:

```yaml
models:
  Message:
    subject: string
    sender_id: id foreign:users
controllers:
  Message:
    resource: api
```

... generates these rules in `MessageStoreRequest` and `MessageUpdateRequest`:

```php
    public function rules(): array
    {
        return [
            'subject' => ['required', 'string'],
            'sender_id' => ['required', 'integer', 'exists:senders,id'],
        ];
    }
```

The expected rule for `sender_id` should be:

```diff
-'sender_id' => ['required', 'integer', 'exists:senders,id'],
+'sender_id' => ['required', 'integer', 'exists:users,id'],
```

# Solution

This PR updates the `Rules` translator to verify if the column includes a foreign table modifier and applies it in the `exists` rule when present. A test has been added to ensure this behavior.

Please let me know if the code and test look good and matches the coding style. Thanks!





