### PR TITLE
Honor table name from dot notation

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -276,7 +276,7 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
         } elseif (Str::contains($on, '.')) {
             [$table, $column] = explode('.', $on);
         } elseif (Str::contains($on, '\\')) {
-            $table = Str::lower(Str::plural(Str::afterLast($on, '\\')));
+            $table = Str::snake(Str::plural(Str::afterLast($on, '\\')));
             $column = Str::afterLast($column_name, '_');
         } else {
             $table = Str::snake(Str::plural($on));

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -275,12 +275,11 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
             $column = Str::afterLast($column_name, '_');
         } elseif (Str::contains($on, '.')) {
             [$table, $column] = explode('.', $on);
-            $table = Str::snake($table);
         } elseif (Str::contains($on, '\\')) {
             $table = Str::lower(Str::plural(Str::afterLast($on, '\\')));
             $column = Str::afterLast($column_name, '_');
         } else {
-            $table = Str::plural($on);
+            $table = Str::snake(Str::plural($on));
             $column = Str::afterLast($column_name, '_');
         }
 
@@ -315,12 +314,15 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
             if ($on_delete_clause === 'cascade') {
                 $on_delete_suffix = '->cascadeOnDelete()';
             }
+
             if ($on_update_clause === 'cascade') {
                 $on_update_suffix = '->cascadeOnUpdate()';
             }
+
             if ($column_name === Str::singular($table) . '_' . $column) {
                 return self::INDENT . "{$prefix}->constrained(){$on_delete_suffix}{$on_update_suffix}";
             }
+
             if ($column === 'id') {
                 return self::INDENT . "{$prefix}->constrained('{$table}'){$on_delete_suffix}{$on_update_suffix}";
             }

--- a/tests/fixtures/drafts/unconventional-foreign-key.yaml
+++ b/tests/fixtures/drafts/unconventional-foreign-key.yaml
@@ -1,7 +1,7 @@
 models:
   State:
     name: string
-    countries_id: id foreign:countries
-    country_code: string foreign:countries
-    ccid: string foreign:countries
+    countries_id: id foreign:country
+    country_code: string foreign:Country
+    ccid: string foreign:country.id
     c_code: string foreign:countries.code

--- a/tests/fixtures/factories/unconventional-foreign-key.php
+++ b/tests/fixtures/factories/unconventional-foreign-key.php
@@ -25,7 +25,7 @@ class StateFactory extends Factory
             'name' => fake()->name(),
             'countries_id' => Country::factory(),
             'country_code' => Country::factory()->create()->code,
-            'ccid' => Country::factory()->create()->ccid,
+            'ccid' => Country::factory(),
             'c_code' => Country::factory()->create()->code,
         ];
     }

--- a/tests/fixtures/migrations/unconventional-foreign-key.php
+++ b/tests/fixtures/migrations/unconventional-foreign-key.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->string('country_code');
             $table->foreign('country_code')->references('code')->on('countries');
             $table->string('ccid');
-            $table->foreign('ccid')->references('ccid')->on('countries');
+            $table->foreign('ccid')->references('id')->on('country');
             $table->string('c_code');
             $table->foreign('c_code')->references('code')->on('countries');
             $table->timestamps();


### PR DESCRIPTION
This PR addresses a disconnect between the code and documentation in regards to customizing foreign keys.

The documentation stated:

> If you are not following Laravel's naming conventions, you may set the attribute on the `foreign` modifier. Blueprint supports either the foreign table name or the table and column name using dot notation.

The code always assumed the _table name_ was a model reference and either pluralized or snake cased the value.

After this PR, Blueprint either supports a _model reference_ (base class name or fully qualified class name) or the table and column name using dot notation.

Examples:
```yaml
country_id: id foreign:country          # table: countries column: id
ccid: string foreign:country.id         # table: country column: id
country_code: string foreign:Country    # table: countries column: code
c_code: string foreign:countries.code   # table: countries column: code
```

**Note:** this syntax is only needed if you are using unconventional table or column names.

---
Closes #684 