### PR TITLE
Fix CI failing on Symfony 8.1.x yaml formatting { } to {} 

### DIFF
--- a/tests/Feature/Commands/EraseCommandTest.php
+++ b/tests/Feature/Commands/EraseCommandTest.php
@@ -6,6 +6,7 @@ use Blueprint\Blueprint;
 use Blueprint\Tracer;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Yaml\Yaml;
 use Tests\TestCase;
 
 /**
@@ -45,7 +46,9 @@ final class EraseCommandTest extends TestCase
             'created_file2.php',
         ]);
 
-        $this->filesystem->expects('put')->with('.blueprint', '{  }');
+        $this->filesystem->expects('put')->with('.blueprint', \Mockery::on(
+            static fn (string $contents): bool => Yaml::parse($contents) === []
+        ));
         $this->filesystem->expects('exists')->with('app/Models');
 
         $this->artisan('blueprint:erase')
@@ -62,7 +65,9 @@ final class EraseCommandTest extends TestCase
             ->with('.blueprint')
             ->andReturn("updated:\n  -  updated_file1.php\n  -  updated_file2.php");
 
-        $this->filesystem->expects('put')->with('.blueprint', '{  }');
+        $this->filesystem->expects('put')->with('.blueprint', \Mockery::on(
+            static fn (string $contents): bool => Yaml::parse($contents) === []
+        ));
         $this->filesystem->expects('exists')->with('app/Models');
 
         $this->artisan('blueprint:erase')


### PR DESCRIPTION
## Summary
Fix CI so that failing Symfony 8.1.x yaml formatting no longer fails.

Symfony YAML 8.1.x serializes an empty map as `{}` instead of the previous `{  }`. The `EraseCommandTest` mocks compare the serialized string literally, causing the PHP 8.4 / Laravel 13 stable matrix jobs to fail even though both values represent the same empty map.

This parses the YAML passed to `Filesystem::put()` and asserts its value is an empty array, avoiding assertions on serializer whitespace.

### Link to the Symfony change
https://github.com/symfony/yaml/commit/2a0f3cf4b360ad217534d189646d6e69ca823be2

## Scope
- Test-only change
- No production behavior changes
- Handles both old and new Symfony YAML formatting

## Validation

- `git diff --check` passes
- The complete GitHub Actions matrix will validate supported PHP, Laravel, and Symfony YAML combinations