### PR TITLE
Add `meta.plural` for custom relationship pluralization

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -210,9 +210,12 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
                     $controller->model() &&
                     ($statement instanceof QueryStatement || $statement instanceof EloquentStatement || $statement instanceof ResourceStatement)
                 ) {
+                    $related_model = $this->tree->modelForContext($controller->prefix());
+                    $relation = $related_model ? Str::camel($related_model->pluralName()) : Str::plural(Str::lower($controller->prefix()));
+
                     $body = str_replace(
                         ['::all', Str::singular($controller->prefix()) . '::'],
-                        ['::get', '$' . Str::lower($controller->model()) . '->' . Str::plural(Str::lower($controller->prefix())) . '()->'],
+                        ['::get', '$' . Str::lower($controller->model()) . '->' . $relation . '()->'],
                         $body
                     );
                 }
@@ -260,7 +263,7 @@ class ControllerGenerator extends AbstractClassGenerator implements Generator
         ];
 
         $related = $this->tree->modelForContext($controller->storeRelation(), true);
-        $relation = Str::camel(Str::plural($related->name()));
+        $relation = Str::camel($related->pluralName());
         $this->resolveRelation($model, $relation);
         $columns = $this->writableColumns($related, $model->name());
         $lines[] = '';

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -338,6 +338,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
             foreach ($references as $reference) {
                 $is_model_fqn = Str::startsWith($reference, '\\');
                 $is_pivot = false;
+                $has_custom_relation_name = false;
 
                 $custom_template = $template;
                 $key = null;
@@ -355,6 +356,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
                         $method_name = $column_name;
                     } else {
                         $method_name = Str::beforeLast($column_name, '_id');
+                        $has_custom_relation_name = true;
                     }
 
                     if (Str::contains($foreign_reference, '.')) {
@@ -364,6 +366,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
                             $key = null;
                         }
                         $method_name = $is_model_fqn ? Str::lower(Str::afterLast($class, '\\')) : Str::lower($class);
+                        $has_custom_relation_name = false;
                     } else {
                         $class = $foreign_reference;
                     }
@@ -414,7 +417,12 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
                 if ($type === 'morphTo') {
                     $method_name = Str::lower($class_name);
                 } elseif (in_array($type, ['hasMany', 'belongsToMany', 'morphMany', 'morphToMany', 'morphedByMany'])) {
-                    $method_name = Str::plural($is_pivot ? $column_name : $method_name);
+                    if ($is_pivot || $has_custom_relation_name) {
+                        $method_name = Str::plural($is_pivot ? $column_name : $method_name);
+                    } else {
+                        $related_model = $this->tree->modelForContext($class_name);
+                        $method_name = $related_model ? $related_model->pluralName() : Str::plural($method_name);
+                    }
                 }
 
                 $relationship_type = 'Illuminate\\Database\\Eloquent\\Relations\\' . Str::studly($type === 'morphedByMany' ? 'morphToMany' : $type);

--- a/src/Generators/PestTestGenerator.php
+++ b/src/Generators/PestTestGenerator.php
@@ -442,7 +442,8 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
 
                         if ($model_columns) {
                             $indent = str_pad(' ', 8);
-                            $plural = Str::plural($variable);
+                            $related_model = $this->tree->modelForContext($model);
+                            $plural = $related_model ? Str::camel($related_model->pluralName()) : Str::plural($variable);
                             $assertion = sprintf('$%s = %s::query()', $plural, $model);
                             foreach ($model_columns as $key => $datum) {
                                 $assertion .= PHP_EOL . sprintf('%s->where(\'%s\', %s)', $indent, $key, $datum);
@@ -455,7 +456,9 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
                         } else {
                             $this->addImport($controller, 'function Pest\\Laravel\\assertDatabaseHas');
 
-                            $assertions['generic'][] = 'assertDatabaseHas(' . Str::camel(Str::plural($model)) . ', [ /* ... */ ]);';
+                            $related_model = $this->tree->modelForContext($model);
+                            $plural = $related_model ? $related_model->pluralName() : Str::plural($model);
+                            $assertions['generic'][] = 'assertDatabaseHas(' . Str::camel($plural) . ', [ /* ... */ ]);';
                         }
                     } elseif ($statement->operation() === 'find') {
                         $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
@@ -490,7 +493,9 @@ class PestTestGenerator extends AbstractClassGenerator implements Generator
                         }
                     }
                 } elseif ($statement instanceof QueryStatement) {
-                    $setup['data'][] = sprintf('$%s = %s::factory()->count(3)->create();', Str::plural($variable), $model);
+                    $related_model = $this->tree->modelForContext($model);
+                    $plural = $related_model ? Str::camel($related_model->pluralName()) : Str::plural($variable);
+                    $setup['data'][] = sprintf('$%s = %s::factory()->count(3)->create();', $plural, $model);
 
                     $this->addImport($controller, $modelNamespace . '\\' . $this->determineModel($controller->prefix(), $statement->model()));
                 }
@@ -724,7 +729,7 @@ END;
         $this->addImport($controller, 'function Pest\\Laravel\\assertDatabaseHas');
 
         $related = $this->tree->modelForContext($controller->storeRelation(), true);
-        $relation = Str::camel(Str::plural($related->name()));
+        $relation = Str::camel($related->pluralName());
         $this->storeRelatedModel($model, $relation);
         $data = [];
         $assertion = ["'" . Str::snake(Str::singular($controller->prefix())) . "_id' => \$" . Str::camel($model->name()) . '->id'];
@@ -752,7 +757,10 @@ END;
     {
         foreach ($model->relationships()['hasMany'] ?? [] as $reference) {
             $context = Str::before($reference, ':');
-            if (Str::camel(Str::plural($context)) === $relation) {
+            $related = $this->tree->modelForContext($context);
+            $plural = $related ? $related->pluralName() : Str::plural($context);
+
+            if (Str::camel($plural) === $relation) {
                 if (Str::contains($reference, ':')) {
                     throw new \InvalidArgumentException('Aliases are unsupported for store relationships.');
                 }

--- a/src/Generators/PhpUnitTestGenerator.php
+++ b/src/Generators/PhpUnitTestGenerator.php
@@ -440,7 +440,8 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
 
                         if ($model_columns) {
                             $indent = str_pad(' ', 12);
-                            $plural = Str::plural($variable);
+                            $related_model = $this->tree->modelForContext($model);
+                            $plural = $related_model ? Str::camel($related_model->pluralName()) : Str::plural($variable);
                             $assertion = sprintf('$%s = %s::query()', $plural, $model);
                             foreach ($model_columns as $key => $datum) {
                                 $assertion .= PHP_EOL . sprintf('%s->where(\'%s\', %s)', $indent, $key, $datum);
@@ -451,7 +452,9 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                             $assertions['sanity'][] = '$this->assertCount(1, $' . $plural . ');';
                             $assertions['sanity'][] = sprintf('$%s = $%s->first();', $variable, $plural);
                         } else {
-                            $assertions['generic'][] = '$this->assertDatabaseHas(' . Str::camel(Str::plural($model)) . ', [ /* ... */ ]);';
+                            $related_model = $this->tree->modelForContext($model);
+                            $plural = $related_model ? $related_model->pluralName() : Str::plural($model);
+                            $assertions['generic'][] = '$this->assertDatabaseHas(' . Str::camel($plural) . ', [ /* ... */ ]);';
                         }
                     } elseif ($statement->operation() === 'find') {
                         $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
@@ -483,7 +486,9 @@ class PhpUnitTestGenerator extends AbstractClassGenerator implements Generator
                     }
                 } elseif ($statement instanceof QueryStatement) {
                     $this->addRefreshDatabaseTrait($controller);
-                    $setup['data'][] = sprintf('$%s = %s::factory()->count(3)->create();', Str::plural($variable), $model);
+                    $related_model = $this->tree->modelForContext($model);
+                    $plural = $related_model ? Str::camel($related_model->pluralName()) : Str::plural($variable);
+                    $setup['data'][] = sprintf('$%s = %s::factory()->count(3)->create();', $plural, $model);
 
                     $this->addImport($controller, $modelNamespace . '\\' . $this->determineModel($controller->prefix(), $statement->model()));
                 }
@@ -636,7 +641,7 @@ END;
         $model = $this->tree->modelForContext(Str::singular($controller->prefix()), true);
 
         $related = $this->tree->modelForContext($controller->storeRelation(), true);
-        $relation = Str::camel(Str::plural($related->name()));
+        $relation = Str::camel($related->pluralName());
         $this->storeRelatedModel($model, $relation);
         $data = [];
         $assertion = ["'" . Str::snake(Str::singular($controller->prefix())) . "_id' => \$" . Str::camel($model->name()) . '->id'];
@@ -663,7 +668,10 @@ END;
     {
         foreach ($model->relationships()['hasMany'] ?? [] as $reference) {
             $context = Str::before($reference, ':');
-            if (Str::camel(Str::plural($context)) === $relation) {
+            $related = $this->tree->modelForContext($context);
+            $plural = $related ? $related->pluralName() : Str::plural($context);
+
+            if (Str::camel($plural) === $relation) {
                 if (Str::contains($reference, ':')) {
                     throw new \InvalidArgumentException('Aliases are unsupported for store relationships.');
                 }

--- a/src/Generators/Statements/FormRequestGenerator.php
+++ b/src/Generators/Statements/FormRequestGenerator.php
@@ -79,7 +79,7 @@ class FormRequestGenerator extends AbstractClassGenerator implements Generator
 
         $model = $this->tree->modelForContext($context, true);
         $related = $this->tree->modelForContext($controller->storeRelation(), true);
-        $relation = Str::camel(Str::plural($related->name()));
+        $relation = Str::camel($related->pluralName());
         $this->relatedModel($model, $relation);
         $output .= PHP_EOL . self::INDENT . "'{$relation}' => ['required', 'array'],";
         $output .= PHP_EOL . self::INDENT . "'{$relation}.*' => ['required', 'array'],";
@@ -123,7 +123,10 @@ class FormRequestGenerator extends AbstractClassGenerator implements Generator
     {
         foreach ($model->relationships()['hasMany'] ?? [] as $reference) {
             $context = Str::before($reference, ':');
-            if (Str::camel(Str::plural($context)) === $relation) {
+            $related = $this->tree->modelForContext($context);
+            $plural = $related ? $related->pluralName() : Str::plural($context);
+
+            if (Str::camel($plural) === $relation) {
                 if (Str::contains($reference, ':')) {
                     throw new \InvalidArgumentException('Aliases are unsupported for store relationships.');
                 }

--- a/src/Generators/Statements/ResourceGenerator.php
+++ b/src/Generators/Statements/ResourceGenerator.php
@@ -108,7 +108,7 @@ class ResourceGenerator extends StatementGenerator implements Generator
 
             if (in_array($type, ['hasMany', 'belongsToMany', 'morphMany'])) {
                 $relation_resource_name = $relation_model->name() . 'Collection';
-                $method_name = Str::plural($method_name);
+                $method_name = lcfirst($relation_model->pluralName());
             } else {
                 $relation_resource_name = $relation_model->name() . 'Resource';
             }

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -142,6 +142,10 @@ class ModelLexer implements Lexer
                 $model->setTableName($columns['meta']['table']);
             }
 
+            if (isset($columns['meta']['plural'])) {
+                $model->setPluralName($columns['meta']['plural']);
+            }
+
             if (!empty($columns['meta']['pivot'])) {
                 $model->setPivot();
             }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -26,6 +26,8 @@ class Model implements BlueprintModel
 
     private string $table;
 
+    private string $plural;
+
     private array $columns = [];
 
     private array $relationships = [];
@@ -169,6 +171,21 @@ class Model implements BlueprintModel
     public function setTableName($name): void
     {
         $this->table = $name;
+    }
+
+    public function usesCustomPluralName(): bool
+    {
+        return isset($this->plural);
+    }
+
+    public function pluralName(): string
+    {
+        return $this->plural ?? Str::plural($this->name());
+    }
+
+    public function setPluralName($name): void
+    {
+        $this->plural = $name;
     }
 
     public function timestampsDataType(): string

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -158,6 +158,40 @@ final class ModelGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function output_generates_relationships_using_meta_plural_override(): void
+    {
+        $this->filesystem->expects('stub')
+            ->with('model.class.stub')
+            ->andReturn($this->stub('model.class.stub'));
+        $this->filesystem->expects('stub')
+            ->twice()
+            ->with('model.fillable.stub')
+            ->andReturn($this->stub('model.fillable.stub'));
+        $this->filesystem->expects('stub')
+            ->twice()
+            ->with('model.casts.stub')
+            ->andReturn($this->stub('model.casts.stub'));
+        $this->filesystem->expects('stub')
+            ->twice()
+            ->with('model.method.stub')
+            ->andReturn($this->stub('model.method.stub'));
+
+        $this->filesystem->expects('exists')
+            ->twice()
+            ->with('app/Models')
+            ->andReturnTrue();
+        $this->filesystem->expects('put')
+            ->with('app/Models/Nazione.php', $this->fixture('models/model-relationships-custom-plural-nazione.php'));
+        $this->filesystem->expects('put')
+            ->with('app/Models/Regione.php', $this->fixture('models/model-relationships-custom-plural-regione.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/model-relationships-custom-plural.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertSame(['created' => [['Model', 'app/Models/Nazione.php'], ['Model', 'app/Models/Regione.php']]], $this->subject->output($tree));
+    }
+
+    #[Test]
     public function output_generates_relationships_added_with_full_model_namespace(): void
     {
         $this->files->expects('stub')

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -763,6 +763,7 @@ final class ModelLexerTest extends TestCase
                     'meta' => [
                         'pivot' => true,
                         'table' => 'post',
+                        'plural' => 'posti',
                     ],
                 ],
             ],
@@ -776,6 +777,8 @@ final class ModelLexerTest extends TestCase
         $model = $actual['models']['Post'];
         $this->assertEquals('Post', $model->name());
         $this->assertSame('post', $model->tableName());
+        $this->assertTrue($model->usesCustomPluralName());
+        $this->assertSame('posti', $model->pluralName());
         $this->assertTrue($model->isPivot());
         $this->assertTrue($model->usesTimestamps());
 

--- a/tests/fixtures/drafts/model-relationships-custom-plural.yaml
+++ b/tests/fixtures/drafts/model-relationships-custom-plural.yaml
@@ -1,0 +1,15 @@
+models:
+  Nazione:
+    codice: string:2
+
+    relationships:
+      hasMany: Regione
+
+  Regione:
+    meta:
+      plural: regioni
+
+    nazione_id: id
+
+    relationships:
+      belongsTo: Nazione

--- a/tests/fixtures/models/model-relationships-custom-plural-nazione.php
+++ b/tests/fixtures/models/model-relationships-custom-plural-nazione.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Nazione extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'codice',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'id' => 'integer',
+        ];
+    }
+
+    public function regioni(): HasMany
+    {
+        return $this->hasMany(Regione::class);
+    }
+}

--- a/tests/fixtures/models/model-relationships-custom-plural-regione.php
+++ b/tests/fixtures/models/model-relationships-custom-plural-regione.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Regione extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'nazione_id',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'id' => 'integer',
+            'nazione_id' => 'integer',
+        ];
+    }
+
+    public function nazione(): BelongsTo
+    {
+        return $this->belongsTo(Nazione::class);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `meta.plural` key so a model's plural form can be declared explicitly instead of always being derived by `Str::plural()`. This helps for pluralizations that don't follow English rules (e.g. Italian `Regione` → `Regioni`).

## Syntax

```yaml
models:
  Nazione:
    codice: string:2

    relationships:
      hasMany: Regione

  Regione:
    meta:
      plural: regioni

    nazione_id: id

    relationships:
      belongsTo: Nazione
```

## Generated Model example

```php
class Nazione extends Model
{
    use HasFactory;

    public function regioni(): HasMany
    {
        return $this->hasMany(Regione::class);
    }
}
```


**Note::** This does **not** touch every `Str::plural()` call site in the codebase. Left out, with reasons:

- **`RouteGenerator`** — `Tree` isn't stored on the class at the point routes are built; needs its own plumbing change unrelated to this feature.
- **`Models\Statements\QueryStatement`** — has no `Tree`/model access at all; wiring this in would mean injecting `Tree` into the Statement layer and touching every caller.
- **`MigrationGenerator::buildForeignKey`** — lowest priority of the four, since users can already override the FK target table explicitly via `foreign:table_name`, which is the workaround the issue's own YAML example uses.
- **`ControllerLexer`'s `[plural]` placeholder** — runs during lexing, before any `Tree` exists, so honoring the override there means deferring that substitution to generation time — a structural change, not a naming one.

These are independent follow-ups if wanted, not blockers for this change.

---
Closes #769