### PR TITLE
Fix MigrationGenerator.php for some keys with underscore

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -320,7 +320,7 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
                 $on_update_suffix = '->cascadeOnUpdate()';
             }
 
-            if ($column_name === Str::singular($table) . '_' . $column) {
+            if ($column_name === Str::singular($table) . '_' . $column && !Str::contains($column, '_') {
                 return self::INDENT . "{$prefix}->constrained(){$on_delete_suffix}{$on_update_suffix}";
             }
 


### PR DESCRIPTION
In cases where column is like:
agent_party_id: id foreign:agents.party_id
migration was created like:
$table->foreignId('agent_party_id')->constrained(); which is wrong, since this sintax assumes agent_parties table and id key. Check for _ in column fixed this.