### PR TITLE
Add support for routes with nested model binding

### DIFF
--- a/src/Generators/PestTestGenerator.php
+++ b/src/Generators/PestTestGenerator.php
@@ -115,6 +115,11 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
                 $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
             }
 
+            if ($parent = $controller->parent()) {
+                $this->addImport($controller, $modelNamespace . '\\' . $parent);
+                $setup['data'][] = sprintf('$%s = %s::factory()->create();', Str::camel($parent), $parent);
+            }
+
             foreach ($statements as $statement) {
                 if ($statement instanceof SendStatement) {
                     if ($statement->isNotification()) {
@@ -492,6 +497,22 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
                 $call .= ', $' . Str::camel($context);
             }
             $call .= ')';
+
+            if ($controller->parent()) {
+                $parent = Str::camel($controller->parent());
+                $variable = Str::camel($context);
+                $binding = sprintf(', $%s)', $variable);
+                $params = sprintf("'%s' => $%s", $parent, $parent);
+
+                if (Str::contains($call, $binding)) {
+                    $params .= sprintf(", '%s' => $%s", $variable, $variable);
+                    $search = $binding;
+                } else {
+                    $search = ')';
+                }
+
+                $call = str_replace($search, sprintf(', [%s])', $params), $call);
+            }
 
             if ($request_data) {
                 $call .= ', [';

--- a/src/Generators/PhpUnitTestGenerator.php
+++ b/src/Generators/PhpUnitTestGenerator.php
@@ -114,6 +114,11 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                 $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
             }
 
+            if ($parent = $controller->parent()) {
+                $this->addImport($controller, $modelNamespace . '\\' . $parent);
+                $setup['data'][] = sprintf('$%s = %s::factory()->create();', Str::camel($parent), $parent);
+            }
+
             foreach ($statements as $statement) {
                 if ($statement instanceof SendStatement) {
                     if ($statement->isNotification()) {
@@ -485,6 +490,22 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                 $call .= ', $' . Str::camel($context);
             }
             $call .= ')';
+
+            if ($controller->parent()) {
+                $parent = Str::camel($controller->parent());
+                $variable = Str::camel($context);
+                $binding = sprintf(', $%s)', $variable);
+                $params = sprintf("'%s' => $%s", $parent, $parent);
+
+                if (Str::contains($call, $binding)) {
+                    $params .= sprintf(", '%s' => $%s", $variable, $variable);
+                    $search = $binding;
+                } else {
+                    $search = ')';
+                }
+
+                $call = str_replace($search, sprintf(', [%s])', $params), $call);
+            }
 
             if ($request_data) {
                 $call .= ', [';

--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -45,6 +45,12 @@ class RouteGenerator extends AbstractClassGenerator implements Generator
         $className = $this->getClassName($controller);
         $slug = config('blueprint.singular_routes') ? Str::kebab($controller->prefix()) : Str::plural(Str::kebab($controller->prefix()));
 
+        if ($controller->parent()) {
+            $parentSlug = config('blueprint.singular_routes') ? Str::kebab($controller->parent()) : Str::plural(Str::kebab($controller->parent()));
+            $parentBinding = '/{' . Str::kebab($controller->parent()) . '}/';
+            $slug = $parentSlug . $parentBinding . $slug;
+        }
+
         foreach (array_diff($methods, Controller::$resourceMethods) as $method) {
             $routes .= $this->buildRouteLine($className, $slug, $method);
             $routes .= PHP_EOL;

--- a/src/Lexers/ControllerLexer.php
+++ b/src/Lexers/ControllerLexer.php
@@ -74,6 +74,10 @@ class ControllerLexer implements Lexer
                     $registry['policies'][] = $policy;
                 }
 
+                if (isset($definition['meta']['parent'])) {
+                    $controller->setParent($definition['meta']['parent']);
+                }
+
                 unset($definition['meta']);
             }
 

--- a/src/Models/Controller.php
+++ b/src/Models/Controller.php
@@ -21,6 +21,8 @@ class Controller implements BlueprintModel
 
     private bool $apiResource = false;
 
+    private ?string $parent = null;
+
     public function __construct(string $name)
     {
         $this->name = class_basename($name);
@@ -102,5 +104,15 @@ class Controller implements BlueprintModel
     public function isApiResource(): bool
     {
         return $this->apiResource;
+    }
+
+    public function setParent(string $parent): void
+    {
+        $this->parent = Str::studly(Str::singular($parent));
+    }
+
+    public function parent(): ?string
+    {
+        return $this->parent;
     }
 }

--- a/tests/Feature/Generators/ControllerGeneratorTest.php
+++ b/tests/Feature/Generators/ControllerGeneratorTest.php
@@ -273,6 +273,7 @@ final class ControllerGeneratorTest extends TestCase
             ['drafts/inertia-render.yaml', 'app/Http/Controllers/CustomerController.php', 'controllers/inertia-render.php'],
             ['drafts/save-without-validation.yaml', 'app/Http/Controllers/PostController.php', 'controllers/save-without-validation.php'],
             ['drafts/api-resource-pagination.yaml', 'app/Http/Controllers/PostController.php', 'controllers/api-resource-pagination.php'],
+            ['drafts/api-resource-nested.yaml', 'app/Http/Controllers/CommentController.php', 'controllers/api-resource-nested.php'],
             ['drafts/api-routes-example.yaml', 'app/Http/Controllers/Api/CertificateController.php', 'controllers/api-routes-example.php'],
             ['drafts/invokable-controller.yaml', 'app/Http/Controllers/ReportController.php', 'controllers/invokable-controller.php'],
             ['drafts/invokable-controller-shorthand.yaml', 'app/Http/Controllers/ReportController.php', 'controllers/invokable-controller-shorthand.php'],

--- a/tests/Feature/Generators/PestTestGeneratorTest.php
+++ b/tests/Feature/Generators/PestTestGeneratorTest.php
@@ -225,6 +225,7 @@ final class PestTestGeneratorTest extends TestCase
             ['drafts/model-reference-validate.yaml', 'tests/Feature/Http/Controllers/CertificateControllerTest.php', 'tests/pest/api-shorthand-validation.php'],
             ['drafts/controllers-only-no-context.yaml', 'tests/Feature/Http/Controllers/ReportControllerTest.php', 'tests/pest/controllers-only-no-context.php'],
             ['drafts/date-formats.yaml', 'tests/Feature/Http/Controllers/DateControllerTest.php', 'tests/pest/date-formats.php'],
+            ['drafts/api-resource-nested.yaml', 'tests/Feature/Http/Controllers/CommentControllerTest.php', 'tests/pest/api-resource-nested.php'],
             ['drafts/call-to-a-member-function-columns-on-null.yaml', [
                 'tests/Feature/Http/Controllers/SubscriptionControllerTest.php',
                 'tests/Feature/Http/Controllers/TelegramControllerTest.php',

--- a/tests/Feature/Generators/PhpUnitTestGeneratorTest.php
+++ b/tests/Feature/Generators/PhpUnitTestGeneratorTest.php
@@ -226,6 +226,7 @@ final class PhpUnitTestGeneratorTest extends TestCase
             ['drafts/controllers-only-no-context.yaml', 'tests/Feature/Http/Controllers/ReportControllerTest.php', 'tests/phpunit/controllers-only-no-context.php'],
             ['drafts/date-formats.yaml', 'tests/Feature/Http/Controllers/DateControllerTest.php', 'tests/phpunit/date-formats.php'],
             ['drafts/test-relationships.yaml', 'tests/Feature/Http/Controllers/ConferenceControllerTest.php', 'tests/phpunit/test-relationships.php'],
+            ['drafts/api-resource-nested.yaml', 'tests/Feature/Http/Controllers/CommentControllerTest.php', 'tests/phpunit/api-resource-nested.php'],
             ['drafts/call-to-a-member-function-columns-on-null.yaml', [
                 'tests/Feature/Http/Controllers/SubscriptionControllerTest.php',
                 'tests/Feature/Http/Controllers/TelegramControllerTest.php',

--- a/tests/Feature/Generators/RouteGeneratorTest.php
+++ b/tests/Feature/Generators/RouteGeneratorTest.php
@@ -119,6 +119,7 @@ final class RouteGeneratorTest extends TestCase
             ['drafts/respond-statements.yaml', 'routes/respond-statements.php'],
             ['drafts/invokable-controller.yaml', 'routes/invokable-controller.php'],
             ['drafts/invokable-controller-shorthand.yaml', 'routes/invokable-controller.php'],
+            ['drafts/controller-nested.yaml', 'routes/nested-controller.php'],
         ];
     }
 }

--- a/tests/Feature/Lexers/ControllerLexerTest.php
+++ b/tests/Feature/Lexers/ControllerLexerTest.php
@@ -486,4 +486,30 @@ final class ControllerLexerTest extends TestCase
         $this->assertInstanceOf(Policy::class, $controller->policy());
         $this->assertEquals(['viewAny', 'view'], $controller->policy()->methods());
     }
+
+    #[Test]
+    public function it_returns_a_nested_controller(): void
+    {
+        $tokens = [
+            'controllers' => [
+                'Comment' => [
+                    'resource' => 'api',
+                    'meta' => [
+                        'parent' => 'post',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->statementLexer->shouldReceive('analyze');
+
+        $actual = $this->subject->analyze($tokens);
+
+        $this->assertCount(1, $actual['controllers']);
+
+        $controller = $actual['controllers']['Comment'];
+        $this->assertEquals('CommentController', $controller->className());
+        $this->assertCount(5, $controller->methods());
+        $this->assertEquals($controller->parent(), 'Post');
+    }
 }

--- a/tests/fixtures/controllers/api-resource-nested.php
+++ b/tests/fixtures/controllers/api-resource-nested.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CommentStoreRequest;
+use App\Http\Requests\CommentUpdateRequest;
+use App\Http\Resources\CommentCollection;
+use App\Http\Resources\CommentResource;
+use App\Models\Comment;
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class CommentController extends Controller
+{
+    public function index(Request $request, Post $post): CommentCollection
+    {
+        $comments = $post->comments()->get();
+
+        return new CommentCollection($comments);
+    }
+
+    public function store(CommentStoreRequest $request, Post $post): CommentResource
+    {
+        $comment = $post->comments()->create($request->validated());
+
+        return new CommentResource($comment);
+    }
+
+    public function show(Request $request, Post $post, Comment $comment): CommentResource
+    {
+        return new CommentResource($comment);
+    }
+
+    public function update(CommentUpdateRequest $request, Post $post, Comment $comment): CommentResource
+    {
+        $comment->update($request->validated());
+
+        return new CommentResource($comment);
+    }
+
+    public function destroy(Request $request, Post $post, Comment $comment): Response
+    {
+        $comment->delete();
+
+        return response()->noContent();
+    }
+}

--- a/tests/fixtures/drafts/api-resource-nested.yaml
+++ b/tests/fixtures/drafts/api-resource-nested.yaml
@@ -1,0 +1,16 @@
+models:
+  Post:
+    title: string
+    body: text
+    relationships:
+      hasMany: comment
+      belongsTo: user
+  Comment:
+    body: text
+    relationships:
+      belongsTo: post, user
+controllers:
+  Comment:
+    resource: api
+    meta:
+      parent: post

--- a/tests/fixtures/drafts/controller-nested.yaml
+++ b/tests/fixtures/drafts/controller-nested.yaml
@@ -1,0 +1,5 @@
+controllers:
+  Comment:
+    resource: web
+    meta:
+      parent: post

--- a/tests/fixtures/routes/nested-controller.php
+++ b/tests/fixtures/routes/nested-controller.php
@@ -1,0 +1,3 @@
+
+
+Route::resource('posts/{post}/comments', App\Http\Controllers\CommentController::class);

--- a/tests/fixtures/tests/pest/api-resource-nested.php
+++ b/tests/fixtures/tests/pest/api-resource-nested.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\User;
+use function Pest\Faker\fake;
+use function Pest\Laravel\assertModelMissing;
+use function Pest\Laravel\delete;
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\put;
+
+test('index behaves as expected', function (): void {
+    $post = Post::factory()->create();
+    $comments = Comment::factory()->count(3)->create();
+
+    $response = get(route('comments.index', ['post' => $post]));
+
+    $response->assertOk();
+    $response->assertJsonStructure([]);
+});
+
+
+test('store uses form request validation')
+    ->assertActionUsesFormRequest(
+        \App\Http\Controllers\CommentController::class,
+        'store',
+        \App\Http\Requests\CommentStoreRequest::class
+    );
+
+test('store saves', function (): void {
+    $post = Post::factory()->create();
+    $body = fake()->text();
+    $user = User::factory()->create();
+
+    $response = post(route('comments.store', ['post' => $post]), [
+        'body' => $body,
+        'post_id' => $post->id,
+        'user_id' => $user->id,
+    ]);
+
+    $comments = Comment::query()
+        ->where('body', $body)
+        ->where('post_id', $post->id)
+        ->where('user_id', $user->id)
+        ->get();
+    expect($comments)->toHaveCount(1);
+    $comment = $comments->first();
+
+    $response->assertCreated();
+    $response->assertJsonStructure([]);
+});
+
+
+test('show behaves as expected', function (): void {
+    $comment = Comment::factory()->create();
+    $post = Post::factory()->create();
+
+    $response = get(route('comments.show', ['post' => $post, 'comment' => $comment]));
+
+    $response->assertOk();
+    $response->assertJsonStructure([]);
+});
+
+
+test('update uses form request validation')
+    ->assertActionUsesFormRequest(
+        \App\Http\Controllers\CommentController::class,
+        'update',
+        \App\Http\Requests\CommentUpdateRequest::class
+    );
+
+test('update behaves as expected', function (): void {
+    $comment = Comment::factory()->create();
+    $post = Post::factory()->create();
+    $body = fake()->text();
+    $user = User::factory()->create();
+
+    $response = put(route('comments.update', ['post' => $post, 'comment' => $comment]), [
+        'body' => $body,
+        'post_id' => $post->id,
+        'user_id' => $user->id,
+    ]);
+
+    $comment->refresh();
+
+    $response->assertOk();
+    $response->assertJsonStructure([]);
+
+    expect($body)->toEqual($comment->body);
+    expect($post->id)->toEqual($comment->post_id);
+    expect($user->id)->toEqual($comment->user_id);
+});
+
+
+test('destroy deletes and responds with', function (): void {
+    $comment = Comment::factory()->create();
+    $post = Post::factory()->create();
+
+    $response = delete(route('comments.destroy', ['post' => $post, 'comment' => $comment]));
+
+    $response->assertNoContent();
+
+    assertModelMissing($comment);
+});

--- a/tests/fixtures/tests/phpunit/api-resource-nested.php
+++ b/tests/fixtures/tests/phpunit/api-resource-nested.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use JMac\Testing\Traits\AdditionalAssertions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\CommentController
+ */
+final class CommentControllerTest extends TestCase
+{
+    use AdditionalAssertions, RefreshDatabase, WithFaker;
+
+    #[Test]
+    public function index_behaves_as_expected(): void
+    {
+        $post = Post::factory()->create();
+        $comments = Comment::factory()->count(3)->create();
+
+        $response = $this->get(route('comments.index', ['post' => $post]));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
+    }
+
+
+    #[Test]
+    public function store_uses_form_request_validation(): void
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\CommentController::class,
+            'store',
+            \App\Http\Requests\CommentStoreRequest::class
+        );
+    }
+
+    #[Test]
+    public function store_saves(): void
+    {
+        $post = Post::factory()->create();
+        $body = $this->faker->text();
+        $user = User::factory()->create();
+
+        $response = $this->post(route('comments.store', ['post' => $post]), [
+            'body' => $body,
+            'post_id' => $post->id,
+            'user_id' => $user->id,
+        ]);
+
+        $comments = Comment::query()
+            ->where('body', $body)
+            ->where('post_id', $post->id)
+            ->where('user_id', $user->id)
+            ->get();
+        $this->assertCount(1, $comments);
+        $comment = $comments->first();
+
+        $response->assertCreated();
+        $response->assertJsonStructure([]);
+    }
+
+
+    #[Test]
+    public function show_behaves_as_expected(): void
+    {
+        $comment = Comment::factory()->create();
+        $post = Post::factory()->create();
+
+        $response = $this->get(route('comments.show', ['post' => $post, 'comment' => $comment]));
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
+    }
+
+
+    #[Test]
+    public function update_uses_form_request_validation(): void
+    {
+        $this->assertActionUsesFormRequest(
+            \App\Http\Controllers\CommentController::class,
+            'update',
+            \App\Http\Requests\CommentUpdateRequest::class
+        );
+    }
+
+    #[Test]
+    public function update_behaves_as_expected(): void
+    {
+        $comment = Comment::factory()->create();
+        $post = Post::factory()->create();
+        $body = $this->faker->text();
+        $user = User::factory()->create();
+
+        $response = $this->put(route('comments.update', ['post' => $post, 'comment' => $comment]), [
+            'body' => $body,
+            'post_id' => $post->id,
+            'user_id' => $user->id,
+        ]);
+
+        $comment->refresh();
+
+        $response->assertOk();
+        $response->assertJsonStructure([]);
+
+        $this->assertEquals($body, $comment->body);
+        $this->assertEquals($post->id, $comment->post_id);
+        $this->assertEquals($user->id, $comment->user_id);
+    }
+
+
+    #[Test]
+    public function destroy_deletes_and_responds_with(): void
+    {
+        $comment = Comment::factory()->create();
+        $post = Post::factory()->create();
+
+        $response = $this->delete(route('comments.destroy', ['post' => $post, 'comment' => $comment]));
+
+        $response->assertNoContent();
+
+        $this->assertModelMissing($comment);
+    }
+}


### PR DESCRIPTION
This PR introduces support for defining routes with nested model bindings by specifying a `meta.parent` attribute in the controller's configuration. The `parent` attribute identifies the name of the related model.

### Example

Given the following draft:

```yaml
controllers:
  Comment:
    resource: api
    meta:
      parent: post
```

Blueprint will generate a **nested resource route** instead of a standard resource route:

```diff
-Route::apiResource('comments', App\Http\Controllers\CommentController::class);
+Route::apiResource('posts/{post}/comments', App\Http\Controllers\CommentController::class);
```

The `meta.parent` works not only for web or API resources, but for individual routes as well:

```php
Route::get('posts/{post}/comments/foobar', [App\Http\Controllers\CommentController::class, 'foobar']);
```

The **controller methods** will automatically inject the parent model as a parameter:

```diff
-public function index(Request $request): CommentCollection
+public function index(Request $request, Post $post): CommentCollection
```

And queries within the controller will utilize the parent model to scope operations. The relationship is inferred using the controller's name, following Laravel conventions:

```diff
-Comment::all();
+$post->comments()->get();

-Comment::create($request->validated());
+$post->comments()->create($request->validated());
```


<details>
<summary>
Click here to see a full controller example
</summary>

```php
<?php

namespace App\Http\Controllers;

use App\Models\Post;
use App\Models\Comment;
use Illuminate\Http\Request;
use Illuminate\Http\Response;
use App\Http\Resources\CommentResource;
use App\Http\Resources\CommentCollection;
use App\Http\Requests\CommentStoreRequest;
use App\Http\Requests\CommentUpdateRequest;

class CommentController extends Controller
{
    public function index(Request $request, Post $post): CommentCollection
    {
        $comments = $post->comments()->get();

        return new CommentCollection($comments);
    }

    public function store(CommentStoreRequest $request, Post $post): CommentResource
    {
        $comment = $post->comments()->create($request->validated());

        return new CommentResource($comment);
    }

    public function show(Request $request, Post $post, Comment $comment): CommentResource
    {
        return new CommentResource($comment);
    }

    public function update(CommentUpdateRequest $request, Post $post, Comment $comment): CommentResource
    {
        $comment->update($request->validated());

        return new CommentResource($comment);
    }

    public function destroy(Request $request, Post $post, Comment $comment): Response
    {
        $comment->delete();

        return response()->noContent();
    }
}
```
</details>

This PR also makes the necessary adjustments to the **generated tests**, both for Pest and PHPUnit, to fit the changes. You can check examples of these generated tests in `tests/fixtures/tests/pest/api-resource-nested.php` and `tests/fixtures/tests/phpunit/api-resource-nested.php`.

## Testing

I have added tests to assert the correct generation of the route, controller, and tests when the `meta.parent` is present. I also added a test in `ControllerLexerTest` to assert that the parent is being set as expected.

The previous tests are passing, ensuring that the introduction of this feature does not alter the existing functionality.

Let me know if this approach is valid and if you would like to see any changes. It would be great to have this feature in Blueprint. Thank you!
