### PR TITLE
Fix failing resource nested test

### DIFF
--- a/tests/fixtures/tests/pest/api-resource-nested.php
+++ b/tests/fixtures/tests/pest/api-resource-nested.php
@@ -5,12 +5,15 @@ namespace Tests\Feature\Http\Controllers;
 use App\Models\Comment;
 use App\Models\Post;
 use App\Models\User;
+use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
+
+pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $post = Post::factory()->create();


### PR DESCRIPTION
This PR fixes a test that fails due to the changes introduced by https://github.com/laravel-shift/blueprint/pull/725.