### PR TITLE
Resolve related models by tree instead of inflecting strings in migrations/factories

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -96,7 +96,8 @@ class FactoryGenerator extends AbstractClassGenerator implements Generator
                     }
                 }
 
-                $class = Str::studly(Str::singular($table));
+                $related_model = $this->tree->modelForContext($table);
+                $class = $related_model ? $related_model->name() : Str::studly(Str::singular($table));
                 $reference = $this->fullyQualifyModelReference($class) ?? $model;
 
                 $this->addImport($model, $reference->fullyQualifiedNamespace() . '\\' . $class);

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -60,6 +60,7 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
 
     public function output(Tree $tree, $overwrite = false): array
     {
+        $this->tree = $tree;
         $tables = ['tableNames' => [], 'pivotTableNames' => [], 'polymorphicManyToManyTables' => []];
 
         $stub = $this->filesystem->stub('migration.stub');
@@ -272,20 +273,31 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
     protected function buildForeignKey(string $column_name, ?string $on, string $type, array $attributes = [], array $modifiers = []): string
     {
         if (is_null($on)) {
-            $table = Str::plural(Str::beforeLast($column_name, '_'));
+            $context = Str::beforeLast($column_name, '_');
+            $table = Str::plural($context);
             $column = Str::afterLast($column_name, '_');
         } elseif (Str::contains($on, '.')) {
-            [$table, $column] = explode('.', $on);
+            [$context, $column] = explode('.', $on);
+            $table = $context;
         } elseif (Str::contains($on, '\\')) {
-            $table = Str::snake(Str::plural(Str::afterLast($on, '\\')));
+            $context = Str::afterLast($on, '\\');
+            $table = Str::snake(Str::plural($context));
             $column = Str::afterLast($column_name, '_');
         } else {
-            $table = Str::snake(Str::plural($on));
+            $context = $on;
+            $table = Str::snake(Str::plural($context));
             $column = Str::afterLast($column_name, '_');
         }
 
         if ($this->isIdColumnType($type) && !empty($attributes)) {
-            $table = Str::lower(Str::plural($attributes[0]));
+            $context = $attributes[0];
+            $table = Str::lower(Str::plural($context));
+        }
+
+        $related_model = $this->tree->modelForContext($context);
+        $uses_custom_table = $related_model && $related_model->usesCustomTableName();
+        if ($related_model) {
+            $table = $related_model->tableName();
         }
 
         $on_delete_suffix = $on_update_suffix = null;
@@ -320,7 +332,7 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
                 $on_update_suffix = '->cascadeOnUpdate()';
             }
 
-            if ($column_name === Str::singular($table) . '_' . $column) {
+            if (!$uses_custom_table && $column_name === Str::singular($table) . '_' . $column) {
                 return self::INDENT . "{$prefix}->constrained(){$on_delete_suffix}{$on_update_suffix}";
             }
 

--- a/tests/Feature/Generators/FactoryGeneratorTest.php
+++ b/tests/Feature/Generators/FactoryGeneratorTest.php
@@ -122,6 +122,39 @@ final class FactoryGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function output_resolves_singular_class_name_from_related_model_instead_of_inflecting_it(): void
+    {
+        $this->filesystem->expects('stub')
+            ->with($this->factoryStub)
+            ->andReturn($this->stub($this->factoryStub));
+
+        $this->filesystem->expects('exists')
+            ->times(4)
+            ->andReturnTrue();
+
+        $this->filesystem->expects('put')
+            ->with('database/factories/NazioneFactory.php', \Mockery::type('string'));
+        $this->filesystem->expects('put')
+            ->with('database/factories/RegioneFactory.php', \Mockery::type('string'));
+        $this->filesystem->expects('put')
+            ->with('database/factories/ProvinciaFactory.php', \Mockery::type('string'));
+        $this->filesystem->expects('put')
+            ->with('database/factories/ComuneFactory.php', $this->fixture('factories/issue-768-comune.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/issue-768.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertEquals([
+            'created' => [
+                ['Factory', 'database/factories/NazioneFactory.php'],
+                ['Factory', 'database/factories/RegioneFactory.php'],
+                ['Factory', 'database/factories/ProvinciaFactory.php'],
+                ['Factory', 'database/factories/ComuneFactory.php'],
+            ],
+        ], $this->subject->output($tree));
+    }
+
+    #[Test]
     public function output_respects_configuration(): void
     {
         $this->app['config']->set('blueprint.namespace', 'Some\\App');

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -157,6 +157,43 @@ final class MigrationGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function output_resolves_foreign_key_table_from_related_models_custom_table_name(): void
+    {
+        $this->filesystem->expects('stub')
+            ->with('migration.stub')
+            ->andReturn($this->stub('migration.stub'));
+
+        $now = Carbon::now();
+        Carbon::setTestNow($now);
+
+        $nazione_migration = str_replace('timestamp', $now->copy()->subSeconds(3)->format('Y_m_d_His'), 'database/migrations/timestamp_create_nazione_table.php');
+        $regione_migration = str_replace('timestamp', $now->copy()->subSeconds(2)->format('Y_m_d_His'), 'database/migrations/timestamp_create_regione_table.php');
+        $provincia_migration = str_replace('timestamp', $now->copy()->subSecond()->format('Y_m_d_His'), 'database/migrations/timestamp_create_provincia_table.php');
+        $comune_migration = str_replace('timestamp', $now->format('Y_m_d_His'), 'database/migrations/timestamp_create_comune_table.php');
+
+        $this->filesystem->expects('exists')->times(4)->andReturn(false);
+
+        $this->filesystem->expects('put')
+            ->with($nazione_migration, $this->fixture('migrations/issue-768-nazione.php'));
+        $this->filesystem->expects('put')
+            ->with($regione_migration, $this->fixture('migrations/issue-768-regione.php'));
+        $this->filesystem->expects('put')
+            ->with($provincia_migration, $this->fixture('migrations/issue-768-provincia.php'));
+        $this->filesystem->expects('put')
+            ->with($comune_migration, $this->fixture('migrations/issue-768-comune.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/issue-768.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertSame(['created' => [
+            ['Migration', $nazione_migration],
+            ['Migration', $regione_migration],
+            ['Migration', $provincia_migration],
+            ['Migration', $comune_migration],
+        ]], $this->subject->output($tree));
+    }
+
+    #[Test]
     public function using_ulids_output_also_creates_pivot_table_migration(): void
     {
         $this->filesystem->expects('stub')

--- a/tests/fixtures/drafts/issue-768.yaml
+++ b/tests/fixtures/drafts/issue-768.yaml
@@ -1,0 +1,38 @@
+models:
+
+  Nazione:
+    meta:
+      table: nazione
+    codice: string:2 unique
+    descrizione: string:100
+    relationships:
+      hasMany: Regione
+
+  Regione:
+    meta:
+      table: regione
+    codice: string:3
+    descrizione: string:100
+    nazione_id: id foreign:nazione
+    relationships:
+      belongsTo: Nazione
+      hasMany: Provincia
+
+  Provincia:
+    meta:
+      table: provincia
+    codice: string:3
+    descrizione: string:100
+    regione_id: id foreign:regione.id
+    relationships:
+      belongsTo: Regione
+      hasMany: Comune
+
+  Comune:
+    meta:
+      table: comune
+    codice: string:3
+    descrizione: string:100
+    provincia_id: id foreign:provincia
+    relationships:
+      belongsTo: Provincia

--- a/tests/fixtures/factories/issue-768-comune.php
+++ b/tests/fixtures/factories/issue-768-comune.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Provincia;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ComuneFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'codice' => fake()->regexify('[A-Za-z0-9]{3}'),
+            'descrizione' => fake()->regexify('[A-Za-z0-9]{100}'),
+            'provincia_id' => Provincia::factory(),
+        ];
+    }
+}

--- a/tests/fixtures/migrations/issue-768-comune.php
+++ b/tests/fixtures/migrations/issue-768-comune.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('comune', function (Blueprint $table) {
+            $table->id();
+            $table->string('codice', 3);
+            $table->string('descrizione', 100);
+            $table->foreignId('provincia_id')->constrained('provincia');
+            $table->timestamps();
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('comune');
+    }
+};

--- a/tests/fixtures/migrations/issue-768-nazione.php
+++ b/tests/fixtures/migrations/issue-768-nazione.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('nazione', function (Blueprint $table) {
+            $table->id();
+            $table->string('codice', 2)->unique();
+            $table->string('descrizione', 100);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('nazione');
+    }
+};

--- a/tests/fixtures/migrations/issue-768-provincia.php
+++ b/tests/fixtures/migrations/issue-768-provincia.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('provincia', function (Blueprint $table) {
+            $table->id();
+            $table->string('codice', 3);
+            $table->string('descrizione', 100);
+            $table->foreignId('regione_id')->constrained('regione');
+            $table->timestamps();
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('provincia');
+    }
+};

--- a/tests/fixtures/migrations/issue-768-regione.php
+++ b/tests/fixtures/migrations/issue-768-regione.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('regione', function (Blueprint $table) {
+            $table->id();
+            $table->string('codice', 3);
+            $table->string('descrizione', 100);
+            $table->foreignId('nazione_id')->constrained('nazione');
+            $table->timestamps();
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('regione');
+    }
+};


### PR DESCRIPTION
Fixes two related bugs reported in  #768, both caused by Blueprint inferring a related model's table/class name via `Str::plural()`/`Str::singular()` instead of resolving the actual model from the parsed tree.

---
Closes  #768