### PR TITLE
Import AdditionalAssertions to base test case when generating Pest tests

### DIFF
--- a/src/Generators/PestTestGenerator.php
+++ b/src/Generators/PestTestGenerator.php
@@ -209,8 +209,7 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
                     $class = $this->buildFormRequestName($controller, $name);
                     $test_case = $this->buildFormRequestTestCase($controller->fullyQualifiedClassName(), $name, config('blueprint.namespace') . '\\Http\\Requests\\' . $class) . PHP_EOL . PHP_EOL . $test_case;
 
-                    $this->addImport($controller, 'JMac\\Testing\\Traits\AdditionalAssertions');
-                    $this->addTrait($controller, 'AdditionalAssertions');
+                    $this->importAdditionalAssertionsToBaseTest();
 
                     if ($statement->data()) {
                         foreach ($statement->data() as $data) {
@@ -678,17 +677,32 @@ END;
         return str_pad(' ', 4) . implode(PHP_EOL . str_pad(' ', 4), $lines);
     }
 
-    protected function buildTraits(BlueprintModel $model): string
+    private function importAdditionalAssertionsToBaseTest(): void
     {
-        if (empty($this->traits[$model->name()])) {
-            return '';
+        $path = base_path('tests/TestCase.php');
+
+        if (!$this->filesystem->exists($path)) {
+            return;
         }
 
-        $traits = collect($this->traits[$model->name()])
-            ->unique()
-            ->sort()
-            ->implode('::class)->use(');
+        $content = $this->filesystem->get($path);
 
-        return "pest()->use({$traits}::class);";
+        if (Str::contains($content, 'use JMac\\Testing\\Traits\\AdditionalAssertions;')) {
+            return;
+        }
+
+        $updatedContent = preg_replace(
+            [
+                '/as BaseTestCase;/',
+                '/abstract class TestCase extends BaseTestCase\s*{/',
+            ],
+            [
+                'as BaseTestCase;' . PHP_EOL . 'use JMac\\Testing\\Traits\\AdditionalAssertions;',
+                'abstract class TestCase extends BaseTestCase' . PHP_EOL . '{' . PHP_EOL . '    use AdditionalAssertions;',
+            ],
+            $content
+        );
+
+        $this->filesystem->put($path, $updatedContent);
     }
 }

--- a/src/Generators/PestTestGenerator.php
+++ b/src/Generators/PestTestGenerator.php
@@ -679,13 +679,14 @@ END;
 
     private function importAdditionalAssertionsToBaseTest(): void
     {
-        $path = base_path('tests/TestCase.php');
+        $path = 'tests/TestCase.php';
+        $fullPath = base_path($path);
 
-        if (!$this->filesystem->exists($path)) {
+        if (!$this->filesystem->exists($fullPath)) {
             return;
         }
 
-        $content = $this->filesystem->get($path);
+        $content = $this->filesystem->get($fullPath);
 
         if (Str::contains($content, 'use JMac\\Testing\\Traits\\AdditionalAssertions;')) {
             return;
@@ -703,6 +704,8 @@ END;
             $content
         );
 
-        $this->filesystem->put($path, $updatedContent);
+        $this->output['updated'][] = $path;
+
+        $this->filesystem->put($fullPath, $updatedContent);
     }
 }

--- a/tests/Feature/Generators/PestTestGeneratorTest.php
+++ b/tests/Feature/Generators/PestTestGeneratorTest.php
@@ -259,7 +259,7 @@ final class PestTestGeneratorTest extends TestCase
         $tokens = $this->blueprint->parse($this->fixture($definition));
         $tree = $this->blueprint->analyze($tokens);
 
-        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+        $this->assertEquals(['created' => [$path], 'updated' => ['tests/TestCase.php']], $this->subject->output($tree));
     }
 
     public static function controllerTreeDataProvider(): array

--- a/tests/Feature/Generators/PestTestGeneratorTest.php
+++ b/tests/Feature/Generators/PestTestGeneratorTest.php
@@ -213,6 +213,55 @@ final class PestTestGeneratorTest extends TestCase
         $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
     }
 
+    #[Test]
+    public function output_imports_additional_assertions_to_base_test(): void
+    {
+        $definition = 'drafts/api-resource-nested.yaml';
+        $path = 'tests/Feature/Http/Controllers/CommentControllerTest.php';
+        $test = 'tests/pest/api-resource-nested.php';
+        $testCasePath = base_path('tests/TestCase.php');
+
+        $this->filesystem->expects('stub')
+            ->with('pest.test.class.stub')
+            ->andReturn($this->stub('pest.test.class.stub'));
+
+        $this->filesystem->expects('stub')
+            ->with('pest.test.case.stub')
+            ->andReturn($this->stub('pest.test.case.stub'));
+
+        $dirname = dirname($path);
+        $this->filesystem->expects('exists')
+            ->with($dirname)
+            ->andReturnFalse();
+
+        $this->filesystem->expects('makeDirectory')
+            ->with($dirname, 0755, true);
+
+        $this->filesystem->expects('put')
+            ->with($path, $this->fixture($test));
+
+        $this->filesystem->expects('exists')
+            ->with($testCasePath)
+            ->twice()
+            ->andReturnTrue();
+
+        $this->filesystem->expects('get')
+            ->twice()
+            ->with($testCasePath)
+            ->andReturn(
+                $this->fixture('tests/pest/test-case.php'),
+                $this->fixture('tests/pest/test-case-with-additional-assertions.php'),
+            );
+
+        $this->filesystem->expects('put')
+            ->with($testCasePath, $this->fixture('tests/pest/test-case-with-additional-assertions.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture($definition));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals(['created' => [$path]], $this->subject->output($tree));
+    }
+
     public static function controllerTreeDataProvider(): array
     {
         return [

--- a/tests/fixtures/tests/pest/api-resource-nested.php
+++ b/tests/fixtures/tests/pest/api-resource-nested.php
@@ -5,15 +5,12 @@ namespace Tests\Feature\Http\Controllers;
 use App\Models\Comment;
 use App\Models\Post;
 use App\Models\User;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $post = Post::factory()->create();

--- a/tests/fixtures/tests/pest/api-shorthand-validation.php
+++ b/tests/fixtures/tests/pest/api-shorthand-validation.php
@@ -5,15 +5,12 @@ namespace Tests\Feature\Http\Controllers;
 use App\Models\Certificate;
 use App\Models\CertificateType;
 use Illuminate\Support\Carbon;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $certificates = Certificate::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/call-to-a-member-function-columns-on-null-Api-PaymentControllerTest.php
+++ b/tests/fixtures/tests/pest/call-to-a-member-function-columns-on-null-Api-PaymentControllerTest.php
@@ -8,12 +8,9 @@ use App\Models\Payment;
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
-
-pest()->use(AdditionalAssertions::class);
 
 test('store uses form request validation')
     ->assertActionUsesFormRequest(

--- a/tests/fixtures/tests/pest/call-to-a-member-function-columns-on-null-PaymentControllerTest.php
+++ b/tests/fixtures/tests/pest/call-to-a-member-function-columns-on-null-PaymentControllerTest.php
@@ -8,12 +8,9 @@ use App\Models\Payment;
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
-
-pest()->use(AdditionalAssertions::class);
 
 test('create displays view', function (): void {
     $response = get(route('payments.create'));

--- a/tests/fixtures/tests/pest/certificate-pascal-case-example.php
+++ b/tests/fixtures/tests/pest/certificate-pascal-case-example.php
@@ -5,15 +5,12 @@ namespace Tests\Feature\Http\Controllers;
 use App\Models\Certificate;
 use App\Models\CertificateType;
 use Illuminate\Support\Carbon;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $certificates = Certificate::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/certificate-type-pascal-case-example.php
+++ b/tests/fixtures/tests/pest/certificate-type-pascal-case-example.php
@@ -3,15 +3,12 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\CertificateType;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $certificateTypes = CertificateType::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/date-formats.php
+++ b/tests/fixtures/tests/pest/date-formats.php
@@ -4,15 +4,12 @@ namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Date;
 use Illuminate\Support\Carbon;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index displays view', function (): void {
     $dates = Date::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/full-crud-example.php
+++ b/tests/fixtures/tests/pest/full-crud-example.php
@@ -3,15 +3,12 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Post;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index displays view', function (): void {
     $posts = Post::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/models-with-custom-namespace.php
+++ b/tests/fixtures/tests/pest/models-with-custom-namespace.php
@@ -3,15 +3,12 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Category;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $categories = Category::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/readme-example-notification.php
+++ b/tests/fixtures/tests/pest/readme-example-notification.php
@@ -9,12 +9,9 @@ use App\Notification\ReviewNotification;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index displays view', function (): void {
     $posts = Post::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/readme-example.php
+++ b/tests/fixtures/tests/pest/readme-example.php
@@ -10,12 +10,9 @@ use App\Models\User;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index displays view', function (): void {
     $posts = Post::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/reference-cache.php
+++ b/tests/fixtures/tests/pest/reference-cache.php
@@ -3,11 +3,8 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\User;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\post;
-
-pest()->use(AdditionalAssertions::class);
 
 test('store uses form request validation')
     ->assertActionUsesFormRequest(

--- a/tests/fixtures/tests/pest/respond-statements.php
+++ b/tests/fixtures/tests/pest/respond-statements.php
@@ -3,12 +3,9 @@
 namespace Tests\Feature\Http\Controllers\Api;
 
 use App\Models\Post;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index responds with', function (): void {
     $posts = Post::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/routes-with-pluralized-names.php
+++ b/tests/fixtures/tests/pest/routes-with-pluralized-names.php
@@ -3,15 +3,12 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Category;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $categories = Category::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/routes-with-singular-names.php
+++ b/tests/fixtures/tests/pest/routes-with-singular-names.php
@@ -3,15 +3,12 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Category;
-use JMac\Testing\Traits\AdditionalAssertions;
 use function Pest\Faker\fake;
 use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
 use function Pest\Laravel\put;
-
-pest()->use(AdditionalAssertions::class);
 
 test('index behaves as expected', function (): void {
     $categories = Category::factory()->count(3)->create();

--- a/tests/fixtures/tests/pest/test-case-with-additional-assertions.php
+++ b/tests/fixtures/tests/pest/test-case-with-additional-assertions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use JMac\Testing\Traits\AdditionalAssertions;
+
+abstract class TestCase extends BaseTestCase
+{
+    use AdditionalAssertions;
+
+}

--- a/tests/fixtures/tests/pest/test-case.php
+++ b/tests/fixtures/tests/pest/test-case.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+
+}


### PR DESCRIPTION
This PR modifies the strategy for importing `AdditionalAssertions` into Pest tests, changing from importing it in every test to importing it once in `test/TestCase.php` (from which Pest tests extend). The original idea was not to alter files beyond those generated, but doing so avoids boilerplate and streamlines the codebase. Check https://github.com/laravel-shift/blueprint/pull/726#issuecomment-2568598874

### What changed

If validation statements are detected, `PestTestGenerator` checks if the file `test/TestCase.php` exists. If it does, it verifies whether `AdditionalAssertions` is imported. If not, the following modifications are made:

```diff
<?php

namespace Tests;

use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use JMac\Testing\Traits\AdditionalAssertions;

abstract class TestCase extends BaseTestCase
{
+    use AdditionalAssertions;
}
```

A test has been added to validate this behavior and check that these alterations only happen once.

The `use JMac\Testing\Traits\AdditionalAssertions;` and `pest()->use(AdditionalAssertions::class);` lines are no longer added to the individual test files. The test fixtures have been updated to reflect this change.

> [!NOTE]
> The only caveat with this strategy is that the regex might require updating if the `TestCase` content changes in future Laravel versions.

### How to test locally

Install:

```sh
# Create Laravel project
composer create-project laravel/laravel test
cd test
# Install Blueprint
composer require -W --dev laravel-shift/blueprint
# Install Pest
composer remove phpunit/phpunit
composer require pestphp/pest --dev --with-all-dependencies
composer require pestphp/pest-plugin-faker --dev
composer require pestphp/pest-plugin-laravel --dev
./vendor/bin/pest --init
# Install Laravel Test Assertions
composer require --dev jasonmccreary/laravel-test-assertions
```

Point the Blueprint package to this fork and branch.

Then, initialize:

```sh
php artisan blueprint:new --config
```

Comment out PHPUnit and uncomment Pest:

```php
// 'test' => \Blueprint\Generators\PhpUnitTestGenerator::class,
'test' => \Blueprint\Generators\PestTestGenerator::class,
```

Paste this in the `draft.yaml`:

```yaml
models:
  Post:
    title: string
controllers:
  Post:
    resource: web
```

Generate:

```sh
php artisan blueprint:build
```

Blueprint must say test base case was updated:

```
Updated:
- routes/web.php
- tests/TestCase.php
```

Go to `tests/Pest.php` and use `RefreshDatabase`:

```php
->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
```

Then run the generated tests:

```sh
./vendor/bin/pest
```

Tests should run without errors.

```
   PASS  Tests\Feature\Http\Controllers\PostControllerTest
  ✓ index displays view                                                                                                  0.12s
  ✓ create displays view                                                                                                 0.01s
  ✓ store uses form request validation                                                                                   0.01s
  ✓ store saves and redirects                                                                                            0.02s
  ✓ show displays view                                                                                                   0.01s
  ✓ edit displays view                                                                                                   0.01s
  ✓ update uses form request validation                                                                                  0.01s
  ✓ update redirects                                                                                                     0.01s
  ✓ destroy deletes and redirects                                                                                        0.01s
```
