### PR TITLE
Add PHPDoc annotations to stubs for better PHPStan support (#738)

### DIFF
--- a/tests/fixtures/models/disable-auto-columns-phpdoc.php
+++ b/tests/fixtures/models/disable-auto-columns-phpdoc.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class State extends Model
 {
+    /** @use HasFactory<\Database\Factories\StateFactory> */
     use HasFactory;
 
     /**

--- a/tests/fixtures/models/foreign-key-shorthand-phpdoc.php
+++ b/tests/fixtures/models/foreign-key-shorthand-phpdoc.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class Comment extends Model
 {
+    /** @use HasFactory<\Database\Factories\CommentFactory> */
     use HasFactory;
 
     /**

--- a/tests/fixtures/models/readme-example-phpdoc.php
+++ b/tests/fixtures/models/readme-example-phpdoc.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class Post extends Model
 {
+    /** @use HasFactory<\Database\Factories\PostFactory> */
     use HasFactory;
 
     /**

--- a/tests/fixtures/models/relationships-phpdoc.php
+++ b/tests/fixtures/models/relationships-phpdoc.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class Comment extends Model
 {
+    /** @use HasFactory<\Database\Factories\CommentFactory> */
     use HasFactory;
 
     /**

--- a/tests/fixtures/models/soft-deletes-phpdoc.php
+++ b/tests/fixtures/models/soft-deletes-phpdoc.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  */
 class Comment extends Model
 {
+    /** @use HasFactory<\Database\Factories\CommentFactory> */
     use HasFactory, SoftDeletes;
 
     /**


### PR DESCRIPTION

## What stubs were updated

- **Model generation output (PHPDoc-enabled mode)**:
  - Models generated when `blueprint.generate_phpdocs=true` now include a **trait-level PHPDoc `@use` annotation** for `HasFactory`.
- **No stub template file was changed** (e.g. [stubs/model.class.stub](cci:7://file:///var/www/html/laravel-shift/blueprint/stubs/model.class.stub:0:0-0:0) stayed the same).
  - The change is implemented in the generator: [src/Generators/ModelGenerator.php](cci:7://file:///var/www/html/laravel-shift/blueprint/src/Generators/ModelGenerator.php:0:0-0:0) (overrides trait rendering for models).
- **Test fixtures updated** to reflect the new expected output:
  - [tests/fixtures/models/readme-example-phpdoc.php](cci:7://file:///var/www/html/laravel-shift/blueprint/tests/fixtures/models/readme-example-phpdoc.php:0:0-0:0)
  - [tests/fixtures/models/relationships-phpdoc.php](cci:7://file:///var/www/html/laravel-shift/blueprint/tests/fixtures/models/relationships-phpdoc.php:0:0-0:0)
  - [tests/fixtures/models/soft-deletes-phpdoc.php](cci:7://file:///var/www/html/laravel-shift/blueprint/tests/fixtures/models/soft-deletes-phpdoc.php:0:0-0:0)
  - [tests/fixtures/models/disable-auto-columns-phpdoc.php](cci:7://file:///var/www/html/laravel-shift/blueprint/tests/fixtures/models/disable-auto-columns-phpdoc.php:0:0-0:0)
  - [tests/fixtures/models/foreign-key-shorthand-phpdoc.php](cci:7://file:///var/www/html/laravel-shift/blueprint/tests/fixtures/models/foreign-key-shorthand-phpdoc.php:0:0-0:0)

## Example before / after

**Before (generated model, PHPDoc enabled):**
```php
class Post extends Model
{
    use HasFactory;
}
```

**After (generated model, PHPDoc enabled):**
```php
class Post extends Model
{
    /** @use HasFactory<\Database\Factories\PostFactory> */
    use HasFactory;
}
```

**SoftDeletes stays a real trait (no regression):**
```php
class Comment extends Model
{
    /** @use HasFactory<\Database\Factories\CommentFactory> */
    use HasFactory, SoftDeletes;
}
```

## How this improves static analysis (PHPStan / IDE type inference)

- **Eliminates missing/unclear generic warnings** for `HasFactory` by explicitly declaring the factory type via `@use HasFactory<...>`.
- **Improves IDE autocomplete and navigation**:
  - IDEs can more reliably infer the associated `Factory` class for a model and offer better completion for factory-related calls.
- **Keeps runtime behavior unchanged**:
  - This is purely an annotation enhancement; traits like `SoftDeletes` remain actual `use SoftDeletes;` statements (not moved into PHPDoc).