### PR TITLE
Omit redundant parent ID validation

### DIFF
--- a/tests/Feature/Generators/Statements/FormRequestGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/FormRequestGeneratorTest.php
@@ -299,4 +299,27 @@ final class FormRequestGeneratorTest extends TestCase
             ],
         ], $this->subject->output($tree));
     }
+
+    public function test_output_generates_form_request_without_parent_id_column_validation(): void
+    {
+        $this->filesystem->expects('stub')
+            ->with('request.stub')
+            ->andReturn($this->stub('request.stub'));
+        $this->filesystem->expects('exists')
+            ->twice()
+            ->with('app/Http/Requests')
+            ->andReturnFalse();
+        $this->filesystem->expects('put')
+            ->with('app/Http/Requests/CommentStoreRequest.php', $this->fixture('form-requests/form-requests-controller-has-parent.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/form-requests-controller-has-parent.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        self::assertSame([
+            'created' => [
+                'app/Http/Requests/CommentStoreRequest.php',
+                'app/Http/Requests/CommentUpdateRequest.php',
+            ],
+        ], $this->subject->output($tree));
+    }
 }

--- a/tests/fixtures/drafts/form-requests-controller-has-parent.yaml
+++ b/tests/fixtures/drafts/form-requests-controller-has-parent.yaml
@@ -1,0 +1,15 @@
+models:
+  Post:
+    title: string
+    body: text
+    relationships:
+      hasMany: comment
+  Comment:
+    body: text
+    relationships:
+      belongsTo: post
+controllers:
+  Comment:
+    resource: api
+    meta:
+      parent: post

--- a/tests/fixtures/form-requests/form-requests-controller-has-parent.php
+++ b/tests/fixtures/form-requests/form-requests-controller-has-parent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string'],
+        ];
+    }
+}


### PR DESCRIPTION
Since https://github.com/laravel-shift/blueprint/pull/725, we can use `meta.parent` to generate routes with nested model binding. For example, this draft:

```yaml
controllers:
  Comment:
    resource: api
    meta:
      parent: post
```

... generates the following routes:

```
  GET|HEAD        api/posts/{post}/comments
  POST            api/posts/{post}/comments
  GET|HEAD        api/posts/{post}/comments/{comment}
  PUT|PATCH       api/posts/{post}/comments/{comment}
  DELETE          api/posts/{post}/comments/{comment}
```

Laravel automatically resolves the Post model matching the provided `{post}` ID or returns a 404 if not found. For this reason, receiving and validating `post_id` in the `FormRequest` for these routes is redundant.

This PR removes the generation of form requests validation rules for columns named after the controller `meta.parent` plus the `_id` suffix (e.g., `post_id`).

### Before and after

_Validation Rules **Before**:_

```php
return [
    'body' => ['required', 'string'],
    'post_id' => ['required', 'integer', 'exists:posts,id'],
];
```

_Validation Rules **After**:_

```php
return [
    'body' => ['required', 'string'],
];
```

### Testing

This PR includes a test to verify the generated form request for a controller with a parent. All existing tests remain unchanged and are passing, ensuring form requests are correctly generated in all other scenarios.
