### PR TITLE
Fix Pest generated tests

### DIFF
--- a/tests/fixtures/tests/pest/api-shorthand-validation.php
+++ b/tests/fixtures/tests/pest/api-shorthand-validation.php
@@ -5,12 +5,15 @@ namespace Tests\Feature\Http\Controllers;
 use App\Models\Certificate;
 use App\Models\CertificateType;
 use Illuminate\Support\Carbon;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $certificates = Certificate::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/call-to-a-member-function-columns-on-null-Api-PaymentControllerTest.php
+++ b/tests/fixtures/tests/pest/call-to-a-member-function-columns-on-null-Api-PaymentControllerTest.php
@@ -8,9 +8,12 @@ use App\Models\Payment;
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
+
+pest()->use(AdditionalAssertions::class);
 
 test('store uses form request validation')
     ->assertActionUsesFormRequest(

--- a/tests/fixtures/tests/pest/call-to-a-member-function-columns-on-null-PaymentControllerTest.php
+++ b/tests/fixtures/tests/pest/call-to-a-member-function-columns-on-null-PaymentControllerTest.php
@@ -8,9 +8,12 @@ use App\Models\Payment;
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
+
+pest()->use(AdditionalAssertions::class);
 
 test('create displays view', function (): void {
     $response = get(route('payments.create'));

--- a/tests/fixtures/tests/pest/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/pest/certificate-pascal-case-example.php
@@ -5,12 +5,15 @@ namespace Tests\Feature\Http\Controllers;
 use App\Models\Certificate;
 use App\Models\CertificateType;
 use Illuminate\Support\Carbon;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $certificates = Certificate::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/certificate-type-pascal-case-example.php
+++ b/tests/fixtures/tests/pest/certificate-type-pascal-case-example.php
@@ -3,12 +3,15 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\CertificateType;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $certificateTypes = CertificateType::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/date-formats.php
+++ b/tests/fixtures/tests/pest/date-formats.php
@@ -4,12 +4,15 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Date;
 use Illuminate\Support\Carbon;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index displays view', function (): void {
     $dates = Date::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/full-crud-example.php
+++ b/tests/fixtures/tests/pest/full-crud-example.php
@@ -3,12 +3,15 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Post;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index displays view', function (): void {
     $posts = Post::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/models-with-custom-namespace.php
+++ b/tests/fixtures/tests/pest/models-with-custom-namespace.php
@@ -3,12 +3,15 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Category;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $categories = Category::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/readme-example-notification.php
+++ b/tests/fixtures/tests/pest/readme-example-notification.php
@@ -9,9 +9,12 @@ use App\Notification\ReviewNotification;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index displays view', function (): void {
     $posts = Post::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/readme-example.php
+++ b/tests/fixtures/tests/pest/readme-example.php
@@ -10,9 +10,12 @@ use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index displays view', function (): void {
     $posts = Post::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/reference-cache.php
+++ b/tests/fixtures/tests/pest/reference-cache.php
@@ -3,8 +3,11 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\User;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\post;
+
+pest()->use(AdditionalAssertions::class);
 
 test('store uses form request validation')
     ->assertActionUsesFormRequest(

--- a/tests/fixtures/tests/pest/respond-statements.php
+++ b/tests/fixtures/tests/pest/respond-statements.php
@@ -3,9 +3,12 @@
 namespace Tests\Feature\Http\Controllers\Api;
 
 use App\Models\Post;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index responds with', function (): void {
     $posts = Post::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/routes-with-pluralized-names.php
+++ b/tests/fixtures/tests/pest/routes-with-pluralized-names.php
@@ -3,12 +3,15 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Category;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $categories = Category::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/routes-with-singular-names.php
+++ b/tests/fixtures/tests/pest/routes-with-singular-names.php
@@ -3,12 +3,15 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Category;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $categories = Category::factory()->count(3)->create();


### PR DESCRIPTION
On a clean installation, the generated Pest tests fail because `assertActionUsesFormRequest` is an undefined method.

## Steps to replicate

Installation:

```sh
# Create Laravel project
composer create-project laravel/laravel test
cd test
# Install Blueprint
composer require -W --dev laravel-shift/blueprint
# Install Pest
composer remove phpunit/phpunit
composer require pestphp/pest --dev --with-all-dependencies
composer require pestphp/pest-plugin-faker --dev
composer require pestphp/pest-plugin-laravel --dev
./vendor/bin/pest --init
# Install Laravel Test Assertions
composer require --dev jasonmccreary/laravel-test-assertions
```

Initialize Blueprint:

```sh
php artisan blueprint:new --config
```

Comment out PHPUnit and uncomment Pest:

```php
// 'test' => \Blueprint\Generators\PhpUnitTestGenerator::class,
'test' => \Blueprint\Generators\PestTestGenerator::class,
```

Create draft:

```yaml
models:
  Post:
    title: string
controllers:
  Post:
    resource: web
```

Generate:

```sh
php artisan blueprint:build
```

Run tests:

```sh
./vendor/bin/pest
```

Tests fail with the following error:

```
   FAILED  Tests\Feature\Http\Controllers\PostControllerTest > store uses form request validation         ReflectionException
  Call to undefined method Tests\TestCase::assertActionUsesFormRequest()

  at tests/Feature/Http/Controllers/PostControllerTest.php:33
     29▕ });
     30▕
     31▕
     32▕ test('store uses form request validation')
  ➜  33▕     ->assertActionUsesFormRequest(
     34▕         \App\Http\Controllers\PostController::class,
     35▕         'store',
     36▕         \App\Http\Requests\PostStoreRequest::class
     37▕     );

  1   tests/Feature/Http/Controllers/PostControllerTest.php:33
```

## Reason

This happens for two reasons:

1. The `PestTestGenerator` is not calling `addTrait` to add `AdditionalAssertions`.
2. The `PestTestGenerator` uses the trait `HandlesTraits`, but Pest tests manage traits differently: `pest()->use()`.

## Solution

Tests relying on `assertActionUsesFormRequest` should include the following:

- This line at the top of the file:

```php
use JMac\Testing\Traits\AdditionalAssertions;
```

- This line before the tests:

```php
pest()->use(AdditionalAssertions::class);
```

This PR achieves that outcome by adding this logic when processing a `ValidateStatement`:

```php
$this->addImport($controller, 'JMac\\Testing\\Traits\\AdditionalAssertions');
$this->addTrait($controller, 'AdditionalAssertions');
```

The `PestTestGenerator` now uses its own `addTrait` method instead of relying on `HandlesTraits`. Given that this method is specific to `PestTestGenerator` and not shared across other classes, introducing it locally rather than creating a new concern seemed appropriate.
