### PR TITLE
Add precision to timestamps and softdeletes

### DIFF
--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -240,11 +240,11 @@ class MigrationGenerator extends AbstractClassGenerator implements Generator
             $definition .= $index_definition;
         }
         if ($model->usesTimestamps()) {
-            $definition .= self::INDENT . '$table->' . $model->timestampsDataType() . '();' . PHP_EOL;
+            $definition .= self::INDENT . '$table->' . $model->timestampsDataType() . '(' . $model->timestampsPrecision() . ');' . PHP_EOL;
         }
 
         if ($model->usesSoftDeletes()) {
-            $definition .= self::INDENT . '$table->' . $model->softDeletesDataType() . '();' . PHP_EOL;
+            $definition .= self::INDENT . '$table->' . $model->softDeletesDataType() . '(' . $model->softDeletesPrecision() . ');' . PHP_EOL;
         }
 
         return trim($definition);

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -175,11 +175,13 @@ class ModelLexer implements Lexer
         if (isset($columns['timestamps'])) {
             if ($columns['timestamps'] === false) {
                 $model->disableTimestamps();
+            } else {
+                $model->enableTimestamps(precision: $this->extractPrecision($columns['timestamps']));
             }
 
             unset($columns['timestamps']);
         } elseif (isset($columns['timestampstz'])) {
-            $model->enableTimestamps(true);
+            $model->enableTimestamps(true, $this->extractPrecision($columns['timestampstz']));
             unset($columns['timestampstz']);
         } elseif (config('blueprint.types.timestamps') === false) {
             $model->disableTimestamps();
@@ -188,10 +190,10 @@ class ModelLexer implements Lexer
         }
 
         if (isset($columns['softdeletes'])) {
-            $model->enableSoftDeletes();
+            $model->enableSoftDeletes(precision: $this->extractPrecision($columns['softdeletes']));
             unset($columns['softdeletes']);
         } elseif (isset($columns['softdeletestz'])) {
-            $model->enableSoftDeletes(true);
+            $model->enableSoftDeletes(true, $this->extractPrecision($columns['softdeletestz']));
             unset($columns['softdeletestz']);
         }
 
@@ -239,6 +241,19 @@ class ModelLexer implements Lexer
         $this->inferMissingBelongsToRelationships($model);
 
         return $model;
+    }
+
+    private function extractPrecision(mixed $value): ?int
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        if (preg_match('/^precision:(\d+)$/i', trim($value), $matches)) {
+            return (int)$matches[1];
+        }
+
+        return null;
     }
 
     private function buildColumn(string $name, string $definition): Column

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -20,7 +20,11 @@ class Model implements BlueprintModel
 
     private string|bool $timestamps = 'timestamps';
 
+    private ?int $timestampsPrecision = null;
+
     private string|bool $softDeletes = false;
+
+    private ?int $softDeletesPrecision = null;
 
     private ?string $connection;
 
@@ -176,6 +180,11 @@ class Model implements BlueprintModel
         return $this->timestamps;
     }
 
+    public function timestampsPrecision(): ?int
+    {
+        return $this->timestampsPrecision;
+    }
+
     public function usesTimestamps(): bool
     {
         return $this->timestamps !== false;
@@ -186,9 +195,10 @@ class Model implements BlueprintModel
         $this->timestamps = false;
     }
 
-    public function enableTimestamps(bool $withTimezone = false): void
+    public function enableTimestamps(bool $withTimezone = false, ?int $precision = null): void
     {
         $this->timestamps = $withTimezone ? 'timestampsTz' : 'timestamps';
+        $this->timestampsPrecision = $precision;
     }
 
     public function softDeletesDataType(): string
@@ -196,14 +206,20 @@ class Model implements BlueprintModel
         return $this->softDeletes;
     }
 
+    public function softDeletesPrecision(): ?int
+    {
+        return $this->softDeletesPrecision;
+    }
+
     public function usesSoftDeletes(): bool
     {
         return $this->softDeletes !== false;
     }
 
-    public function enableSoftDeletes(bool $withTimezone = false): void
+    public function enableSoftDeletes(bool $withTimezone = false, ?int $precision = null): void
     {
         $this->softDeletes = $withTimezone ? 'softDeletesTz' : 'softDeletes';
+        $this->softDeletesPrecision = $precision;
         $this->addTrait(\Illuminate\Database\Eloquent\SoftDeletes::class);
     }
 

--- a/tests/Feature/Generators/MigrationGeneratorTest.php
+++ b/tests/Feature/Generators/MigrationGeneratorTest.php
@@ -682,6 +682,7 @@ final class MigrationGeneratorTest extends TestCase
             ['drafts/model-numeric-defaults.yaml', 'database/migrations/timestamp_create_numerics_table.php', 'migrations/model-numeric-defaults.php'],
             ['drafts/soft-deletes.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/soft-deletes.php'],
             ['drafts/with-timezones.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/with-timezones.php'],
+            ['drafts/timestamps-softdeletes-precision.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/timestamps-softdeletes-precision.php'],
             ['drafts/relationships.yaml', 'database/migrations/timestamp_create_comments_table.php', 'migrations/relationships.php'],
             ['drafts/models-with-custom-namespace.yaml', 'database/migrations/timestamp_create_categories_table.php', 'migrations/models-with-custom-namespace.php'],
             ['drafts/custom-indexes.yaml', 'database/migrations/timestamp_create_cooltables_table.php', 'migrations/custom-indexes.php'],

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -504,6 +504,82 @@ final class ModelLexerTest extends TestCase
     }
 
     #[Test]
+    public function it_sets_timestamps_precision(): void
+    {
+        $tokens = [
+            'models' => [
+                'Model' => [
+                    'timestamps' => 'precision:6',
+                ],
+            ],
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $model = $actual['models']['Model'];
+        $this->assertTrue($model->usesTimestamps());
+        $this->assertSame('timestamps', $model->timestampsDataType());
+        $this->assertSame(6, $model->timestampsPrecision());
+    }
+
+    #[Test]
+    public function it_sets_timestamps_precision_with_timezone(): void
+    {
+        $tokens = [
+            'models' => [
+                'Model' => [
+                    'timestampstz' => 'precision:6',
+                ],
+            ],
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $model = $actual['models']['Model'];
+        $this->assertTrue($model->usesTimestamps());
+        $this->assertSame('timestampsTz', $model->timestampsDataType());
+        $this->assertSame(6, $model->timestampsPrecision());
+    }
+
+    #[Test]
+    public function it_enables_soft_deletes_with_precision(): void
+    {
+        $tokens = [
+            'models' => [
+                'Model' => [
+                    'softdeletes' => 'precision:6',
+                ],
+            ],
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $model = $actual['models']['Model'];
+        $this->assertTrue($model->usesSoftDeletes());
+        $this->assertSame('softDeletes', $model->softDeletesDataType());
+        $this->assertSame(6, $model->softDeletesPrecision());
+    }
+
+    #[Test]
+    public function it_enables_soft_deletes_with_precision_and_timezone(): void
+    {
+        $tokens = [
+            'models' => [
+                'Model' => [
+                    'softdeletestz' => 'precision:6',
+                ],
+            ],
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $model = $actual['models']['Model'];
+        $this->assertTrue($model->usesSoftDeletes());
+        $this->assertSame('softDeletesTz', $model->softDeletesDataType());
+        $this->assertSame(6, $model->softDeletesPrecision());
+    }
+
+    #[Test]
     public function it_converts_foreign_shorthand_to_id(): void
     {
         $tokens = [

--- a/tests/fixtures/drafts/timestamps-softdeletes-precision.yaml
+++ b/tests/fixtures/drafts/timestamps-softdeletes-precision.yaml
@@ -1,0 +1,5 @@
+models:
+  Comment:
+    body: string
+    timestamps: precision:6
+    softdeletes: precision:6

--- a/tests/fixtures/migrations/timestamps-softdeletes-precision.php
+++ b/tests/fixtures/migrations/timestamps-softdeletes-precision.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->string('body');
+            $table->timestamps(6);
+            $table->softDeletes(6);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};


### PR DESCRIPTION
Adds support for specifying precision on `timestamps`/`timestampstz` and `softdeletes`/`softdeletestz` model columns (e.g. `timestamps: precision:6`)

---
Closes #773 