### PR TITLE
Add option to disable generation of resource collection classes

### DIFF
--- a/config/blueprint.php
+++ b/config/blueprint.php
@@ -132,6 +132,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Generate Resource Collection Classes
+    |--------------------------------------------------------------------------
+    |
+    | By default, Blueprint generates resource collection classes to manage resource
+    | collections (e.g. `PostResourceCollection`). You may disable this option to
+    | generate only resource classes and use their `collection` method instead.
+    |
+    */
+    'generate_resource_collection_classes' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Generators
     |--------------------------------------------------------------------------
     |

--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -195,7 +195,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
                     $statement instanceof InertiaStatement => 'Inertia\Response',
                     $statement instanceof RenderStatement => 'Illuminate\View\View',
                     $statement instanceof RedirectStatement => 'Illuminate\Http\RedirectResponse',
-                    $statement instanceof ResourceStatement => config('blueprint.namespace') . '\\Http\\Resources\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $statement->name(),
+                    $statement instanceof ResourceStatement => $statement->collection() && !$statement->generateCollectionClass() ? 'Illuminate\Http\Resources\Json\ResourceCollection' : config('blueprint.namespace') . '\\Http\\Resources\\' . ($controller->namespace() ? $controller->namespace() . '\\' : '') . $statement->name(),
                     default => 'Illuminate\Http\Response'
                 };
 

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -60,14 +60,14 @@ class ResourceGenerator extends StatementGenerator implements Generator
             . ($controller->namespace() ? '\\' . $controller->namespace() : '');
 
         $imports = ['use Illuminate\\Http\\Request;'];
-        $imports[] = $resource->collection() ? 'use Illuminate\\Http\\Resources\\Json\\ResourceCollection;' : 'use Illuminate\\Http\\Resources\\Json\\JsonResource;';
+        $imports[] = $resource->collection() && $resource->generateCollectionClass() ? 'use Illuminate\\Http\\Resources\\Json\\ResourceCollection;' : 'use Illuminate\\Http\\Resources\\Json\\JsonResource;';
 
         $stub = str_replace('{{ namespace }}', $namespace, $stub);
         $stub = str_replace('{{ imports }}', implode(PHP_EOL, $imports), $stub);
-        $stub = str_replace('{{ parentClass }}', $resource->collection() ? 'ResourceCollection' : 'JsonResource', $stub);
+        $stub = str_replace('{{ parentClass }}', $resource->collection() && $resource->generateCollectionClass() ? 'ResourceCollection' : 'JsonResource', $stub);
         $stub = str_replace('{{ class }}', $resource->name(), $stub);
-        $stub = str_replace('{{ parentClass }}', $resource->collection() ? 'ResourceCollection' : 'JsonResource', $stub);
-        $stub = str_replace('{{ resource }}', $resource->collection() ? 'resource collection' : 'resource', $stub);
+        $stub = str_replace('{{ parentClass }}', $resource->collection() && $resource->generateCollectionClass() ? 'ResourceCollection' : 'JsonResource', $stub);
+        $stub = str_replace('{{ resource }}', $resource->collection() && $resource->generateCollectionClass() ? 'resource collection' : 'resource', $stub);
         $stub = str_replace('{{ body }}', $this->buildData($resource), $stub);
 
         return $stub;
@@ -83,7 +83,7 @@ class ResourceGenerator extends StatementGenerator implements Generator
         $model = $this->tree->modelForContext($context, true);
 
         $data = [];
-        if ($resource->collection()) {
+        if ($resource->collection() && $resource->generateCollectionClass()) {
             $data[] = 'return [';
             $data[] = self::INDENT . '\'data\' => $this->collection,';
             $data[] = '        ];';

--- a/src/Models/Statements/ResourceStatement.php
+++ b/src/Models/Statements/ResourceStatement.php
@@ -45,7 +45,7 @@ class ResourceStatement
 
     public function generateCollectionClass(): bool
     {
-        return config('blueprint.generate_resource_collection_classes');
+        return config('blueprint.generate_resource_collection_classes', true);
     }
 
     public function output(array $properties = []): string

--- a/src/Models/Statements/ResourceStatement.php
+++ b/src/Models/Statements/ResourceStatement.php
@@ -21,7 +21,7 @@ class ResourceStatement
 
     public function name(): string
     {
-        if ($this->collection()) {
+        if ($this->collection() && $this->generateCollectionClass()) {
             return Str::studly(Str::singular($this->reference)) . 'Collection';
         }
 
@@ -43,8 +43,17 @@ class ResourceStatement
         return $this->paginate;
     }
 
+    public function generateCollectionClass(): bool
+    {
+        return config('blueprint.generate_resource_collection_classes');
+    }
+
     public function output(array $properties = []): string
     {
+        if ($this->collection() && !$this->generateCollectionClass()) {
+            return sprintf('return %s::collection(%s);', $this->name(), $this->buildArgument($properties));
+        }
+
         return sprintf('return new %s(%s);', $this->name(), $this->buildArgument($properties));
     }
 

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -232,6 +232,33 @@ final class ControllerGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
+    #[Test]
+    public function output_generates_controller_without_generating_resource_collection_classes(): void
+    {
+        config(['blueprint.generate_resource_collection_classes' => false]);
+
+        $definition = 'drafts/api-resource-pagination.yaml';
+        $path = 'app/Http/Controllers/PostController.php';
+        $controller = 'controllers/without-generating-resource-collection-classes.php';
+
+        $this->filesystem->expects('stub')
+            ->with('controller.class.stub')
+            ->andReturn($this->stub('controller.class.stub'));
+        $this->filesystem->expects('stub')
+            ->with('controller.method.stub')
+            ->andReturn($this->stub('controller.method.stub'));
+
+        $this->filesystem->expects('exists')
+            ->with(dirname($path))
+            ->andReturnTrue();
+        $this->filesystem->expects('put')
+            ->with($path, $this->fixture($controller));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
     public static function controllerTreeDataProvider(): array
     {
         return [

--- a/tests/Feature/Generators/Statements/ResourceGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/ResourceGeneratorTest.php
@@ -96,6 +96,38 @@ final class ResourceGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function output_writes_resource_for_resource_statements_whitout_generating_resource_collection_classes(): void
+    {
+        config(['blueprint.generate_resource_collection_classes' => false]);
+
+        $template = $this->stub('resource.stub');
+        $this->filesystem->expects('stub')
+            ->with('resource.stub')
+            ->andReturn($template);
+
+        $this->filesystem->shouldReceive('exists')
+            ->with('app/Http/Resources')
+            ->andReturns(false, true);
+        $this->filesystem->expects('makeDirectory')
+            ->with('app/Http/Resources', 0755, true);
+
+        $this->filesystem->shouldReceive('exists')
+            ->with('app/Http/Resources/UserResource.php')
+            ->andReturns(false, true);
+        $this->filesystem->expects('put')
+            ->with('app/Http/Resources/UserResource.php', $this->fixture('resources/user.php'));
+
+        $this->filesystem->shouldReceive('put')
+            ->with('app/Http/Resources/UserCollection.php')
+            ->never();
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/resource-statements.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => ['app/Http/Resources/UserResource.php']], $this->subject->output($tree));
+    }
+
+    #[Test]
     public function output_writes_namespaced_classes(): void
     {
         $this->filesystem->expects('stub')
@@ -165,6 +197,40 @@ final class ResourceGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function output_writes_nested_resource_without_generating_resource_collection_classes(): void
+    {
+        config(['blueprint.generate_resource_collection_classes' => false]);
+
+        $this->filesystem->expects('stub')
+            ->with('resource.stub')
+            ->andReturn(file_get_contents('stubs/resource.stub'));
+
+        $this->filesystem->expects('exists')
+            ->with('app/Http/Resources/Api')
+            ->andReturns(false);
+        $this->filesystem->expects('makeDirectory')
+            ->with('app/Http/Resources/Api', 0755, true);
+
+        $this->filesystem->expects('exists')
+            ->times(4)
+            ->with('app/Http/Resources/Api/CertificateResource.php')
+            ->andReturns(false, true, true, true);
+        $this->filesystem->expects('put')
+            ->with('app/Http/Resources/Api/CertificateResource.php', $this->fixture('resources/certificate-with-nested-resource.php'));
+
+        $this->filesystem->shouldReceive('put')
+            ->with('app/Http/Resources/Api/CertificateCollection.php')
+            ->never();
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/resource-nested.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals([
+            'created' => ['app/Http/Resources/Api/CertificateResource.php'],
+        ], $this->subject->output($tree));
+    }
+
+    #[Test]
     public function output_api_resource_pagination(): void
     {
         $this->files->expects('stub')
@@ -196,6 +262,42 @@ final class ResourceGeneratorTest extends TestCase
 
         $this->assertEquals([
             'created' => ['app/Http/Resources/PostCollection.php', 'app/Http/Resources/PostResource.php'],
+        ], $this->subject->output($tree));
+    }
+
+    #[Test]
+    public function output_api_resource_pagination_without_generating_resource_collection_classes(): void
+    {
+        config(['blueprint.generate_resource_collection_classes' => false]);
+
+        $this->files->expects('stub')
+            ->with('resource.stub')
+            ->andReturn(file_get_contents('stubs/resource.stub'));
+
+        $this->files->expects('exists')
+            ->with('app/Http/Resources')
+            ->andReturns(false, true);
+
+        $this->files->expects('makeDirectory')
+            ->with('app/Http/Resources', 0755, true);
+
+        $this->files->expects('exists')
+            ->times(4)
+            ->with('app/Http/Resources/PostResource.php')
+            ->andReturns(false, true, true, true);
+
+        $this->files->expects('put')
+            ->with('app/Http/Resources/PostResource.php', $this->fixture('resources/api-post-resource.php'));
+
+        $this->files->expects('put')
+            ->with('app/Http/Resources/PostCollection.php')
+            ->never();
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/api-resource-pagination.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals([
+            'created' => ['app/Http/Resources/PostResource.php'],
         ], $this->subject->output($tree));
     }
 }

--- a/tests/Feature/Lexers/StatementLexerTest.php
+++ b/tests/Feature/Lexers/StatementLexerTest.php
@@ -17,7 +17,7 @@ use Blueprint\Models\Statements\SessionStatement;
 use Blueprint\Models\Statements\ValidateStatement;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 /**
  * @see StatementLexer
@@ -677,6 +677,26 @@ final class StatementLexerTest extends TestCase
         $this->assertEquals('users', $actual[0]->reference());
         $this->assertTrue($actual[0]->collection());
         $this->assertTrue($actual[0]->paginate());
+    }
+
+    #[Test]
+    public function it_returns_a_resource_collection_statement_without_generating_a_resource_collection_class(): void
+    {
+        config(['blueprint.generate_resource_collection_classes' => false]);
+
+        $tokens = [
+            'resource' => 'collection:users',
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertCount(1, $actual);
+        $this->assertInstanceOf(ResourceStatement::class, $actual[0]);
+
+        $this->assertEquals('UserResource', $actual[0]->name());
+        $this->assertEquals('users', $actual[0]->reference());
+        $this->assertTrue($actual[0]->collection());
+        $this->assertFalse($actual[0]->paginate());
     }
 
     public static function sessionTokensProvider(): array

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,6 +30,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $app['config']->set('blueprint.generate_phpdocs', false);
         $app['config']->set('blueprint.use_constraints', false);
         $app['config']->set('blueprint.fake_nullables', true);
+        $app['config']->set('blueprint.generate_resource_collection_classes', true);
         $app['config']->set('database.default', 'testing');
     }
 

--- a/tests/fixtures/controllers/without-generating-resource-collection-classes.php
+++ b/tests/fixtures/controllers/without-generating-resource-collection-classes.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\PostStoreRequest;
+use App\Http\Requests\PostUpdateRequest;
+use App\Http\Resources\PostResource;
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+use Illuminate\Http\Response;
+
+class PostController extends Controller
+{
+    public function index(Request $request): ResourceCollection
+    {
+        $posts = Post::paginate();
+
+        return PostResource::collection($posts);
+    }
+
+    public function store(PostStoreRequest $request): PostResource
+    {
+        $post = Post::create($request->validated());
+
+        return new PostResource($post);
+    }
+
+    public function show(Request $request, Post $post): PostResource
+    {
+        return new PostResource($post);
+    }
+
+    public function update(PostUpdateRequest $request, Post $post): PostResource
+    {
+        $post->update($request->validated());
+
+        return new PostResource($post);
+    }
+
+    public function destroy(Request $request, Post $post): Response
+    {
+        $post->delete();
+
+        return response()->noContent();
+    }
+}


### PR DESCRIPTION
This PR introduces a new configuration option, `generate_resource_collection_classes`, to toggle the generation of resource collection classes in Blueprint.

## Current behaviour

To return a resource collection, Blueprint creates a **resource collection class**. These classes allows adding custom metadata that may need to be returned with the collection.

```php
class PostCollection extends ResourceCollection
{
    public function toArray(Request $request): array
    {
        return [
            'data' => $this->collection,
        ];
    }
}
```

Blueprint uses them in controllers using the `resource` statement, generating code like this:

```php
use App\Http\Resources\PostCollection;
use App\Http\Resources\PostResource;

public function index(Request $request): PostCollection
{
    $posts = Post::paginate();

    return new PostCollection($posts);
}

public function store(PostStoreRequest $request): PostResource { ... }
```

However, as convenient as these dedicated classes are for extending basic functionality, they are not necessary when dealing with simple collections, as all resources provide a `collection` method to generate an "ad-hoc" resource collection on the fly.

So given a `PostResource`, the controller can do:

```diff
-use App\Http\Resources\PostCollection;
use App\Http\Resources\PostResource;

-public function index(Request $request): PostCollection
+public function index(Request $request): ResourceCollection
{
    $posts = Post::paginate();

-    return new PostCollection($posts);
+    return PostResource::collection($posts);
}

public function store(PostStoreRequest $request): PostResource { ... }
```

## Proposed Feature

A new configuration option, `generate_resource_collection_classes`, toggles the generation of resource collection classes in Blueprint.

This feature is useful for developers who prefer a leaner approach to resource handling by relying solely on resource classes and their `collection` methods, reducing the number of generated files.

```php
'generate_resource_collection_classes' => true,
```

- If this option is true, it will generate resource collection classes (e.g., `PostResourceCollection`). This is the default value, maintaining existing behavior where dedicated resource collection classes are generated. It also defaults to true if the value is missing from the config (useful for people who already published the configuration file).

- If this option is false, it will only generate resource classes (e.g., `PostResource`) and use their `collection` method instead.

### Testing

Added test cases to verify:

- Resource collection classes are generated when the option is enabled.
- Resource collection classes are not generated when the option is disabled.
- Controllers return the correct class type.

Please let me know if this approach is valid. I would love to see this feature available, happy to make a PR to the docs repo if it does. Thank you!