### PR TITLE
Fix pivot table migration building

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -381,7 +381,8 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
     {
         $definition = '';
         foreach ($segments as $segment) {
-            $column = Str::before(Str::snake($segment), ':');
+            $key = Str::before($segment, ":");
+            $column = Str::snake($key);
             $references = 'id';
             $on = Str::plural($column);
             $foreign = Str::singular($column) . '_' . $references;
@@ -389,7 +390,7 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
             if (config('blueprint.use_constraints')) {
                 $this->hasForeignKeyConstraints = true;
 
-                $type = isset($models[$segment]) ? $models[$segment]->idType() : 'id';
+                $type = isset($models[$key]) ? $models[$key]->idType() : 'id';
                 $definition .= $this->buildForeignKey($foreign, $on, $type) . ';' . PHP_EOL;
             } else {
                 $definition .= $this->generateForeignKeyDefinition($segment, $foreign, $models);


### PR DESCRIPTION
When the belongstomany attribute was given a special name, the id column type identifying wasn't working and would fall back to the usual integer id, causing errors. Now, by considering as a key the string before the `:`, it should work.