### PR TITLE
Set up API router when first API routes are generated

### DIFF
--- a/stubs/routes.api.stub
+++ b/stubs/routes.api.stub
@@ -1,0 +1,3 @@
+<?php
+
+use Illuminate\Support\Facades\Route;

--- a/tests/Feature/Generators/RouteGeneratorTest.php
+++ b/tests/Feature/Generators/RouteGeneratorTest.php
@@ -109,6 +109,84 @@ final class RouteGeneratorTest extends TestCase
         $this->assertEquals(['updated' => ['routes/api.php', 'routes/web.php']], $this->subject->output($tree));
     }
 
+    #[Test]
+    public function output_creates_api_routes_file_when_missing(): void
+    {
+        $this->filesystem->expects('exists')
+            ->with('routes/api.php')
+            ->andReturn(false);
+
+        $this->filesystem->expects('stub')
+            ->with('routes.api.stub')
+            ->andReturn($this->stub('routes.api.stub'));
+
+        $this->filesystem->expects('put')
+            ->with('routes/api.php', $this->stub('routes.api.stub'));
+
+        $this->filesystem->expects('append')
+            ->with('routes/api.php', $this->fixture('routes/api-routes.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['updated' => ['routes/api.php']], $this->subject->output($tree));
+    }
+
+    #[Test]
+    public function output_does_not_create_api_routes_file_when_it_exists(): void
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->with('routes/api.php')
+            ->andReturn(true);
+
+        $this->filesystem->expects('put')
+            ->with('routes/api.php', $this->anything())
+            ->never();
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['updated' => ['routes/api.php']], $this->subject->output($tree));
+    }
+
+    #[Test]
+    public function output_adds_api_route_line_to_bootstrap_if_missing(): void
+    {
+        $this->filesystem->expects('get')
+            ->with('bootstrap/app.php')
+            ->andReturn("web: __DIR__.'/../routes/web.php',");
+
+        $this->filesystem->shouldReceive('replaceInFile')
+            ->with(
+                'web: __DIR__.\'/../routes/web.php\',',
+                'web: __DIR__.\'/../routes/web.php\',' . PHP_EOL . '        api: __DIR__.\'/../routes/api.php\',',
+                'bootstrap/app.php'
+            )
+            ->once();
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['updated' => ['routes/api.php']], $this->subject->output($tree));
+    }
+
+    #[Test]
+    public function output_uncomments_api_route_line_in_bootstrap_if_commented(): void
+    {
+        $this->filesystem->expects('get')
+            ->with('bootstrap/app.php')
+            ->andReturn("// api: \nweb: __DIR__.'/../routes/web.php',");
+
+        $this->filesystem->shouldReceive('replaceInFile')
+            ->with('// api: ', 'api: ', 'bootstrap/app.php')
+            ->once();
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['updated' => ['routes/api.php']], $this->subject->output($tree));
+    }
+
     public static function controllerTreeDataProvider(): array
     {
         return [


### PR DESCRIPTION
### Issue

In a clean installation of Laravel 11, the `routes/api.php` file is absent and not configured in `bootstrap/app.php`. When Blueprint generates API routes, it creates the file, but the developer must manually edit it to add the PHP opening tag and the `use Illuminate\Support\Facades\Route;` line. They must also modify `bootstrap/app.php` to enable that API route file.

### Changes

This PR updates Blueprint to check the following when creating API routes:

- Ensure the `routes/api.php` file exists, creating it if necessary, using a [basic stub](https://github.com/nicodevs/blueprint/blob/setup-api-routes/stubs/routes.api.stub)
- Ensure the API routes file is configured in `bootstrap/app.php`, adding the configuration if missing

These actions occur before the addition of the generated API routes.

This PR takes inspiration from Laravel's [ApiInstallCommand](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Console/ApiInstallCommand.php).

### Testing

Tests to check this functionality has been added to `RouteGeneratorTest.php`.

PS. No annoying WIPs this time! 😅 