### PR TITLE
Register custom shorthands

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -13,6 +13,50 @@ class Blueprint
 
     private array $generators = [];
 
+    private array $shorthands = [];
+
+    public function registerShorthand(string $shorthand, \Closure $callback): void
+    {
+        $this->shorthands[$shorthand] = $callback;
+    }
+
+    private function expandShorthands(string $content): string
+    {
+        $content = preg_replace_callback(
+            '/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)(: true)?$/mi',
+            fn ($matches) => $matches[1] . strtolower($matches[2]) . ': ' . $matches[2],
+            $content
+        );
+
+        $content = preg_replace_callback(
+            '/^(\s+)resource?$/mi',
+            fn ($matches) => $matches[1] . 'resource: web',
+            $content
+        );
+
+        $content = preg_replace_callback(
+            '/^(\s+)invokable?$/mi',
+            fn ($matches) => $matches[1] . 'invokable: true',
+            $content
+        );
+
+        $content = preg_replace_callback(
+            '/^(\s+)(ulid|uuid)(: true)?$/mi',
+            fn ($matches) => $matches[1] . 'id: ' . $matches[2] . ' primary',
+            $content
+        );
+
+        foreach ($this->shorthands as $shorthand => $callback) {
+            $content = preg_replace_callback(
+                '/^(\s+)' . preg_quote($shorthand, '/') . '$/mi',
+                $callback,
+                $content
+            );
+        }
+
+        return $content;
+    }
+
     public static function relativeNamespace(string $fullyQualifiedClassName): string
     {
         $namespace = config('blueprint.namespace') . '\\';
@@ -39,36 +83,7 @@ class Blueprint
         }
 
         $content = $this->transformDuplicatePropertyKeys($content);
-
-        $content = preg_replace_callback(
-            '/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?)$/mi',
-            fn ($matches) => $matches[1] . strtolower($matches[2]) . ': ' . $matches[2],
-            $content
-        );
-
-        $content = preg_replace_callback(
-            '/^(\s+)(id|timestamps(Tz)?|softDeletes(Tz)?): true$/mi',
-            fn ($matches) => $matches[1] . strtolower($matches[2]) . ': ' . $matches[2],
-            $content
-        );
-
-        $content = preg_replace_callback(
-            '/^(\s+)resource?$/mi',
-            fn ($matches) => $matches[1] . 'resource: web',
-            $content
-        );
-
-        $content = preg_replace_callback(
-            '/^(\s+)invokable?$/mi',
-            fn ($matches) => $matches[1] . 'invokable: true',
-            $content
-        );
-
-        $content = preg_replace_callback(
-            '/^(\s+)(ulid|uuid)(: true)?$/mi',
-            fn ($matches) => $matches[1] . 'id: ' . $matches[2] . ' primary',
-            $content
-        );
+        $content = $this->expandShorthands($content);
 
         return Yaml::parse($content);
     }

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -625,6 +625,28 @@ final class BlueprintTest extends TestCase
     }
 
     #[Test]
+    public function it_replaces_custom_shorthands(): void
+    {
+        $this->subject->registerShorthand('custom', fn ($matches) => $matches[1] . 'custom: shorthand');
+
+        $blueprint = <<<'DRAFT'
+models:
+  Person:
+    custom
+    another: custom
+DRAFT;
+
+        $this->assertEquals([
+            'models' => [
+                'Person' => [
+                    'custom' => 'shorthand',
+                    'another' => 'custom',
+                ],
+            ],
+        ], $this->subject->parse($blueprint));
+    }
+
+    #[Test]
     public function it_parses_yaml_with_dashed_syntax(): void
     {
         $definition = $this->fixture('drafts/readme-example-dashes.yaml');


### PR DESCRIPTION
After presenting Blueprint at Laracon AU 2025 an attendee suggested a no-brainer feature - the ability to register custom _shorthands_.

This would be incredibly useful for teams that have a common set of columns or statements they define for models or controllers. It also aligns with Blueprint's _type less, generate more_ motto.

Here's an example of registering a custom _shorthand_.

```php
$blueprint = resolve(Blueprint::class);
$blueprint->registerShorthand('customShorthand', function ($indent) {
    return $indent . 'expanded: definition';
});
```

For now, the YAML returned from the callback must be complete. That is, it can not contain any _shorthands_. When returning multiple lines, be sure to indent each one.