### PR TITLE
Add hasOneThrough and hasManyThrough relationship support

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -101,7 +101,7 @@
     },
     "relationships": {
       "type": "object",
-      "description": "Eloquent relationships this model defines. Each value is one model reference, or a comma-separated list of them. A reference may include a namespace (`\\App\\Models\\Team`), a custom foreign key alias (`Model:column`), or for belongsToMany/morphToMany, a custom pivot model (`Model:&PivotModel`). Relationship type keys are matched case-insensitively by Blueprint; the canonical camelCase spellings are listed here for autocomplete, but other casings are also accepted.",
+      "description": "Eloquent relationships this model defines. Each value is one model reference, or a comma-separated list of them. A reference may include a namespace (`\\App\\Models\\Team`), a custom foreign key alias (`Model:column`), or for belongsToMany/morphToMany, a custom pivot model (`Model:&PivotModel`). For hasOneThrough/hasManyThrough, the reference is `Target:Intermediate`. Relationship type keys are matched case-insensitively by Blueprint; the canonical camelCase spellings are listed here for autocomplete, but other casings are also accepted.",
       "properties": {
         "hasOne": { "$ref": "#/definitions/relationshipValue" },
         "hasMany": { "$ref": "#/definitions/relationshipValue" },
@@ -111,12 +111,19 @@
         "morphMany": { "$ref": "#/definitions/relationshipValue" },
         "morphTo": { "$ref": "#/definitions/relationshipValue" },
         "morphToMany": { "$ref": "#/definitions/relationshipValue" },
-        "morphedByMany": { "$ref": "#/definitions/relationshipValue" }
+        "morphedByMany": { "$ref": "#/definitions/relationshipValue" },
+        "hasOneThrough": { "$ref": "#/definitions/throughRelationshipValue" },
+        "hasManyThrough": { "$ref": "#/definitions/throughRelationshipValue" }
       }
     },
     "relationshipValue": {
       "type": "string",
       "examples": ["Team", "Team, User", "Customer:owner", "Team:&Membership", "\\Some\\Package\\Team"]
+    },
+    "throughRelationshipValue": {
+      "type": "string",
+      "description": "One `Target:Intermediate` model reference, or a comma-separated list of them.",
+      "examples": ["Owner:Car", "Payment:Order, Invoice:Order", "\\App\\Models\\Owner:\\App\\Models\\Car"]
     },
     "index": {
       "type": "object",

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -390,6 +390,21 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
                     $relationship = sprintf('$this->%s(%s::class, \'%s\')', $type, $fqcn, $relation);
                 } elseif ($type === 'morphedByMany') {
                     $relationship = sprintf('$this->%s(%s::class, \'%sable\')', $type, $fqcn, strtolower($model->name()));
+                } elseif (in_array($type, ['hasOneThrough', 'hasManyThrough'])) {
+                    if ($is_model_fqn) {
+                        $through_fqcn = $column_name;
+                        $through_class_name = Str::afterLast($through_fqcn, '\\');
+                    } else {
+                        $through_class_name = Str::studly($column_name);
+                        $through_fqcn = $this->fullyQualifyModelReference($through_class_name) ?? $model->fullyQualifiedNamespace() . '\\' . $through_class_name;
+                    }
+
+                    $through_fqcn = Str::startsWith($through_fqcn, '\\') ? $through_fqcn : '\\' . $through_fqcn;
+                    $through_fqcn = Str::is($through_fqcn, "\\{$model->fullyQualifiedNamespace()}\\{$through_class_name}") ? $through_class_name : $through_fqcn;
+
+                    $relationship = sprintf('$this->%s(%s::class, %s::class)', $type, $fqcn, $through_fqcn);
+                    $method_name = $class_name;
+                    $has_custom_relation_name = false;
                 } elseif (!is_null($key)) {
                     $relationship = sprintf('$this->%s(%s::class, \'%s\', \'%s\')', $type, $fqcn, $column_name, $key);
                 } elseif (!is_null($class) && $type === 'belongsToMany') {
@@ -416,7 +431,7 @@ class ModelGenerator extends AbstractClassGenerator implements Generator
 
                 if ($type === 'morphTo') {
                     $method_name = Str::lower($class_name);
-                } elseif (in_array($type, ['hasMany', 'belongsToMany', 'morphMany', 'morphToMany', 'morphedByMany'])) {
+                } elseif (in_array($type, ['hasMany', 'belongsToMany', 'morphMany', 'morphToMany', 'morphedByMany', 'hasManyThrough'])) {
                     if ($is_pivot || $has_custom_relation_name) {
                         $method_name = Str::plural($is_pivot ? $column_name : $method_name);
                     } else {

--- a/src/Lexers/ModelLexer.php
+++ b/src/Lexers/ModelLexer.php
@@ -20,6 +20,8 @@ class ModelLexer implements Lexer
         'morphto' => 'morphTo',
         'morphtomany' => 'morphToMany',
         'morphedbymany' => 'morphedByMany',
+        'hasonethrough' => 'hasOneThrough',
+        'hasmanythrough' => 'hasManyThrough',
     ];
 
     private static array $dataTypes = [

--- a/tests/Feature/Generators/ModelGeneratorTest.php
+++ b/tests/Feature/Generators/ModelGeneratorTest.php
@@ -757,7 +757,42 @@ final class ModelGeneratorTest extends TestCase
             ['drafts/infer-belongsto.yaml', 'app/Models/Conference.php', 'models/infer-belongsto.php'],
             ['drafts/model-with-ulid-id.yaml', 'app/Models/User.php', 'models/model-with-ulid-trait.php'],
             ['drafts/model-with-uuid-id.yaml', 'app/Models/User.php', 'models/model-with-uuid-trait.php'],
+            ['drafts/model-relationships-through.yaml', 'app/Models/Mechanic.php', 'models/model-relationships-through.php'],
         ];
+    }
+
+    #[Test]
+    public function output_generates_hasonethrough_and_hasmanythrough_relationships_with_fqn_and_custom_plural(): void
+    {
+        $this->filesystem->expects('stub')
+            ->with('model.class.stub')
+            ->andReturn($this->stub('model.class.stub'));
+        $this->filesystem->expects('stub')
+            ->twice()
+            ->with('model.fillable.stub')
+            ->andReturn($this->stub('model.fillable.stub'));
+        $this->filesystem->expects('stub')
+            ->twice()
+            ->with('model.casts.stub')
+            ->andReturn($this->stub('model.casts.stub'));
+        $this->filesystem->expects('stub')
+            ->twice()
+            ->with('model.method.stub')
+            ->andReturn($this->stub('model.method.stub'));
+
+        $this->filesystem->expects('exists')
+            ->twice()
+            ->with('app/Models')
+            ->andReturnTrue();
+        $this->filesystem->expects('put')
+            ->with('app/Models/Mechanic.php', $this->fixture('models/model-relationships-through-fqn-and-plural-mechanic.php'));
+        $this->filesystem->expects('put')
+            ->with('app/Models/Payment.php', $this->fixture('models/model-relationships-through-fqn-and-plural-payment.php'));
+
+        $tokens = $this->blueprint->parse($this->fixture('drafts/model-relationships-through-fqn-and-plural.yaml'));
+        $tree = $this->blueprint->analyze($tokens);
+
+        $this->assertSame(['created' => [['Model', 'app/Models/Mechanic.php'], ['Model', 'app/Models/Payment.php']]], $this->subject->output($tree));
     }
 
     public static function docBlockModelsDataProvider(): array

--- a/tests/Feature/Lexers/ModelLexerTest.php
+++ b/tests/Feature/Lexers/ModelLexerTest.php
@@ -797,6 +797,31 @@ final class ModelLexerTest extends TestCase
     }
 
     #[Test]
+    public function it_stores_hasonethrough_and_hasmanythrough_relationships(): void
+    {
+        $tokens = [
+            'models' => [
+                'Mechanic' => [
+                    'name' => 'string',
+                    'relationships' => [
+                        'hasOneThrough' => 'Owner:Car',
+                        'hasManyThrough' => 'Payment:Order, Invoice:Order',
+                    ],
+                ],
+            ],
+        ];
+
+        $actual = $this->subject->analyze($tokens);
+
+        $model = $actual['models']['Mechanic'];
+        $relationships = $model->relationships();
+
+        $this->assertCount(2, $relationships);
+        $this->assertEquals(['Owner:Car'], $relationships['hasOneThrough']);
+        $this->assertEquals(['Payment:Order', 'Invoice:Order'], $relationships['hasManyThrough']);
+    }
+
+    #[Test]
     public function it_enables_morphable_and_set_its_reference(): void
     {
         $tokens = [

--- a/tests/fixtures/drafts/model-relationships-through-fqn-and-plural.yaml
+++ b/tests/fixtures/drafts/model-relationships-through-fqn-and-plural.yaml
@@ -1,0 +1,13 @@
+models:
+  Mechanic:
+    name: string
+
+    relationships:
+      hasManyThrough: Payment:Order
+      hasOneThrough: \App\Models\Owner:\App\Models\Car
+
+  Payment:
+    meta:
+      plural: pagamenti
+
+    order_id: id

--- a/tests/fixtures/drafts/model-relationships-through.yaml
+++ b/tests/fixtures/drafts/model-relationships-through.yaml
@@ -1,0 +1,7 @@
+models:
+  Mechanic:
+    name: string
+
+    relationships:
+      hasOneThrough: Owner:Car
+      hasManyThrough: Payment:Order

--- a/tests/fixtures/models/model-relationships-through-fqn-and-plural-mechanic.php
+++ b/tests/fixtures/models/model-relationships-through-fqn-and-plural-mechanic.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+
+class Mechanic extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'id' => 'integer',
+        ];
+    }
+
+    public function pagamenti(): HasManyThrough
+    {
+        return $this->hasManyThrough(Payment::class, Order::class);
+    }
+
+    public function owner(): HasOneThrough
+    {
+        return $this->hasOneThrough(Owner::class, Car::class);
+    }
+}

--- a/tests/fixtures/models/model-relationships-through-fqn-and-plural-payment.php
+++ b/tests/fixtures/models/model-relationships-through-fqn-and-plural-payment.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'order_id',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'id' => 'integer',
+            'order_id' => 'integer',
+        ];
+    }
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+}

--- a/tests/fixtures/models/model-relationships-through.php
+++ b/tests/fixtures/models/model-relationships-through.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+
+class Mechanic extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'id' => 'integer',
+        ];
+    }
+
+    public function owner(): HasOneThrough
+    {
+        return $this->hasOneThrough(Owner::class, Car::class);
+    }
+
+    public function payments(): HasManyThrough
+    {
+        return $this->hasManyThrough(Payment::class, Order::class);
+    }
+}


### PR DESCRIPTION
Adds support for Eloquent's `hasOneThrough` / `hasManyThrough` relationships in model YAML.

## Example
```yaml
Mechanic:
  relationships:
    hasOneThrough: Owner:Car
    hasManyThrough: Payment:Order, Invoice:Order
```
generates:
```php
public function owner(): HasOneThrough
{
    return $this->hasOneThrough(Owner::class, Car::class);
}

public function payments(): HasManyThrough
{
    return $this->hasManyThrough(Payment::class, Order::class);
}
```
The reference is `Target:Intermediate`, consistent with existing colon-delimited relationship syntax. Fully-qualified class names (`\App\Models\Owner:\App\Models\Car`) and custom `meta.plural` overrides on the target model are both supported.

## Boundaries
- No support yet for overriding the optional key arguments (`firstKey`, `secondKey`, `localKey`, `secondLocalKey`) that Eloquent's `hasManyThrough` signature accepts — this ships with Laravel's default key conventions only.
- The intermediate model is not auto-scaffolded; if it isn't declared elsewhere in the draft, Blueprint assumes the class already exists in the app (same behavior as every other relationship reference).

---
Closes #641