### PR TITLE
Add typing to HasFactory the Laravel way

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -462,7 +462,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
 
         sort($traits);
 
-        return Str::replaceFirst('use HasFactory', 'use ' . implode(', ', $traits), $stub);
+        return Str::replaceFirst('use HasFactory;', 'use ' . implode(', ', $traits) . ';', $stub);
     }
 
     protected function dateColumns(array $columns)

--- a/stubs/model.class.stub
+++ b/stubs/model.class.stub
@@ -6,5 +6,6 @@ namespace {{ namespace }};
 
 class {{ class }} extends Model
 {
+    /** @use HasFactory<\Database\Factories\{{ class }}Factory> */
     use HasFactory;
 }


### PR DESCRIPTION
Hi, looks like I was beat to it regarding this [commit](https://github.com/laravel-shift/blueprint/commit/1a0a5bbe78af3af8e18ea667c359307f8eef915f).

Context: I'm currently working on a project that uses Laravel's React Starter Kit and I found myself having to customize some stubs and generators more than I thought I would.

Like your last commit and this one, I will create some pull requests that aligns more with Laravel's new starter kits and the way `php artisan make:model` creates files.