### PR TITLE
Fix: Write bootstrap file only when routes API file is missing

### DIFF
--- a/src/Generators/RouteGenerator.php
+++ b/src/Generators/RouteGenerator.php
@@ -101,7 +101,6 @@ class RouteGenerator extends AbstractClassGenerator implements Generator
     protected function setupApiRouter(): void
     {
         $this->createApiRoutesFileIfMissing();
-        $this->configureApiRoutesInAppBootstrap();
     }
 
     protected function createApiRoutesFileIfMissing(): void
@@ -109,6 +108,7 @@ class RouteGenerator extends AbstractClassGenerator implements Generator
         $apiPath = 'routes/api.php';
         if (!$this->filesystem->exists($apiPath)) {
             $this->filesystem->put($apiPath, $this->filesystem->stub('routes.api.stub'));
+            $this->configureApiRoutesInAppBootstrap();
         }
     }
 

--- a/tests/Feature/Generators/RouteGeneratorTest.php
+++ b/tests/Feature/Generators/RouteGeneratorTest.php
@@ -143,6 +143,9 @@ final class RouteGeneratorTest extends TestCase
             ->with('routes/api.php', $this->anything())
             ->never();
 
+        $this->filesystem->expects('replaceInFile')
+            ->never();
+
         $tokens = $this->blueprint->parse($this->fixture('drafts/api-routes-example.yaml'));
         $tree = $this->blueprint->analyze($tokens);
 


### PR DESCRIPTION
This PR fixes a logical error introduced in https://github.com/laravel-shift/blueprint/pull/728, where `configureApiRoutesInAppBootstrap` was always called instead of only when the `routes/api.php` file is missing.