### PR TITLE
Add 'int' => 'integer' mapping in ModelLexer

### DIFF
--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -40,6 +40,7 @@ class ModelLexer implements Lexer
         'geometry' => 'geometry',
         'geometrycollection' => 'geometryCollection',
         'increments' => 'increments',
+        'int' => 'integer',
         'integer' => 'integer',
         'ipaddress' => 'ipAddress',
         'json' => 'json',


### PR DESCRIPTION
As caught by JMac on stream today, this adds "int" as a reference to "integer" in the Model Lexer since it's such a common way to reference integers that it acts as an intuitive guard rail