### PR TITLE
Simplify the test verifying the uncommenting of the API route line in the app bootstrap file

### DIFF
--- a/tests/Feature/Generators/RouteGeneratorTest.php
+++ b/tests/Feature/Generators/RouteGeneratorTest.php
@@ -175,7 +175,7 @@ final class RouteGeneratorTest extends TestCase
     {
         $this->filesystem->expects('get')
             ->with('bootstrap/app.php')
-            ->andReturn("// api: \nweb: __DIR__.'/../routes/web.php',");
+            ->andReturn('// api: ');
 
         $this->filesystem->shouldReceive('replaceInFile')
             ->with('// api: ', 'api: ', 'bootstrap/app.php')


### PR DESCRIPTION
This PR streamlines a test introduced in https://github.com/laravel-shift/blueprint/pull/728. [Related comment](https://github.com/laravel-shift/blueprint/pull/728#discussion_r1902256742)