### PR TITLE
Detect TypeScript in InertiaPageGenerator

### DIFF
--- a/src/Generators/Statements/InertiaPageGenerator.php
+++ b/src/Generators/Statements/InertiaPageGenerator.php
@@ -15,6 +15,7 @@ class InertiaPageGenerator extends StatementGenerator implements Generator
     protected array $adapters = [
         'vue3' => ['framework' => 'vue', 'extension' => '.vue'],
         'react' => ['framework' => 'react', 'extension' => '.jsx'],
+        'reactts' => ['framework' => 'react', 'extension' => '.tsx'],
         'svelte' => ['framework' => 'svelte', 'extension' => '.svelte'],
     ];
 
@@ -67,6 +68,14 @@ class InertiaPageGenerator extends StatementGenerator implements Generator
 
         if (preg_match('/@inertiajs\/(vue3|react|svelte)/i', $contents, $matches)) {
             $adapterKey = strtolower($matches[1]);
+
+            if ($adapterKey === 'react') {
+                $tsConfigPath = base_path('tsconfig.json');
+    
+                if ($this->filesystem->exists($tsConfigPath) || preg_match('/"typescript"/i', $contents)) {
+                    $adapterKey .= 'ts';
+                }
+            }
 
             return $this->adapters[$adapterKey] ?? null;
         }

--- a/tests/Feature/Generators/Statements/InertiaPageGeneratorTest.php
+++ b/tests/Feature/Generators/Statements/InertiaPageGeneratorTest.php
@@ -147,6 +147,7 @@ final class InertiaPageGeneratorTest extends TestCase
         return [
             ['vue', '"@inertiajs/vue3": "^2.0.0"', 'resources/js/Pages/Customer/Show.vue', '.vue'],
             ['react', '"@inertiajs/react": "^2.0.0"', 'resources/js/Pages/Customer/Show.jsx', '.jsx'],
+            ['react', '"@inertiajs/react": "^2.0.0", "typescript": "^5.0.0"', 'resources/js/Pages/Customer/Show.tsx', '.tsx'],
             ['svelte', '"@inertiajs/svelte": "^2.0.0"', 'resources/js/Pages/Customer/Show.svelte', '.svelte'],
         ];
     }

--- a/tests/fixtures/inertia-pages/customer-show.tsx
+++ b/tests/fixtures/inertia-pages/customer-show.tsx
@@ -1,0 +1,10 @@
+import { Head } from '@inertiajs/react'
+
+export default function Show({ customer, customers }) {
+  return (
+    <div>
+      <Head title="Customer Show" />
+      <h1>Customer Show</h1>
+    </div>
+  )
+}


### PR DESCRIPTION
I'm using React with TypeScript and I've been renaming `.jsx` to `.tsx` files a lot so this would help a lot when dealing with several views.

I tried to do something for Vue and Svelte as well, but I couldn't manage to properly mock the additional `Filesystem` calls in [InertiaPageGeneratorTest](https://github.com/laravel-shift/blueprint/blob/fe90c6ab736fd8fa5acba04c8f4d0547da0be092/tests/Feature/Generators/Statements/InertiaPageGeneratorTest.php#L88) : I kept encountering this [confusing message](https://github.com/laravel/framework/issues/49502).